### PR TITLE
[PW_S_ID:254979] [v2,1/2] input: hog: Attempt to set security level if not bonded

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,0 +1,16 @@
+name: Check Patch
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Patch for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v2
+    - name: Check Env
+      run: |
+        echo "##### Environment #####"
+        env
+        echo "##### END #####"

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -27,9 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: master
-        fetch-depth: 0
 
     - name: Patchwork to PR
       uses: tedd-an/action-patchwork-to-pr@master

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,39 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "*/30 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: BluezTestBot/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: master
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: BluezTestBot/action-patchwork-to-pr@master
+      with:
+        pw_url: "https://patchwork.kernel.org/api/1.1"
+        pw_exclude_str: "Bluetooth:"
+        github_token: ${{ secrets.GITHUB_TOKEN }}     

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -34,4 +34,4 @@ jobs:
         pw_url: "https://patchwork.kernel.org/api/1.1"
         pw_exclude_str: "Bluetooth:"
         base_branch: "workflow"
-        github_token: ${{ secrets.GITHUB_TOKEN }}     
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -32,7 +32,7 @@ jobs:
         fetch-depth: 0
 
     - name: Patchwork to PR
-      uses: BluezTestBot/action-patchwork-to-pr@master
+      uses: tedd-an/action-patchwork-to-pr@master
       with:
         pw_url: "https://patchwork.kernel.org/api/1.1"
         pw_exclude_str: "Bluetooth:"

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -36,4 +36,5 @@ jobs:
       with:
         pw_url: "https://patchwork.kernel.org/api/1.1"
         pw_exclude_str: "Bluetooth:"
+        base_branch: "workflow"
         github_token: ${{ secrets.GITHUB_TOKEN }}     

--- a/profiles/input/device.h
+++ b/profiles/input/device.h
@@ -30,6 +30,7 @@ struct input_conn;
 void input_set_idle_timeout(int timeout);
 void input_enable_userspace_hid(bool state);
 void input_set_classic_bonded_only(bool state);
+void input_set_auto_sec(bool state);
 
 int input_device_register(struct btd_service *service);
 void input_device_unregister(struct btd_service *service);

--- a/profiles/input/hog.c
+++ b/profiles/input/hog.c
@@ -49,6 +49,8 @@
 #include "src/shared/util.h"
 #include "src/shared/uhid.h"
 #include "src/shared/queue.h"
+#include "src/shared/att.h"
+#include "src/shared/gatt-client.h"
 #include "src/plugin.h"
 
 #include "suspend.h"
@@ -187,8 +189,15 @@ static int hog_accept(struct btd_service *service)
 	}
 
 	/* HOGP 1.0 Section 6.1 requires bonding */
-	if (!device_is_bonded(device, btd_device_get_bdaddr_type(device)))
-		return -ECONNREFUSED;
+	if (!device_is_bonded(device, btd_device_get_bdaddr_type(device))) {
+		struct bt_gatt_client *client;
+
+		client = btd_device_get_gatt_client(device);
+		if (!bt_gatt_client_set_security(client,
+						BT_ATT_SECURITY_MEDIUM)) {
+			return -ECONNREFUSED;
+		}
+	}
 
 	/* TODO: Replace GAttrib with bt_gatt_client */
 	bt_hog_attach(dev->hog, attrib);

--- a/profiles/input/input.conf
+++ b/profiles/input/input.conf
@@ -19,3 +19,8 @@
 # pairing/encryption.
 # Defaults to false to maximize device compatibility.
 #ClassicBondedOnly=true
+
+# LE upgrade security
+# Enables upgrades of security automatically if required.
+# Defaults to true to maximize device compatibility.
+#LEAutoSecurity=true

--- a/profiles/input/manager.c
+++ b/profiles/input/manager.c
@@ -96,7 +96,7 @@ static int input_init(void)
 	config = load_config_file(CONFIGDIR "/input.conf");
 	if (config) {
 		int idle_timeout;
-		gboolean uhid_enabled, classic_bonded_only;
+		gboolean uhid_enabled, classic_bonded_only, auto_sec;
 
 		idle_timeout = g_key_file_get_integer(config, "General",
 							"IdleTimeout", &err);
@@ -122,6 +122,15 @@ static int input_init(void)
 			DBG("input.conf: ClassicBondedOnly=%s",
 					classic_bonded_only ? "true" : "false");
 			input_set_classic_bonded_only(classic_bonded_only);
+		} else
+			g_clear_error(&err);
+
+		auto_sec = g_key_file_get_boolean(config, "General",
+						"LEAutoSecurity", &err);
+		if (!err) {
+			DBG("input.conf: LEAutoSecurity=%s",
+					auto_sec ? "true" : "false");
+			input_set_auto_sec(auto_sec);
 		} else
 			g_clear_error(&err);
 


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This attempts to set the security if the device is not bonded, the
kernel will block any communication on the ATT socket while bumping
the security and if that fails the device will be disconnected which
is better than having the device dangling around without being able to
communicate with it until it is properly bonded.