### PR TITLE
[PW_S_ID:255165] [Bluez,v1] a2dp: Fix race when connecting and being connected at the same time

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,0 +1,16 @@
+name: Check Patch
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Patch for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v2
+    - name: Check Env
+      run: |
+        echo "##### Environment #####"
+        env
+        echo "##### END #####"

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -27,9 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: master
-        fetch-depth: 0
 
     - name: Patchwork to PR
       uses: tedd-an/action-patchwork-to-pr@master

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,39 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "*/30 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: BluezTestBot/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: master
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: BluezTestBot/action-patchwork-to-pr@master
+      with:
+        pw_url: "https://patchwork.kernel.org/api/1.1"
+        pw_exclude_str: "Bluetooth:"
+        github_token: ${{ secrets.GITHUB_TOKEN }}     

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -34,4 +34,4 @@ jobs:
         pw_url: "https://patchwork.kernel.org/api/1.1"
         pw_exclude_str: "Bluetooth:"
         base_branch: "workflow"
-        github_token: ${{ secrets.GITHUB_TOKEN }}     
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -32,7 +32,7 @@ jobs:
         fetch-depth: 0
 
     - name: Patchwork to PR
-      uses: BluezTestBot/action-patchwork-to-pr@master
+      uses: tedd-an/action-patchwork-to-pr@master
       with:
         pw_url: "https://patchwork.kernel.org/api/1.1"
         pw_exclude_str: "Bluetooth:"

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -36,4 +36,5 @@ jobs:
       with:
         pw_url: "https://patchwork.kernel.org/api/1.1"
         pw_exclude_str: "Bluetooth:"
+        base_branch: "workflow"
         github_token: ${{ secrets.GITHUB_TOKEN }}     

--- a/profiles/audio/a2dp.c
+++ b/profiles/audio/a2dp.c
@@ -2118,7 +2118,7 @@ struct avdtp *a2dp_avdtp_get(struct btd_device *device)
 	return NULL;
 
 found:
-	chan->session = avdtp_new(NULL, device, server->seps);
+	chan->session = avdtp_new(chan->io, device, server->seps);
 	if (!chan->session) {
 		channel_remove(chan);
 		return NULL;
@@ -2136,10 +2136,13 @@ static void connect_cb(GIOChannel *io, GError *err, gpointer user_data)
 		goto fail;
 	}
 
-	chan->session = avdtp_new(chan->io, chan->device, chan->server->seps);
 	if (!chan->session) {
-		error("Unable to create AVDTP session");
-		goto fail;
+		chan->session = avdtp_new(chan->io, chan->device,
+							chan->server->seps);
+		if (!chan->session) {
+			error("Unable to create AVDTP session");
+			goto fail;
+		}
 	}
 
 	g_io_channel_unref(chan->io);


### PR DESCRIPTION
From: Archie Pusaka <apusaka@chromium.org>

There is a possibility where BlueZ initiate an A2DP connection just
around the same time as the peripheral also initiate it.

One scenario is the peripheral initiate the connection first, so
confirm_cb() on /profiles/audio/a2dp.c is called. However, while we
are waiting for the authentication step, BlueZ initiate a connection
to the peripheral, therefore a2dp_sink_connect() is called, which
from there a2dp_avdtp_get() is called.

If this happens: When calling confirm_cb(), chan for the
corresponding device is created.

Then when calling a2dp_avdtp_get(), chan will be found as it is
created in confirm_cb(), and the value of chan->io is not NULL.
However, a NULL is supplied instead to create a new session and
assigned to chan->session.

Then when calling connect_cb(), chan->session will NOT be NULL, as
it is assigned in a2dp_avdtp_get(). Nevertheless, chan->session is
always assigned a new value.

These cause failure in connection.

Therefore, fixing this by supplying the value of chan->io inside
a2dp_avdtp_get() (it's going to be NULL on the normal case so it is
fine), and check whether chan->session already assigned inside
connect_cb().