### PR TITLE
[PW_S_ID:255907] [Bluez,v1] avdtp: Add check for service capabilities length correctness

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,0 +1,16 @@
+name: Check Patch
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Patch for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v2
+    - name: Check Env
+      run: |
+        echo "##### Environment #####"
+        env
+        echo "##### END #####"

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -27,9 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: master
-        fetch-depth: 0
 
     - name: Patchwork to PR
       uses: tedd-an/action-patchwork-to-pr@master

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,39 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "*/30 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: BluezTestBot/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: master
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: BluezTestBot/action-patchwork-to-pr@master
+      with:
+        pw_url: "https://patchwork.kernel.org/api/1.1"
+        pw_exclude_str: "Bluetooth:"
+        github_token: ${{ secrets.GITHUB_TOKEN }}     

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -34,4 +34,4 @@ jobs:
         pw_url: "https://patchwork.kernel.org/api/1.1"
         pw_exclude_str: "Bluetooth:"
         base_branch: "workflow"
-        github_token: ${{ secrets.GITHUB_TOKEN }}     
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -32,7 +32,7 @@ jobs:
         fetch-depth: 0
 
     - name: Patchwork to PR
-      uses: BluezTestBot/action-patchwork-to-pr@master
+      uses: tedd-an/action-patchwork-to-pr@master
       with:
         pw_url: "https://patchwork.kernel.org/api/1.1"
         pw_exclude_str: "Bluetooth:"

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -36,4 +36,5 @@ jobs:
       with:
         pw_url: "https://patchwork.kernel.org/api/1.1"
         pw_exclude_str: "Bluetooth:"
+        base_branch: "workflow"
         github_token: ${{ secrets.GITHUB_TOKEN }}     


### PR DESCRIPTION
From: Archie Pusaka <apusaka@chromium.org>

There is a check for capability length of AVDTP_MEDIA_TRANSPORT,
but there are none for the other capability categories.

Therefore, this patch add such check for these categories:
AVDTP_REPORTING
AVDTP_RECOVERY
AVDTP_CONTENT_PROTECTION
AVDTP_HEADER_COMPRESSION
AVDTP_MULTIPLEXING

Set Configuration Command messages which contains bad length shall
be responded with Set Configuration Reject.

Furthermore, this patch also assign the service category field for
Set Configuration Reject, as what is described in section 8.9.3 of
Bluetooth AVDTP spec.

Signed-off-by: Archie Pusaka <apusaka@chromium.org>