### PR TITLE
[PW_S_ID:256819] [Bluez,v1] input: disconnect intr channel before ctrl channel

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,14 @@
+--no-tree
+--no-signoff
+--emacs
+--summary-file
+--show-types
+--max-line-length=80
+--min-conf-desc-length=1
+
+--ignore COMPLEX_MACRO
+--ignore SPLIT_STRING
+--ignore CONST_STRUCT
+--ignore FILE_PATH_CHANGES
+--ignore MISSING_SIGN_OFF
+--ignore PREFER_PACKED

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -10,6 +10,6 @@ jobs:
     - name: Checkout the code
       uses: actions/checkout@v1
     - name: Checkpatch
-      uses: tedd-an/action-checkpatch
+      uses: tedd-an/action-checkpatch@master
       with:
         github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,0 +1,16 @@
+name: Check Patch
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Patch for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v2
+    - name: Check Env
+      run: |
+        echo "##### Environment #####"
+        env
+        echo "##### END #####"

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -8,9 +8,8 @@ jobs:
     name: Check Patch for Pull Request
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v2
-    - name: Check Env
-      run: |
-        echo "##### Environment #####"
-        env
-        echo "##### END #####"
+      uses: actions/checkout@v1
+    - name: Checkpatch
+      uses: tedd-an/action-checkpatch
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -27,9 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: master
-        fetch-depth: 0
 
     - name: Patchwork to PR
       uses: tedd-an/action-patchwork-to-pr@master

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,39 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "*/30 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: BluezTestBot/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: master
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: BluezTestBot/action-patchwork-to-pr@master
+      with:
+        pw_url: "https://patchwork.kernel.org/api/1.1"
+        pw_exclude_str: "Bluetooth:"
+        github_token: ${{ secrets.GITHUB_TOKEN }}     

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -34,4 +34,4 @@ jobs:
         pw_url: "https://patchwork.kernel.org/api/1.1"
         pw_exclude_str: "Bluetooth:"
         base_branch: "workflow"
-        github_token: ${{ secrets.GITHUB_TOKEN }}     
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -32,7 +32,7 @@ jobs:
         fetch-depth: 0
 
     - name: Patchwork to PR
-      uses: BluezTestBot/action-patchwork-to-pr@master
+      uses: tedd-an/action-patchwork-to-pr@master
       with:
         pw_url: "https://patchwork.kernel.org/api/1.1"
         pw_exclude_str: "Bluetooth:"

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -36,4 +36,5 @@ jobs:
       with:
         pw_url: "https://patchwork.kernel.org/api/1.1"
         pw_exclude_str: "Bluetooth:"
+        base_branch: "workflow"
         github_token: ${{ secrets.GITHUB_TOKEN }}     

--- a/profiles/input/device.c
+++ b/profiles/input/device.c
@@ -1026,14 +1026,19 @@ static bool is_connected(struct input_device *idev)
 
 static int connection_disconnect(struct input_device *idev, uint32_t flags)
 {
+	int sock;
+
 	if (!is_connected(idev))
 		return -ENOTCONN;
 
-	/* Standard HID disconnect */
-	if (idev->intr_io)
-		g_io_channel_shutdown(idev->intr_io, TRUE, NULL);
-	if (idev->ctrl_io)
-		g_io_channel_shutdown(idev->ctrl_io, TRUE, NULL);
+	/* Standard HID disconnect
+	 * Intr channel must be disconnected before ctrl channel, so only
+	 * disconnect intr here, ctrl is disconnected in intr_watch_cb.
+	 */
+	if (idev->intr_io) {
+		sock = g_io_channel_unix_get_fd(idev->intr_io);
+		shutdown(sock, SHUT_RDWR);
+	}
 
 	if (idev->uhid)
 		return 0;


### PR DESCRIPTION
From: Archie Pusaka <apusaka@chromium.org>

According to bluetooth HID Profile spec Ver 1.0, section 7.2.2, A
host or device shall always complete the disconnection of the
interrupt channel before disconnecting the control channel.
However, the current implementation disconnects them both
simultaneously.

This patch postpone the disconnection of control channel to the
callback of interrupt watch, which shall be called upon receiving
interrupt channel disconnection response.