### PR TITLE
[PW_S_ID:261609] [BlueZ,v2] mesh: Handle close for Acceptor

### DIFF
--- a/mesh/pb-adv.c
+++ b/mesh/pb-adv.c
@@ -223,9 +223,6 @@ static void tx_timeout(struct l_timeout *timeout, void *user_data)
 	if (!l_queue_find(pb_sessions, session_match, session))
 		return;
 
-	l_timeout_remove(session->tx_timeout);
-	session->tx_timeout = NULL;
-
 	mesh_send_cancel(filter, sizeof(filter));
 
 	l_info("TX timeout");
@@ -392,17 +389,8 @@ static void pb_adv_packet(void *user_data, const uint8_t *pkt, uint16_t len)
 		break;
 
 	case PB_ADV_CLOSE:
-		l_timeout_remove(session->tx_timeout);
 		l_debug("Link closed notification: %2.2x", pkt[0]);
-		/* Wrap callback for pre-cleaning */
-		if (true) {
-			mesh_prov_close_func_t cb = session->close_cb;
-			void *user_data = session->user_data;
-
-			l_queue_remove(pb_sessions, session);
-			l_free(session);
-			cb(user_data, pkt[0]);
-		}
+		session->close_cb(session->user_data, pkt[0]);
 		break;
 
 	case PB_ADV_ACK:

--- a/mesh/prov-acceptor.c
+++ b/mesh/prov-acceptor.c
@@ -120,7 +120,18 @@ static void acceptor_free(void)
 
 static void acp_prov_close(void *user_data, uint8_t reason)
 {
-	/* TODO: Handle Close */
+	struct mesh_prov_acceptor *rx_prov = user_data;
+
+	if (rx_prov != prov)
+		return;
+
+	if (reason == PROV_ERR_SUCCESS)
+		reason = PROV_ERR_UNEXPECTED_ERR;
+
+	if (prov->cmplt)
+		prov->cmplt(prov->caller_data, reason, NULL);
+
+	prov->cmplt = NULL;
 	acceptor_free();
 }
 


### PR DESCRIPTION
From: Prathyusha N <prathyusha.n@samsung.com>

Provision complete callback is handled in provision failure case.
If link closed received abruptly with reason success, triggered
provision complete callback. Removed session timeout and session
free as they are handled in pb_adv_unreg.