### PR TITLE
[PW_S_ID:261695] [BlueZ] mesh: Fix model publication status after set

### DIFF
--- a/mesh/cfgmod-server.c
+++ b/mesh/cfgmod-server.c
@@ -185,8 +185,8 @@ static void config_pub_set(struct mesh_node *node, uint16_t net_idx,
 	}
 
 	if (!unreliable)
-		send_pub_status(node, net_idx, src, dst, status, ele_addr, ota,
-			mod_id, idx, cred_flag, ttl, period, retransmit);
+		send_pub_status(node, net_idx, src, dst, status, ele_addr,
+			mod_id, ota, idx, cred_flag, ttl, period, retransmit);
 }
 
 static void send_sub_status(struct mesh_node *node, uint16_t net_idx,


### PR DESCRIPTION
This patch fixes usage of send_pub_status() when handling publication
set message - mod_id was swapped with pub_addr, resulting in malformed
message being sent back to the Config Client.