### PR TITLE
[PW_S_ID:260977] [1/1] mesh: Handle KeyRefresh phase set to 3


### DIFF
--- a/mesh/net.c
+++ b/mesh/net.c
@@ -3458,6 +3458,9 @@ uint8_t mesh_net_key_refresh_phase_set(struct mesh_net *net, uint16_t idx,
 	if (transition == subnet->kr_phase)
 		return MESH_STATUS_SUCCESS;
 
+	if (transition == 3 && subnet->kr_phase == KEY_REFRESH_PHASE_NONE)
+		return MESH_STATUS_SUCCESS;
+
 	if ((transition != 2 && transition != 3) ||
 						transition < subnet->kr_phase)
 		return MESH_STATUS_CANNOT_SET;


### PR DESCRIPTION

From: Prathyusha N <prathyusha.n@samsung.com>

If keyRefresh phase 3 is already completed then respond with
current phase state and status as SUCCESS.
