### PR TITLE
[PW_SID:260975] [1/1] mesh: Add mesh agent cleanup to mesh cleanup


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,12 @@
+--no-tree
+--no-signoff
+--summary-file
+--show-types
+--max-line-length=80
+
+--ignore COMPLEX_MACRO
+--ignore SPLIT_STRING
+--ignore CONST_STRUCT
+--ignore FILE_PATH_CHANGES
+--ignore MISSING_SIGN_OFF
+--ignore PREFER_PACKED

--- a/.github/workflows/checkbuild.yml
+++ b/.github/workflows/checkbuild.yml
@@ -1,0 +1,15 @@
+name: Check Build
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Build for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkbuild
+      uses: tedd-an/action-checkbuild@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,0 +1,15 @@
+name: Check Patch
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Patch for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkpatch
+      uses: tedd-an/action-checkpatch@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "*/30 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/mesh/agent.c
+++ b/mesh/agent.c
@@ -205,6 +205,7 @@ static void agent_free(void *agent_data)
 
 	l_free(agent->path);
 	l_free(agent->owner);
+	l_free(agent);
 }
 
 void mesh_agent_remove(struct mesh_agent *agent)
@@ -212,8 +213,8 @@ void mesh_agent_remove(struct mesh_agent *agent)
 	if (!agent || !l_queue_find(agents, simple_match, agent))
 		return;
 
-	agent_free(agent);
 	l_queue_remove(agents, agent);
+	agent_free(agent);
 }
 
 void mesh_agent_cleanup(void)

--- a/mesh/manager.c
+++ b/mesh/manager.c
@@ -93,6 +93,7 @@ static void prov_disc_cb(struct l_dbus *bus, void *user_data)
 	initiator_cancel(add_pending);
 	add_pending->disc_watch = 0;
 
+	mesh_agent_remove(add_pending->agent);
 	free_pending_add_call();
 }
 

--- a/mesh/mesh.c
+++ b/mesh/mesh.c
@@ -340,6 +340,7 @@ void mesh_cleanup(void)
 	l_queue_destroy(pending_queue, pending_request_exit);
 	node_cleanup_all();
 	mesh_model_cleanup();
+	mesh_agent_cleanup();
 
 	l_dbus_object_remove_interface(dbus_get_bus(), BLUEZ_MESH_PATH,
 							MESH_NETWORK_INTERFACE);
@@ -484,6 +485,7 @@ static void node_init_cb(struct mesh_node *node, struct mesh_agent *agent)
 	}
 
 	join_pending->node = node;
+	join_pending->agent = agent;
 	num_ele = node_get_num_elements(node);
 
 	if (!acceptor_start(num_ele, join_pending->uuid, mesh.algorithms,


### PR DESCRIPTION

From: Prathyusha N <prathyusha.n@samsung.com>

Freed agent completely in agent_free(). Removed agent from queue
after app disconnects in provisioner case. Linked agent to
join_pending so that agent gets freed after every join call.
Added mesh_agent_cleanup in mesh_cleanup to clear and free
agents queue.
