### PR TITLE
[PW_SID:262931] API changes for forward compatibility


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,13 @@
+--no-tree
+--no-signoff
+--summary-file
+--show-types
+--max-line-length=80
+
+--ignore COMPLEX_MACRO
+--ignore SPLIT_STRING
+--ignore CONST_STRUCT
+--ignore FILE_PATH_CHANGES
+--ignore MISSING_SIGN_OFF
+--ignore PREFER_PACKED
+--ignore COMMIT_MESSAGE

--- a/.github/workflows/checkbuild.yml
+++ b/.github/workflows/checkbuild.yml
@@ -1,0 +1,15 @@
+name: Check Build
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Build for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkbuild
+      uses: tedd-an/action-checkbuild@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,0 +1,15 @@
+name: Check Patch
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Patch for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkpatch
+      uses: tedd-an/action-checkpatch@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "*/30 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/doc/mesh-api.txt
+++ b/doc/mesh-api.txt
@@ -455,14 +455,20 @@ Object path	/org/bluez/mesh/node<uuid>
 		CreateNetwork() or Import()
 
 Methods:
-	void UnprovisionedScan(uint16 seconds)
+	void UnprovisionedScan(dict options)
 
 		This method is used by the application that supports
 		org.bluez.mesh.Provisioner1 interface to start listening
-		(scanning) for unprovisioned devices in the area. Scanning
-		will continue for the specified number of seconds, or, if 0 is
-		specified, then continuously until UnprovisionedScanCancel() is
-		called or if AddNode() method is called.
+		(scanning) for unprovisioned devices in the area.
+
+		The options parameter is a dictionary with the following keys
+		defined:
+
+		uint16 Seconds
+			Specifies number of seconds for scanning to be active.
+			If set to 0 or if this key is not present, then the
+			scanning will continue until UnprovisionedScanCancel()
+			or AddNode() methods are called.
 
 		Each time a unique unprovisioned beacon is heard, the
 		ScanResult() method on the app will be called with the result.
@@ -482,7 +488,7 @@ Methods:
 			org.bluez.mesh.Error.InvalidArguments
 			org.bluez.mesh.Error.NotAuthorized
 
-	void AddNode(array{byte}[16] uuid)
+	void AddNode(array{byte}[16] uuid, dict options)
 
 		This method is used by the application that supports
 		org.bluez.mesh.Provisioner1 interface to add the
@@ -490,6 +496,10 @@ Methods:
 
 		The uuid parameter is a 16-byte array that contains Device UUID
 		of the unprovisioned device to be added to the network.
+
+		The options parameter is a dictionary that may contain
+		additional configuration info (currently an empty placeholder
+		for forward compatibility).
 
 		PossibleErrors:
 			org.bluez.mesh.Error.InvalidArguments
@@ -927,7 +937,7 @@ Service		unique name
 Interface	org.bluez.mesh.Provisioner1
 Object path	freely definable
 
-	void ScanResult(int16 rssi, array{byte} data)
+	void ScanResult(int16 rssi, array{byte} data, dict options)
 
 		The method is called from the bluetooth-meshd daemon when a
 		unique UUID has been seen during UnprovisionedScan() for
@@ -942,6 +952,10 @@ Object path	freely definable
 		authentication flags (optional), and a 32 bit URI hash (if URI
 		bit set in OOB mask). Whether these fields exist or not is a
 		decision of the remote device.
+
+		The options parameter is a dictionary that may contain
+		additional scan result info (currently an empty placeholder for
+		forward compatibility).
 
 		If a beacon with a UUID that has already been reported is
 		recieved by the daemon, it will be silently discarded unless it

--- a/test/test-mesh
+++ b/test/test-mesh
@@ -474,13 +474,22 @@ class Application(dbus.service.Object):
 	def JoinFailed(self, value):
 		print(set_error('JoinFailed '), value)
 
-	@dbus.service.method(MESH_PROV_IFACE,
-					in_signature="nay", out_signature="")
-	def ScanResult(self, rssi, uuid):
-		uuid_str = array_to_string(uuid)
-		print(set_yellow('ScanResult RSSI ')
-					+ set_green(format(rssi, 'd'))
-					+ ' ' + uuid_str)
+	@dbus.service.method(MESH_PROV_IFACE, in_signature="naya{sv}",
+							out_signature="")
+	def ScanResult(self, rssi, data, options):
+		global remote_uuid
+		remote_uuid = data[:16]
+		uuid_str = array_to_string(remote_uuid)
+		data_str = array_to_string(data[16:])
+		if len(data_str) == 0:
+			data_str = 'Not Present'
+
+		print(set_yellow('ScanResult >> RSSI: ') +
+					set_green(format(rssi, 'd')) +
+					set_yellow(format(' UUID: ')) +
+					set_green(format(uuid_str, 's')) +
+					set_yellow(format(' OOB Data: ')) +
+					set_green(format(data_str, 's')))
 
 	@dbus.service.method(MESH_PROV_IFACE,
 					in_signature="y", out_signature="qq")
@@ -946,8 +955,6 @@ class MainMenu(Menu):
 		uuid = bytearray.fromhex("0a0102030405060708090A0B0C0D0E0F")
 		random.shuffle(uuid)
 		uuid_str = array_to_string(uuid)
-		caps = ["out-numeric"]
-		oob = ["other"]
 
 		print(set_yellow('Joining with UUID ') + set_green(uuid_str))
 		mesh_net.Join(app.get_path(), uuid,
@@ -955,23 +962,27 @@ class MainMenu(Menu):
 			error_handler=join_error_cb)
 
 	def __cmd_scan(self):
+		options = {}
+		options['Seconds'] = dbus.UInt16(0)
 
 		print(set_yellow('Scanning...'))
-		node_mgr.UnprovisionedScan(0, reply_handler=add_cb,
-						error_handler=add_error_cb)
+		node_mgr.UnprovisionedScan(options,
+						reply_handler=scan_cb,
+						error_handler=scan_error_cb)
 
 	def __cmd_add(self):
 		global user_input
+		global remote_uuid
+
 		if agent == None:
 			print(set_error('Provisioning agent not found'))
 			return
 
 		uuid_str = array_to_string(remote_uuid)
-		caps = ["in-numeric"]
-		oob = ["other"]
+		options = {}
 
 		print(set_yellow('Adding dev UUID ') + set_green(uuid_str))
-		node_mgr.AddNode(remote_uuid, reply_handler=add_cb,
+		node_mgr.AddNode(remote_uuid, options, reply_handler=add_cb,
 						error_handler=add_error_cb)
 
 	def __cmd_attach(self):


### PR DESCRIPTION

The changes are contained to Management and Provisioner APIs. 

The following methods are modified to allow for future development:

Interface org.bluez.mesh.Management1:

Old: void UnprovisionedScan(uint16 seconds)
New: void UnprovisionedScan(dict options)

The options parameter is a dictionary with the following keys defined:
uint16 Seconds
Specifies number of seconds for scanning to be active.
If set to 0 or if this key is not present, then the
scanning will continue until UnprovisionedScanCancel()
or AddNode() methods are called.
other keys TBD

Old: void AddNode(array{byte}[16] uuid)
New: void AddNode(array{byte}[16] uuid, dict options)

The options parameter is currently an empty dictionary

Interface org.bluez.mesh.Provisioner1

Old: void ScanResult(int16 rssi, array{byte} data)
New: void ScanResult(int16 rssi, array{byte} data, dict options)

The options parameter is currently an empty dictionary

Inga Stotland (4):
doc/mesh-api: Forward compatibility modifications
mesh: Update UnprovisionedScan, AddNode & ScanResult
test/test-mesh: Update to match modified APIs
tools/mesh-cfgclient: Update to match modified APIs

