### PR TITLE
[PW_SID:264493] [BlueZ] gatt: Fix possible crashes when disconnecting


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,13 @@
+--no-tree
+--no-signoff
+--summary-file
+--show-types
+--max-line-length=80
+
+--ignore COMPLEX_MACRO
+--ignore SPLIT_STRING
+--ignore CONST_STRUCT
+--ignore FILE_PATH_CHANGES
+--ignore MISSING_SIGN_OFF
+--ignore PREFER_PACKED
+--ignore COMMIT_MESSAGE

--- a/.github/workflows/checkbuild.yml
+++ b/.github/workflows/checkbuild.yml
@@ -1,0 +1,15 @@
+name: Check Build
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Build for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkbuild
+      uses: tedd-an/action-checkbuild@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,0 +1,15 @@
+name: Check Patch
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Patch for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkpatch
+      uses: tedd-an/action-checkpatch@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "*/30 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/src/gatt-database.c
+++ b/src/gatt-database.c
@@ -2405,6 +2405,11 @@ static void acquire_write_reply(DBusMessage *message, void *user_data)
 	int fd;
 	uint16_t mtu;
 
+	if (!op->owner_queue) {
+		DBG("Pending write was canceled when object got removed");
+		return;
+	}
+
 	chrc = gatt_db_attribute_get_user_data(op->attrib);
 	dbus_error_init(&err);
 
@@ -2486,6 +2491,11 @@ static void acquire_notify_reply(DBusMessage *message, void *user_data)
 	DBusError err;
 	int fd;
 	uint16_t mtu;
+
+	if (!op->owner_queue) {
+		DBG("Pending notify was canceled when object got removed");
+		return;
+	}
 
 	dbus_error_init(&err);
 


### PR DESCRIPTION

From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

If there are pending AcquireWrite or AcquireNotify when disconnecting
the attribute object may be freed (e.g. device is temporary) leading to
the following backtrace:

bluetoothd[369928]: src/gatt-database.c:gatt_db_service_removed() Local GATT service removed
bluetoothd[369928]: src/adapter.c:adapter_service_remove() /org/bluez/hci1
bluetoothd[369928]: src/adapter.c:remove_uuid() sending remove uuid command for index 1
bluetoothd[369928]: src/sdpd-service.c:remove_record_from_server() Removing record with handle 0x1002e
bluetoothd[369928]: src/gatt-database.c:send_notification_to_device() GATT server sending indication
bluetoothd[369928]: src/device.c:gatt_debug() Write Complete: err -125
bluetoothd[369928]: src/gatt-database.c:client_disconnect_cb() Client disconnected
bluetoothd[369928]: src/advertising.c:client_disconnect_cb() Client disconnected
bluetoothd[369928]: Failed to acquire write: org.freedesktop.DBus.Error.NoReply

Program received signal SIGSEGV, Segmentation fault.
0x0000555555631450 in acquire_write_reply (message=0x55555583dec0, user_data=0x555555843e40) at src/gatt-database.c:2437
2437            send_write(op->device, op->attrib, chrc->proxy, NULL, op->id,
