### PR TITLE
[PW_SID:263569] Add support of setting advertiing intervals.


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,13 @@
+--no-tree
+--no-signoff
+--summary-file
+--show-types
+--max-line-length=80
+
+--ignore COMPLEX_MACRO
+--ignore SPLIT_STRING
+--ignore CONST_STRUCT
+--ignore FILE_PATH_CHANGES
+--ignore MISSING_SIGN_OFF
+--ignore PREFER_PACKED
+--ignore COMMIT_MESSAGE

--- a/.github/workflows/checkbuild.yml
+++ b/.github/workflows/checkbuild.yml
@@ -1,0 +1,15 @@
+name: Check Build
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Build for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkbuild
+      uses: tedd-an/action-checkbuild@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,0 +1,15 @@
+name: Check Patch
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Patch for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkpatch
+      uses: tedd-an/action-checkpatch@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "*/30 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/doc/advertising-api.txt
+++ b/doc/advertising-api.txt
@@ -209,3 +209,16 @@ Properties	byte ActiveInstances
 			Possible values: "1M"
 					 "2M"
 					 "Coded"
+
+		void SetAdvertisingIntervals(uint16 min_interval_ms,
+					     uint16 max_interval_ms)
+
+			This method sets the advertising intervals.
+
+			The parameters min_interval_ms and max_interval_ms
+			are specified in milli-seconds. Valid values of
+			the intervals must fall between 20 ms and 10,240 ms.
+
+			Possible errors: org.bluez.Error.Failed
+					 org.bluez.Error.InProgress
+					 org.bluez.Error.InvalidArguments

--- a/doc/mgmt-api.txt
+++ b/doc/mgmt-api.txt
@@ -2925,6 +2925,31 @@ Read Extended Controller Information Command
 				Invalid Index
 
 
+Set Advertising Intervals Command
+=================================
+
+	Command Code:		0x0101
+	Controller Index:	<controller id>
+	Command Parameters:	Min_Interval     (2 Octets)
+				Max_Interval     (2 Octets)
+	Return Parameters:	Current_Settings (4 Octets)
+
+	This command is used to set advertising intervals. The intervals
+	are expressed in multiples of 0.625 ms. The default values of
+	both intervals are 0x0800. Valid Min_Interval and Max_Interval
+	values must fall between 0x0020 and 0x4000.
+
+	The advertising intervals are first kept in hdev struct. The values
+	would be sent to the controller and take effect when advertising is
+	actually enabled. If the advertising intervals are set when
+	advertising is already on, the advertising would be disabled and
+	re-enabled to make the intervals take effect.
+
+	Possible errors:	Busy
+				Rejected
+				Invalid Parameters
+
+
 Set Appearance Command
 ======================
 

--- a/lib/mgmt.h
+++ b/lib/mgmt.h
@@ -103,6 +103,7 @@ struct mgmt_rp_read_index_list {
 #define MGMT_SETTING_STATIC_ADDRESS	0x00008000
 #define MGMT_SETTING_PHY_CONFIGURATION	0x00010000
 #define MGMT_SETTING_WIDEBAND_SPEECH	0x00020000
+#define MGMT_SETTING_ADVERTISING_INTERVALS	0x00040000
 
 #define MGMT_OP_READ_INFO		0x0004
 struct mgmt_rp_read_info {
@@ -602,6 +603,15 @@ struct mgmt_cp_set_blocked_keys {
 
 #define MGMT_OP_SET_WIDEBAND_SPEECH	0x0047
 
+#define MGMT_OP_SET_ADVERTISING_INTERVALS	0x0048
+#define ADVERTISING_INTERVAL_UNIT_TIME 0.625
+struct mgmt_cp_set_advertising_intervals {
+	/* A unit of the intervals below is 0.625 ms.*/
+	uint16_t min_interval;
+	uint16_t max_interval;
+} __packed;
+#define MGMT_SET_ADVERTISING_INTERVALS_SIZE	4
+
 #define MGMT_EV_CMD_COMPLETE		0x0001
 struct mgmt_ev_cmd_complete {
 	uint16_t opcode;
@@ -898,6 +908,7 @@ static const char *mgmt_op[] = {
 	"Set PHY Configuration",
 	"Set Blocked Keys",
 	"Set Wideband Speech",
+	"Set Advertising Intervals",			/* 0x0048 */
 };
 
 static const char *mgmt_ev[] = {

--- a/monitor/control.c
+++ b/monitor/control.c
@@ -200,7 +200,7 @@ static const char *settings_str[] = {
 	"powered", "connectable", "fast-connectable", "discoverable",
 	"bondable", "link-security", "ssp", "br/edr", "hs", "le",
 	"advertising", "secure-conn", "debug-keys", "privacy",
-	"configuration", "static-addr", "phy", "wbs"
+	"configuration", "static-addr", "phy", "wbs" "advertising-intervals",
 };
 
 static void mgmt_new_settings(uint16_t len, const void *buf)

--- a/monitor/packet.c
+++ b/monitor/packet.c
@@ -11685,6 +11685,7 @@ static const struct bitfield_data mgmt_settings_table[] = {
 	{ 15, "Static Address"		},
 	{ 16, "PHY Configuration"	},
 	{ 17, "Wideband Speech"		},
+	{ 18, "Advertising Intervals"	},
 	{ }
 };
 
@@ -13004,6 +13005,23 @@ static void mgmt_set_phy_cmd(const void *data, uint16_t size)
 	mgmt_print_phys("Selected PHYs", selected_phys);
 }
 
+static void mgmt_set_adv_interval_cmd(const void *data, uint16_t size)
+{
+	uint16_t min_adv_interval = get_le16(data);
+	uint16_t max_adv_interval = get_le16(data+2);
+
+	print_field("Min advertising interval: 0x%4.4x", min_adv_interval);
+	print_field("Max advertising interval: 0x%4.4x", max_adv_interval);
+}
+
+static void mgmt_set_adv_interval_rsp(const void *data, uint16_t size)
+{
+	uint32_t current_settings = get_le32(data);
+
+	print_field("Current settings: 0x%8.8x", current_settings);
+}
+
+
 struct mgmt_data {
 	uint16_t opcode;
 	const char *str;
@@ -13223,6 +13241,9 @@ static const struct mgmt_data mgmt_command_table[] = {
 	{ 0x0045, "Set PHY Configuration",
 				mgmt_set_phy_cmd, 4, true,
 				mgmt_null_rsp, 0, true },
+	{ 0x0060, "LE Set Advertising Interval",
+				mgmt_set_adv_interval_cmd, 4, true,
+				mgmt_set_adv_interval_rsp, 4, true},
 	{ }
 };
 

--- a/test/example-advertising-intervals
+++ b/test/example-advertising-intervals
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+
+"""A simple script to set advertising intervals through the dbus method.
+
+Usage:
+    $ ./example_advertising_intervals.py min_interval_ms max_interval_ms
+
+    Example:
+    # Set both min and max advertising intervals to 200 ms.
+    $ ./exampel_advertising_intervals.py 200 200
+"""
+
+import dbus
+import time
+import subprocess
+import sys
+
+argv = sys.argv
+argc = len(argv)
+prog = argv[0]
+if argc == 3:
+    min_interval_ms = int(argv[1])
+    max_interval_ms = int(argv[2])
+    print 'Set advertising intervals: [%d, %d]' % (min_interval_ms,
+                                                   max_interval_ms)
+else:
+    print 'Usage: python %s min_interval_ms max_interval_ms' % prog
+    print '       python %s 200 200' % prog
+    sys.exit(1)
+
+
+# Set advertising intervals.
+bus = dbus.SystemBus()
+adapter = bus.get_object('org.bluez', '/org/bluez/hci0')
+adapter.SetAdvertisingIntervals(
+        min_interval_ms, max_interval_ms,
+        dbus_interface='org.bluez.LEAdvertisingManager1')
+
+
+# Wait a little while for dbus method to complete.
+time.sleep(0.2)
+
+
+# Check the current settings using btmgmt.
+btmgmt_cmd = 'btmgmt info'
+for line in subprocess.check_output(btmgmt_cmd.split()).splitlines():
+    if 'current settings' in line:
+        print line.strip()

--- a/tools/btmgmt.c
+++ b/tools/btmgmt.c
@@ -355,6 +355,7 @@ static const char *settings_str[] = {
 				"static-addr",
 				"phy-configuration",
 				"wide-band-speech",
+				"advertising-intervals",
 };
 
 static const char *settings2str(uint32_t settings)


### PR DESCRIPTION

Hi Linux bluetooth, this is a series of patches for supporting
setting of LE advertising intervals from D-Bus API.

Hi linux bluetooth, this is the lib/mgmt part of supporting LE
set advertising interval series patches.
Thanks

Hi linux bluetooth, this is the advertising part of supporting LE
set advertising interval series patches.
Thanks

Hi linux bluetooth, this is the documentation part of supporting LE
set advertising interval series patches.
Thanks

Hi linux bluetooth, this is the monitor part of supporting LE
set advertising interval series patches.
Thanks

Hi linux bluetooth, this is the test part of supporting LE set
advertising interval series patches.
Thanks

Hi linux bluetooth, this patch is the btmgmt part of supporting
LE Set Advertising Interval series.
Thanks

Changes in v2:
- Rebase and resolve conflict in monitor/control.c

Howard Chung (6):
lib/mgmt: Add LE Set Advertising Interval definition
core/advertising: Add support for LE set adverting interval
doc: Add documentation for LE Set Advertising Interval
monitor: Add support for decoding LE Set Advertising Interval
test: Add test for LE Set Advertising Interval
tools/btmgmt: Add setting string for LE Set Advertising Interval

doc/advertising-api.txt            | 13 +++++
doc/mgmt-api.txt                   | 25 +++++++++
lib/mgmt.h                         | 11 ++++
monitor/control.c                  |  2 +-
monitor/packet.c                   | 21 +++++++
src/advertising.c                  | 90 ++++++++++++++++++++++++++++++
test/example-advertising-intervals | 48 ++++++++++++++++
tools/btmgmt.c                     |  1 +
8 files changed, 210 insertions(+), 1 deletion(-)
create mode 100644 test/example-advertising-intervals
