### PR TITLE
[PW_SID:276383] [v2,1/6] monitor: Remove use of base defines for 5.2


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,13 @@
+--no-tree
+--no-signoff
+--summary-file
+--show-types
+--max-line-length=80
+
+--ignore COMPLEX_MACRO
+--ignore SPLIT_STRING
+--ignore CONST_STRUCT
+--ignore FILE_PATH_CHANGES
+--ignore MISSING_SIGN_OFF
+--ignore PREFER_PACKED
+--ignore COMMIT_MESSAGE

--- a/.github/workflows/checkbuild.yml
+++ b/.github/workflows/checkbuild.yml
@@ -1,0 +1,15 @@
+name: Check Build
+
+on: [pull_request]
+
+jobs:
+  checkbuild:
+    runs-on: ubuntu-latest
+    name: Check Build for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkbuild
+      uses: tedd-an/action-checkbuild@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/checkbuild.yml
+++ b/.github/workflows/checkbuild.yml
@@ -13,3 +13,4 @@ jobs:
       uses: tedd-an/action-checkbuild@master
       with:
         github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,0 +1,15 @@
+name: Check Patch
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Patch for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkpatch
+      uses: tedd-an/action-checkpatch@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -13,3 +13,4 @@ jobs:
       uses: tedd-an/action-checkpatch@master
       with:
         github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -2,7 +2,7 @@ name: Scheduled Work
 
 on:
   schedule:
-  - cron:  "*/30 * * * *"
+  - cron:  "*/8 * * * *"
 
 jobs:
 

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,38 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "*/30 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/emulator/btdev.c
+++ b/emulator/btdev.c
@@ -447,7 +447,7 @@ static void set_le_50_commands(struct btdev *btdev)
 	btdev->commands[38] |= 0x40;	/* LE Read Periodic Adv List Size */
 }
 
-static void set_le_60_commands(struct btdev *btdev)
+static void set_le_52_commands(struct btdev *btdev)
 {
 	btdev->commands[41] |= 0x20;	/* LE Read Buffer Size v2 */
 	btdev->commands[41] |= 0x40;	/* LE Read ISO TX Sync */
@@ -516,9 +516,9 @@ static void set_le_commands(struct btdev *btdev)
 	if (btdev->type >= BTDEV_TYPE_BREDRLE50)
 		set_le_50_commands(btdev);
 
-	/* Extra LE commands for >= 6.0 adapters */
-	if (btdev->type >= BTDEV_TYPE_BREDRLE60)
-		set_le_60_commands(btdev);
+	/* Extra LE commands for >= 5.2 adapters */
+	if (btdev->type >= BTDEV_TYPE_BREDRLE52)
+		set_le_52_commands(btdev);
 }
 
 static void set_bredrle_commands(struct btdev *btdev)
@@ -587,7 +587,7 @@ static void set_bredrle_features(struct btdev *btdev)
 		btdev->le_features[1] |= 0x10;  /* LE EXT ADV */
 	}
 
-	if (btdev->type >= BTDEV_TYPE_BREDRLE60) {
+	if (btdev->type >= BTDEV_TYPE_BREDRLE52) {
 		btdev->le_features[3] |= 0x10;  /* LE CIS Master */
 		btdev->le_features[3] |= 0x20;  /* LE CIS Slave */
 		btdev->le_features[3] |= 0x40;  /* LE ISO Broadcaster */
@@ -691,7 +691,7 @@ struct btdev *btdev_create(enum btdev_type type, uint16_t id)
 
 	if (type == BTDEV_TYPE_BREDRLE || type == BTDEV_TYPE_LE ||
 			type == BTDEV_TYPE_BREDRLE50 ||
-			type == BTDEV_TYPE_BREDRLE60) {
+			type == BTDEV_TYPE_BREDRLE52) {
 		btdev->crypto = bt_crypto_new();
 		if (!btdev->crypto) {
 			free(btdev);
@@ -707,7 +707,7 @@ struct btdev *btdev_create(enum btdev_type type, uint16_t id)
 	switch (btdev->type) {
 	case BTDEV_TYPE_BREDRLE:
 	case BTDEV_TYPE_BREDRLE50:
-	case BTDEV_TYPE_BREDRLE60:
+	case BTDEV_TYPE_BREDRLE52:
 		btdev->version = 0x09;
 		set_bredrle_features(btdev);
 		set_bredrle_commands(btdev);
@@ -3076,7 +3076,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 	case BT_HCI_CMD_READ_LE_HOST_SUPPORTED:
 		if (btdev->type != BTDEV_TYPE_BREDRLE &&
 				btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 		rlhs.status = BT_HCI_ERR_SUCCESS;
 		rlhs.supported = btdev->le_supported;
@@ -3088,7 +3088,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 		if (btdev->type != BTDEV_TYPE_BREDRLE &&
 				btdev->type != BTDEV_TYPE_LE &&
 				btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 		wlhs = data;
 		btdev->le_supported = wlhs->supported;
@@ -3100,7 +3100,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 	case BT_HCI_CMD_READ_SECURE_CONN_SUPPORT:
 		if (btdev->type != BTDEV_TYPE_BREDRLE &&
 				btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 		rscs.status = BT_HCI_ERR_SUCCESS;
 		rscs.support = btdev->secure_conn_support;
@@ -3110,7 +3110,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 	case BT_HCI_CMD_WRITE_SECURE_CONN_SUPPORT:
 		if (btdev->type != BTDEV_TYPE_BREDRLE &&
 				btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 		wscs = data;
 		btdev->secure_conn_support = wscs->support;
@@ -3121,7 +3121,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 	case BT_HCI_CMD_READ_LOCAL_OOB_EXT_DATA:
 		if (btdev->type != BTDEV_TYPE_BREDRLE &&
 				btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 		rloed.status = BT_HCI_ERR_SUCCESS;
 		cmd_complete(btdev, opcode, &rloed, sizeof(rloed));
@@ -3130,7 +3130,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 	case BT_HCI_CMD_READ_SYNC_TRAIN_PARAMS:
 		if (btdev->type != BTDEV_TYPE_BREDRLE &&
 				btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 		rstp.status = BT_HCI_ERR_SUCCESS;
 		rstp.interval = cpu_to_le16(btdev->sync_train_interval);
@@ -3282,7 +3282,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 		if (btdev->type != BTDEV_TYPE_BREDRLE &&
 					btdev->type != BTDEV_TYPE_BREDR &&
 					btdev->type != BTDEV_TYPE_BREDRLE50 &&
-					btdev->type != BTDEV_TYPE_BREDRLE60)
+					btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 		reks = data;
 		read_enc_key_size_complete(btdev, le16_to_cpu(reks->handle));
@@ -3658,7 +3658,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 		break;
 	case BT_HCI_CMD_LE_READ_NUM_SUPPORTED_ADV_SETS:
 		if (btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 
 		rlrnsas.status = BT_HCI_ERR_SUCCESS;
@@ -3668,7 +3668,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 		break;
 	case BT_HCI_CMD_LE_SET_ADV_SET_RAND_ADDR:
 		if (btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 
 		lsasra = data;
@@ -3678,7 +3678,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 		break;
 	case BT_HCI_CMD_LE_SET_EXT_ADV_PARAMS:
 		if (btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 
 		if (btdev->le_adv_enable) {
@@ -3699,7 +3699,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 		break;
 	case BT_HCI_CMD_LE_SET_EXT_ADV_ENABLE:
 		if (btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 
 		lseae = data;
@@ -3715,7 +3715,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 		break;
 	case BT_HCI_CMD_LE_SET_EXT_ADV_DATA:
 		if (btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 
 		lsead = data;
@@ -3726,7 +3726,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 		break;
 	case BT_HCI_CMD_LE_SET_EXT_SCAN_RSP_DATA:
 		if (btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 
 		lsesrd = data;
@@ -3737,7 +3737,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 		break;
 	case BT_HCI_CMD_LE_REMOVE_ADV_SET:
 		if (btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 
 		status = BT_HCI_ERR_SUCCESS;
@@ -3745,7 +3745,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 		break;
 	case BT_HCI_CMD_LE_CLEAR_ADV_SETS:
 		if (btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 
 		status = BT_HCI_ERR_SUCCESS;
@@ -3767,7 +3767,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 		break;
 	case BT_HCI_CMD_LE_SET_EXT_SCAN_PARAMS:
 		if (btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 
 		lsesp = data;
@@ -3790,7 +3790,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 		break;
 	case BT_HCI_CMD_LE_SET_EXT_SCAN_ENABLE:
 		if (btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 
 		lsese = data;
@@ -3805,14 +3805,14 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 		break;
 	case BT_HCI_CMD_LE_EXT_CREATE_CONN:
 		if (btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 
 		cmd_status(btdev, BT_HCI_ERR_SUCCESS, opcode);
 		break;
 
 	case BT_HCI_CMD_LE_READ_BUFFER_SIZE_V2:
-		if (btdev->type != BTDEV_TYPE_BREDRLE60)
+		if (btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 		lrbsv2.status = BT_HCI_ERR_SUCCESS;
 		lrbsv2.acl_mtu = cpu_to_le16(btdev->acl_mtu);
@@ -3823,7 +3823,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 		break;
 
 	case BT_HCI_CMD_LE_SET_CIG_PARAMS:
-		if (btdev->type != BTDEV_TYPE_BREDRLE60)
+		if (btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 		memcpy(&btdev->le_cig, data, len);
 		lscp.params.status = BT_HCI_ERR_SUCCESS;
@@ -3834,7 +3834,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 		break;
 
 	case BT_HCI_CMD_LE_CREATE_CIS:
-		if (btdev->type != BTDEV_TYPE_BREDRLE60)
+		if (btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 
 		cmd_status(btdev, BT_HCI_ERR_SUCCESS, opcode);
@@ -3842,7 +3842,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 		break;
 
 	case BT_HCI_CMD_LE_ACCEPT_CIS:
-		if (btdev->type != BTDEV_TYPE_BREDRLE60)
+		if (btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 
 		cmd_status(btdev, BT_HCI_ERR_SUCCESS, opcode);
@@ -3851,7 +3851,7 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 		break;
 
 	case BT_HCI_CMD_LE_REJECT_CIS:
-		if (btdev->type != BTDEV_TYPE_BREDRLE60)
+		if (btdev->type != BTDEV_TYPE_BREDRLE52)
 			goto unsupported;
 
 		cmd_status(btdev, BT_HCI_ERR_SUCCESS, opcode);
@@ -4098,7 +4098,7 @@ static void default_cmd_completion(struct btdev *btdev, uint16_t opcode,
 		break;
 	case BT_HCI_CMD_LE_SET_EXT_SCAN_ENABLE:
 		if (btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			return;
 		lsese = data;
 		if (btdev->le_scan_enable && lsese->enable)
@@ -4106,7 +4106,7 @@ static void default_cmd_completion(struct btdev *btdev, uint16_t opcode,
 		break;
 	case BT_HCI_CMD_LE_EXT_CREATE_CONN:
 		if (btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			return;
 		leecc = data;
 		btdev->le_scan_own_addr_type = leecc->own_addr_type;
@@ -4114,7 +4114,7 @@ static void default_cmd_completion(struct btdev *btdev, uint16_t opcode,
 		break;
 	case BT_HCI_CMD_LE_CREATE_CIS:
 		if (btdev->type != BTDEV_TYPE_BREDRLE50 &&
-				btdev->type != BTDEV_TYPE_BREDRLE60)
+				btdev->type != BTDEV_TYPE_BREDRLE52)
 			return;
 		leccis = data;
 		le_cis_request(btdev, leccis);

--- a/emulator/btdev.c
+++ b/emulator/btdev.c
@@ -469,6 +469,7 @@ static void set_le_52_commands(struct btdev *btdev)
 	btdev->commands[43] |= 0x40;	/* LE ISO RX Test */
 	btdev->commands[43] |= 0x80;	/* LE ISO Read Test Counter */
 	btdev->commands[44] |= 0x01;	/* LE ISO Test End */
+	btdev->commands[44] |= 0x02;	/* LE ISO Set Host Feature */
 }
 
 static void set_le_commands(struct btdev *btdev)
@@ -3858,6 +3859,15 @@ static void default_cmd(struct btdev *btdev, uint16_t opcode,
 
 		lrcis = data;
 		le_cis_estabilished(btdev, lrcis->reason);
+
+		break;
+
+	case BT_HCI_CMD_LE_SET_HOST_FEATURE:
+		if (btdev->type != BTDEV_TYPE_BREDRLE52)
+			goto unsupported;
+
+		status = BT_HCI_ERR_SUCCESS;
+		cmd_complete(btdev, opcode, &status, sizeof(status));
 
 		break;
 

--- a/emulator/btdev.h
+++ b/emulator/btdev.h
@@ -64,7 +64,7 @@ enum btdev_type {
 	BTDEV_TYPE_AMP,
 	BTDEV_TYPE_BREDR20,
 	BTDEV_TYPE_BREDRLE50,
-	BTDEV_TYPE_BREDRLE60,
+	BTDEV_TYPE_BREDRLE52,
 };
 
 enum btdev_hook_type {

--- a/emulator/hciemu.c
+++ b/emulator/hciemu.c
@@ -335,8 +335,8 @@ struct hciemu *hciemu_new(enum hciemu_type type)
 	case HCIEMU_TYPE_BREDRLE50:
 		hciemu->btdev_type = BTDEV_TYPE_BREDRLE50;
 		break;
-	case HCIEMU_TYPE_BREDRLE60:
-		hciemu->btdev_type = BTDEV_TYPE_BREDRLE60;
+	case HCIEMU_TYPE_BREDRLE52:
+		hciemu->btdev_type = BTDEV_TYPE_BREDRLE52;
 		break;
 	default:
 		return NULL;

--- a/emulator/hciemu.h
+++ b/emulator/hciemu.h
@@ -32,7 +32,7 @@ enum hciemu_type {
 	HCIEMU_TYPE_LE,
 	HCIEMU_TYPE_LEGACY,
 	HCIEMU_TYPE_BREDRLE50,
-	HCIEMU_TYPE_BREDRLE60,
+	HCIEMU_TYPE_BREDRLE52,
 };
 
 enum hciemu_hook_type {

--- a/emulator/vhci.c
+++ b/emulator/vhci.c
@@ -105,7 +105,7 @@ struct vhci *vhci_open(enum vhci_type type)
 
 	switch (type) {
 	case VHCI_TYPE_BREDRLE:
-		btdev_type = BTDEV_TYPE_BREDRLE60;
+		btdev_type = BTDEV_TYPE_BREDRLE52;
 		ctrl_type = HCI_PRIMARY;
 		break;
 	case VHCI_TYPE_BREDR:

--- a/monitor/bt.h
+++ b/monitor/bt.h
@@ -24,11 +24,7 @@
 
 #include <stdint.h>
 
-#define BT_HCI_CMD_5_2		0x2060
-#define BT_HCI_BIT_5_2		(8 * 41) + 5
-#define BT_HCI_SUBEVT_5_2	0x19
-
-#define BT_LL_CMD_5_2		0x1f
+#define BT_HCI_CMD_BIT(_byte, _bit) ((8 * _byte) + _bit)
 
 struct bt_ll_hdr {
 	uint8_t  preamble;
@@ -181,7 +177,7 @@ struct bt_ll_clock_acc {
 
 #define BT_LL_CLOCK_ACCURACY_RSP 0x1e
 
-#define BT_LL_CIS_REQ		BT_LL_CMD_5_2
+#define BT_LL_CIS_REQ		0x1f
 struct bt_ll_cis_req {
 	uint8_t  cig;
 	uint8_t  cis;
@@ -204,14 +200,14 @@ struct bt_ll_cis_req {
 	uint16_t conn_event_count;
 } __attribute__ ((packed));
 
-#define BT_LL_CIS_RSP		BT_LL_CMD_5_2 + 1
+#define BT_LL_CIS_RSP		0x20
 struct bt_ll_cis_rsp {
 	uint8_t  offset_min[3];
 	uint8_t  offset_max[3];
 	uint16_t conn_event_count;
 } __attribute__ ((packed));
 
-#define BT_LL_CIS_IND		BT_LL_CMD_5_2 + 2
+#define BT_LL_CIS_IND		0x21
 struct bt_ll_cis_ind {
 	uint32_t addr;
 	uint8_t  cis_offset[3];
@@ -220,7 +216,7 @@ struct bt_ll_cis_ind {
 	uint16_t conn_event_count;
 } __attribute__ ((packed));
 
-#define BT_LL_CIS_TERMINATE_IND	BT_LL_CMD_5_2 + 3
+#define BT_LL_CIS_TERMINATE_IND	0x22
 struct bt_ll_cis_term_ind {
 	uint8_t  cig;
 	uint8_t  cis;
@@ -2568,8 +2564,8 @@ struct bt_hci_cmd_default_periodic_adv_sync_trans_params {
 	uint8_t  cte_type;
 } __attribute__ ((packed));
 
-#define BT_HCI_CMD_LE_READ_BUFFER_SIZE_V2	BT_HCI_CMD_5_2
-#define BT_HCI_BIT_LE_READ_BUFFER_SIZE_V2	BT_HCI_BIT_5_2
+#define BT_HCI_CMD_LE_READ_BUFFER_SIZE_V2	0x2060
+#define BT_HCI_BIT_LE_READ_BUFFER_SIZE_V2	BT_HCI_CMD_BIT(41, 5)
 struct bt_hci_rsp_le_read_buffer_size_v2 {
 	uint8_t  status;
 	uint16_t acl_mtu;
@@ -2578,8 +2574,8 @@ struct bt_hci_rsp_le_read_buffer_size_v2 {
 	uint8_t  iso_max_pkt;
 } __attribute__ ((packed));
 
-#define BT_HCI_CMD_LE_READ_ISO_TX_SYNC		BT_HCI_CMD_5_2 + 1
-#define BT_HCI_BIT_LE_READ_ISO_TX_SYNC		BT_HCI_BIT_5_2 + 1
+#define BT_HCI_CMD_LE_READ_ISO_TX_SYNC		0x2061
+#define BT_HCI_BIT_LE_READ_ISO_TX_SYNC		BT_HCI_CMD_BIT(41, 6)
 struct bt_hci_cmd_le_read_iso_tx_sync {
 	uint16_t handle;
 } __attribute__ ((packed));
@@ -2592,8 +2588,8 @@ struct bt_hci_rsp_le_read_iso_tx_sync {
 	uint8_t  offset[3];
 } __attribute__ ((packed));
 
-#define BT_HCI_CMD_LE_SET_CIG_PARAMS		BT_HCI_CMD_5_2 + 2
-#define BT_HCI_BIT_LE_SET_CIG_PARAMS		BT_HCI_BIT_5_2 + 2
+#define BT_HCI_CMD_LE_SET_CIG_PARAMS		0x2062
+#define BT_HCI_BIT_LE_SET_CIG_PARAMS		BT_HCI_CMD_BIT(41, 7)
 struct bt_hci_cis_params {
 	uint8_t  cis_id;
 	uint16_t m_sdu;
@@ -2624,8 +2620,8 @@ struct bt_hci_rsp_le_set_cig_params {
 	uint16_t handle[0];
 } __attribute__ ((packed));
 
-#define BT_HCI_CMD_LE_SET_CIG_PARAMS_TEST	BT_HCI_CMD_5_2 + 3
-#define BT_HCI_BIT_LE_SET_CIG_PARAMS_TEST	BT_HCI_BIT_5_2 + 3
+#define BT_HCI_CMD_LE_SET_CIG_PARAMS_TEST	0x2063
+#define BT_HCI_BIT_LE_SET_CIG_PARAMS_TEST	BT_HCI_CMD_BIT(42, 0)
 struct bt_hci_cis_params_test {
 	uint8_t  cis_id;
 	uint8_t  nse;
@@ -2653,8 +2649,8 @@ struct bt_hci_cmd_le_set_cig_params_test {
 	struct bt_hci_cis_params_test cis[0];
 } __attribute__ ((packed));
 
-#define BT_HCI_CMD_LE_CREATE_CIS		BT_HCI_CMD_5_2 + 4
-#define BT_HCI_BIT_LE_CREATE_CIS		BT_HCI_BIT_5_2 + 4
+#define BT_HCI_CMD_LE_CREATE_CIS		0x2064
+#define BT_HCI_BIT_LE_CREATE_CIS		BT_HCI_CMD_BIT(42, 1)
 struct bt_hci_cis {
 	uint16_t  cis_handle;
 	uint16_t  acl_handle;
@@ -2665,27 +2661,27 @@ struct bt_hci_cmd_le_create_cis {
 	struct bt_hci_cis cis[0];
 } __attribute__ ((packed));
 
-#define BT_HCI_CMD_LE_REMOVE_CIG		BT_HCI_CMD_5_2 + 5
-#define BT_HCI_BIT_LE_REMOVE_CIG		BT_HCI_BIT_5_2 + 5
+#define BT_HCI_CMD_LE_REMOVE_CIG		0x2065
+#define BT_HCI_BIT_LE_REMOVE_CIG		BT_HCI_CMD_BIT(42, 2)
 struct bt_hci_cmd_le_remove_cig {
 	uint8_t  cig_id;
 } __attribute__ ((packed));
 
-#define BT_HCI_CMD_LE_ACCEPT_CIS		BT_HCI_CMD_5_2 + 6
-#define BT_HCI_BIT_LE_ACCEPT_CIS		BT_HCI_BIT_5_2 + 6
+#define BT_HCI_CMD_LE_ACCEPT_CIS		0x2066
+#define BT_HCI_BIT_LE_ACCEPT_CIS		BT_HCI_CMD_BIT(42, 3)
 struct bt_hci_cmd_le_accept_cis {
 	uint16_t handle;
 } __attribute__ ((packed));
 
-#define BT_HCI_CMD_LE_REJECT_CIS		BT_HCI_CMD_5_2 + 7
-#define BT_HCI_BIT_LE_REJECT_CIS		BT_HCI_BIT_5_2 + 7
+#define BT_HCI_CMD_LE_REJECT_CIS		0x2067
+#define BT_HCI_BIT_LE_REJECT_CIS		BT_HCI_CMD_BIT(42, 4)
 struct bt_hci_cmd_le_reject_cis {
 	uint16_t handle;
 	uint8_t  reason;
 } __attribute__ ((packed));
 
-#define BT_HCI_CMD_LE_CREATE_BIG		BT_HCI_CMD_5_2 + 8
-#define BT_HCI_BIT_LE_CREATE_BIG		BT_HCI_BIT_5_2 + 8
+#define BT_HCI_CMD_LE_CREATE_BIG		0x2068
+#define BT_HCI_BIT_LE_CREATE_BIG		BT_HCI_CMD_BIT(42, 5)
 struct bt_hci_bis {
 	uint8_t  sdu_interval[3];
 	uint16_t sdu;
@@ -2705,8 +2701,8 @@ struct bt_hci_cmd_le_create_big {
 	struct bt_hci_bis bis[0];
 } __attribute__ ((packed));
 
-#define BT_HCI_CMD_LE_CREATE_BIG_TEST		BT_HCI_CMD_5_2 + 9
-#define BT_HCI_BIT_LE_CREATE_BIG_TEST		BT_HCI_BIT_5_2 + 9
+#define BT_HCI_CMD_LE_CREATE_BIG_TEST		0x2069
+#define BT_HCI_BIT_LE_CREATE_BIG_TEST		BT_HCI_CMD_BIT(42, 6)
 struct bt_hci_bis_test {
 	uint8_t  sdu_interval[3];
 	uint16_t iso_interval;
@@ -2731,15 +2727,15 @@ struct bt_hci_cmd_le_create_big_test {
 	struct bt_hci_bis_test bis[0];
 } __attribute__ ((packed));
 
-#define BT_HCI_CMD_LE_TERM_BIG			BT_HCI_CMD_5_2 + 10
-#define BT_HCI_BIT_LE_TERM_BIG			BT_HCI_BIT_5_2 + 10
+#define BT_HCI_CMD_LE_TERM_BIG			0x206a
+#define BT_HCI_BIT_LE_TERM_BIG			BT_HCI_CMD_BIT(42, 7)
 struct bt_hci_cmd_le_term_big {
 	uint8_t  big_id;
 	uint8_t  reason;
 } __attribute__ ((packed));
 
-#define BT_HCI_CMD_LE_BIG_CREATE_SYNC		BT_HCI_CMD_5_2 + 11
-#define BT_HCI_BIT_LE_BIG_CREATE_SYNC		BT_HCI_BIT_5_2 + 11
+#define BT_HCI_CMD_LE_BIG_CREATE_SYNC		0x206b
+#define BT_HCI_BIT_LE_BIG_CREATE_SYNC		BT_HCI_CMD_BIT(43, 0)
 struct bt_hci_bis_sync {
 } __attribute__ ((packed));
 
@@ -2754,20 +2750,20 @@ struct bt_hci_cmd_le_big_create_sync {
 	struct bt_hci_bis_sync bis[0];
 } __attribute__ ((packed));
 
-#define BT_HCI_CMD_LE_BIG_TERM_SYNC		BT_HCI_CMD_5_2 + 12
-#define BT_HCI_BIT_LE_BIG_TERM_SYNC		BT_HCI_BIT_5_2 + 12
+#define BT_HCI_CMD_LE_BIG_TERM_SYNC		0x206c
+#define BT_HCI_BIT_LE_BIG_TERM_SYNC		BT_HCI_CMD_BIT(43, 1)
 struct bt_hci_cmd_le_big_term_sync {
 	uint8_t  big_id;
 } __attribute__ ((packed));
 
-#define BT_HCI_CMD_LE_REQ_PEER_SCA		BT_HCI_CMD_5_2 + 13
-#define BT_HCI_BIT_LE_REQ_PEER_SCA		BT_HCI_BIT_5_2 + 13
+#define BT_HCI_CMD_LE_REQ_PEER_SCA		0x206d
+#define BT_HCI_BIT_LE_REQ_PEER_SCA		BT_HCI_CMD_BIT(43, 2)
 struct bt_hci_cmd_le_req_peer_sca {
 	uint16_t handle;
 } __attribute__ ((packed));
 
-#define BT_HCI_CMD_LE_SETUP_ISO_PATH		BT_HCI_CMD_5_2 + 14
-#define BT_HCI_BIT_LE_SETUP_ISO_PATH		BT_HCI_BIT_5_2 + 14
+#define BT_HCI_CMD_LE_SETUP_ISO_PATH		0x206e
+#define BT_HCI_BIT_LE_SETUP_ISO_PATH		BT_HCI_CMD_BIT(43, 3)
 struct bt_hci_cmd_le_setup_iso_path {
 	uint16_t handle;
 	uint8_t  direction;
@@ -2780,24 +2776,31 @@ struct bt_hci_cmd_le_setup_iso_path {
 	uint8_t  codec_cfg[0];
 } __attribute__ ((packed));
 
-#define BT_HCI_CMD_LE_REMOVE_ISO_PATH		BT_HCI_CMD_5_2 + 15
-#define BT_HCI_BIT_LE_REMOVE_ISO_PATH		BT_HCI_BIT_5_2 + 15
+#define BT_HCI_CMD_LE_REMOVE_ISO_PATH		0x206f
+#define BT_HCI_BIT_LE_REMOVE_ISO_PATH		BT_HCI_CMD_BIT(43, 4)
 struct bt_hci_cmd_le_remove_iso_path {
 	uint16_t handle;
 	uint8_t  path_dir;
 } __attribute__ ((packed));
 
-#define BT_HCI_CMD_LE_ISO_TX_TEST		BT_HCI_CMD_5_2 + 16
-#define BT_HCI_BIT_LE_ISO_TX_TEST		BT_HCI_BIT_5_2 + 16
+#define BT_HCI_CMD_LE_ISO_TX_TEST		0x2070
+#define BT_HCI_BIT_LE_ISO_TX_TEST		BT_HCI_CMD_BIT(43, 5)
 
-#define BT_HCI_CMD_LE_ISO_RX_TEST		BT_HCI_CMD_5_2 + 17
-#define BT_HCI_BIT_LE_ISO_RX_TEST		BT_HCI_BIT_5_2 + 17
+#define BT_HCI_CMD_LE_ISO_RX_TEST		0x2071
+#define BT_HCI_BIT_LE_ISO_RX_TEST		BT_HCI_CMD_BIT(43, 6)
 
-#define BT_HCI_CMD_LE_ISO_READ_TEST_COUNTER	BT_HCI_CMD_5_2 + 18
-#define BT_HCI_BIT_LE_ISO_READ_TEST_COUNTER	BT_HCI_BIT_5_2 + 18
+#define BT_HCI_CMD_LE_ISO_READ_TEST_COUNTER	0x2072
+#define BT_HCI_BIT_LE_ISO_READ_TEST_COUNTER	BT_HCI_CMD_BIT(43, 7)
 
-#define BT_HCI_CMD_LE_ISO_TEST_END		BT_HCI_CMD_5_2 + 19
-#define BT_HCI_BIT_LE_ISO_TEST_END		BT_HCI_BIT_5_2 + 19
+#define BT_HCI_CMD_LE_ISO_TEST_END		0x2073
+#define BT_HCI_BIT_LE_ISO_TEST_END		BT_HCI_CMD_BIT(44, 0)
+
+#define BT_HCI_CMD_LE_SET_HOST_FEATURE		0x2074
+#define BT_HCI_BIT_LE_SET_HOST_FEATURE		BT_HCI_CMD_BIT(44, 1)
+struct bt_hci_cmd_le_set_host_feature {
+	uint8_t  bit_number;
+	uint8_t  bit_value;
+} __packed;
 
 #define BT_HCI_EVT_INQUIRY_COMPLETE		0x01
 struct bt_hci_evt_inquiry_complete {
@@ -3155,7 +3158,7 @@ struct bt_hci_evt_keypress_notify {
 
 #define BT_HCI_EVT_REMOTE_HOST_FEATURES_NOTIFY	0x3d
 struct bt_hci_evt_remote_host_features_notify {
-	uint8_t  bdaddr[6];
+uint8_t  bdaddr[6];
 	uint8_t  features[8];
 } __attribute__ ((packed));
 
@@ -3498,7 +3501,7 @@ struct bt_hci_evt_le_per_adv_sync_trans_rec {
 	uint8_t  clock_accuracy;
 } __attribute__ ((packed));
 
-#define BT_HCI_EVT_LE_CIS_ESTABLISHED		BT_HCI_SUBEVT_5_2
+#define BT_HCI_EVT_LE_CIS_ESTABLISHED			0x19
 struct bt_hci_evt_le_cis_established {
 	uint8_t  status;
 	uint16_t conn_handle;
@@ -3518,7 +3521,7 @@ struct bt_hci_evt_le_cis_established {
 	uint16_t interval;
 } __attribute__ ((packed));
 
-#define BT_HCI_EVT_LE_CIS_REQ			BT_HCI_SUBEVT_5_2 + 1
+#define BT_HCI_EVT_LE_CIS_REQ				0x1a
 struct bt_hci_evt_le_cis_req {
 	uint16_t acl_handle;
 	uint16_t cis_handle;
@@ -3526,7 +3529,7 @@ struct bt_hci_evt_le_cis_req {
 	uint8_t  cis_id;
 } __attribute__ ((packed));
 
-#define BT_HCI_EVT_LE_BIG_COMPLETE		BT_HCI_SUBEVT_5_2 + 2
+#define BT_HCI_EVT_LE_BIG_COMPLETE			0x1b
 struct bt_hci_evt_le_big_complete {
 	uint8_t  status;
 	uint8_t  big_id;
@@ -3537,13 +3540,13 @@ struct bt_hci_evt_le_big_complete {
 	uint16_t handle[0];
 } __attribute__ ((packed));
 
-#define BT_HCI_EVT_LE_BIG_TERMINATE		BT_HCI_SUBEVT_5_2 + 3
+#define BT_HCI_EVT_LE_BIG_TERMINATE			0x1c
 struct bt_hci_evt_le_big_terminate {
 	uint8_t  reason;
 	uint8_t  big_id;
 } __attribute__ ((packed));
 
-#define BT_HCI_EVT_LE_BIG_SYNC_ESTABILISHED	BT_HCI_SUBEVT_5_2 + 4
+#define BT_HCI_EVT_LE_BIG_SYNC_ESTABILISHED		0x1d
 struct bt_hci_evt_le_big_sync_estabilished {
 	uint8_t  status;
 	uint8_t  big_id;
@@ -3552,13 +3555,13 @@ struct bt_hci_evt_le_big_sync_estabilished {
 	uint16_t handle[0];
 } __attribute__ ((packed));
 
-#define BT_HCI_EVT_LE_BIG_SYNC_LOST		BT_HCI_SUBEVT_5_2 + 5
+#define BT_HCI_EVT_LE_BIG_SYNC_LOST			0x1e
 struct bt_hci_evt_le_big_sync_lost {
 	uint8_t  big_id;
 	uint8_t  reason;
 } __attribute__ ((packed));
 
-#define BT_HCI_EVT_LE_REQ_PEER_SCA_COMPLETE	BT_HCI_SUBEVT_5_2 + 6
+#define BT_HCI_EVT_LE_REQ_PEER_SCA_COMPLETE		0x1f
 struct bt_hci_evt_le_req_peer_sca_complete {
 	uint8_t  status;
 	uint16_t handle;

--- a/monitor/bt.h
+++ b/monitor/bt.h
@@ -2780,7 +2780,7 @@ struct bt_hci_cmd_le_setup_iso_path {
 #define BT_HCI_BIT_LE_REMOVE_ISO_PATH		BT_HCI_CMD_BIT(43, 4)
 struct bt_hci_cmd_le_remove_iso_path {
 	uint16_t handle;
-	uint8_t  path_dir;
+	uint8_t  direction;
 } __attribute__ ((packed));
 
 #define BT_HCI_CMD_LE_ISO_TX_TEST		0x2070

--- a/monitor/packet.c
+++ b/monitor/packet.c
@@ -8118,7 +8118,7 @@ static void le_remove_iso_path_cmd(const void *data, uint8_t size)
 	const struct bt_hci_cmd_le_remove_iso_path *cmd = data;
 
 	print_field("Connection Handle: %d", le16_to_cpu(cmd->handle));
-	print_iso_dir("Data Path Direction", cmd->path_dir);
+	print_iso_dir("Data Path Direction", cmd->direction);
 }
 
 static void le_req_peer_sca_cmd(const void *data, uint8_t size)

--- a/monitor/packet.c
+++ b/monitor/packet.c
@@ -8128,6 +8128,21 @@ static void le_req_peer_sca_cmd(const void *data, uint8_t size)
 	print_field("Connection Handle: %d", le16_to_cpu(cmd->handle));
 }
 
+static void le_set_host_feature_cmd(const void *data, uint8_t size)
+{
+	const struct bt_hci_cmd_le_set_host_feature *cmd = data;
+	uint64_t mask;
+
+	print_field("Bit Number:");
+
+	mask = print_bitfield(2, cmd->bit_number, features_le);
+	if (mask)
+		print_text(COLOR_UNKNOWN_FEATURE_BIT, "  Unknown features "
+						"(0x%16.16" PRIx64 ")", mask);
+
+	print_field("Bit Value: %u", cmd->bit_value);
+}
+
 struct opcode_data {
 	uint16_t opcode;
 	int bit;
@@ -9041,6 +9056,10 @@ static const struct opcode_data opcode_table[] = {
 	{ BT_HCI_CMD_LE_ISO_TEST_END, BT_HCI_BIT_LE_ISO_TEST_END,
 				"LE Isochronous Read Test Counters", NULL, 0,
 				false },
+	{ BT_HCI_CMD_LE_SET_HOST_FEATURE, BT_HCI_BIT_LE_SET_HOST_FEATURE,
+				"LE Set Host Feature", le_set_host_feature_cmd,
+				sizeof(struct bt_hci_cmd_le_set_host_feature),
+				true, status_rsp, 1, true },
 	{ }
 };
 


### PR DESCRIPTION

From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

Use the allocated value directly instead of base value + offset.
