### PR TITLE
[PW_SID:281875] [BlueZ,v1] doc:adding definitions for load default params mgmt op


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,13 @@
+--no-tree
+--no-signoff
+--summary-file
+--show-types
+--max-line-length=80
+
+--ignore COMPLEX_MACRO
+--ignore SPLIT_STRING
+--ignore CONST_STRUCT
+--ignore FILE_PATH_CHANGES
+--ignore MISSING_SIGN_OFF
+--ignore PREFER_PACKED
+--ignore COMMIT_MESSAGE

--- a/.github/workflows/checkbuild.yml
+++ b/.github/workflows/checkbuild.yml
@@ -1,0 +1,15 @@
+name: Check Build
+
+on: [pull_request]
+
+jobs:
+  checkbuild:
+    runs-on: ubuntu-latest
+    name: Check Build for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkbuild
+      uses: tedd-an/action-checkbuild@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/checkbuild.yml
+++ b/.github/workflows/checkbuild.yml
@@ -13,3 +13,4 @@ jobs:
       uses: tedd-an/action-checkbuild@master
       with:
         github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,0 +1,15 @@
+name: Check Patch
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Patch for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkpatch
+      uses: tedd-an/action-checkpatch@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -13,3 +13,4 @@ jobs:
       uses: tedd-an/action-checkpatch@master
       with:
         github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -2,7 +2,7 @@ name: Scheduled Work
 
 on:
   schedule:
-  - cron:  "*/30 * * * *"
+  - cron:  "*/8 * * * *"
 
 jobs:
 

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,38 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "*/30 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/doc/mgmt-api.txt
+++ b/doc/mgmt-api.txt
@@ -3137,6 +3137,65 @@ Read Security Information Command
 	Possible errors:	Invalid Parameters
 				Invalid Index
 
+Load Default Parameter Command
+=============================
+
+	Command Code:		0x0049
+	Controller Index:	<controller id>
+	Command Parameters:	Parameter_Count (2 Octets)
+				Parameter1 {
+					Parameter_Type (2 Octet)
+					Value_Length (1 Octet)
+					Value (0-255 Octets)
+				}
+				Parameter2 { }
+				...
+	Return Parameters:
+
+	This command is used to feed the kernel a list of default parameters.
+
+	Currently defined Parameter_Type values are:
+
+			0x0000	BR/EDR Page Scan Type
+			0x0001	BR/EDR Page Scan Interval
+			0x0002	BR/EDR Page Scan Window
+			0x0003	BR/EDR Inquiry Scan Type
+			0x0004	BR/EDR Inquiry Scan Interval
+			0x0005	BR/EDR Inquiry Scan Window
+			0x0006	BR/EDR Link Supervision Timeout
+			0x0007	BR/EDR Page Timeout
+			0x0008	BR/EDR Min Sniff Interval
+			0x0009	BR/EDR Max Sniff Interval
+			0x0080	LE Advertisement Min Interval
+			0x0081	LE Advertisement Max Interval
+			0x0082	LE Multi Advertisement Rotation Interval
+			0x0083	LE Scanning Interval for auto connect
+			0x0084	LE Scanning Window for auto connect
+			0x0085	LE Scanning Interval for HID only
+			0x0086	LE Scanning Window for HID only
+			0x0087	LE Scanning Interval for wake scenarios
+			0x0088	LE Scanning Window for wake scenarios
+			0x0089	LE Scanning Interval for discovery
+			0x008a	LE Scanning Window for discovery
+			0x008b	LE Scanning Interval for adv monitoring
+			0x008c	LE Scanning Window for adv monitoring
+			0x008d	LE Scanning Interval for connect
+			0x008e	LE Scanning Window for connect
+			0x008f	LE Min Connection Interval
+			0x0090	LE Max Connection Interval
+			0x0091	LE Connection Connection Latency
+			0x0092	LE Connection Supervision Timeout
+
+	This command can be used any time, but will not take effect until the
+	next activity requiring the parameters.  In the case the parameters are
+	used during initialization of the adapter, it is expected that the
+	parameters be set before the adapter is powered.
+
+	This command generates a Command Complete event on success or
+	a Command Status event on failure.
+
+	Possible errors:	Invalid Parameters
+				Invalid Index
 
 Command Complete Event
 ======================


### PR DESCRIPTION

This change adds the definition for the load default parameter command.
In particular, this command is used to load default parameters for
various operations in the kernel. This mechanism is also expandable to
future knobs that may be necessary.

This will allow bluetoothd to load parameters from a conf file that may
be customized for the specific requirements of each platforms.
