### PR TITLE
[PW_SID:282865] [BlueZ,v1] doc/advertisement-monitor-api: Rename methods and shorten the preset strings


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,13 @@
+--no-tree
+--no-signoff
+--summary-file
+--show-types
+--max-line-length=80
+
+--ignore COMPLEX_MACRO
+--ignore SPLIT_STRING
+--ignore CONST_STRUCT
+--ignore FILE_PATH_CHANGES
+--ignore MISSING_SIGN_OFF
+--ignore PREFER_PACKED
+--ignore COMMIT_MESSAGE

--- a/.github/workflows/checkbuild.yml
+++ b/.github/workflows/checkbuild.yml
@@ -1,0 +1,15 @@
+name: Check Build
+
+on: [pull_request]
+
+jobs:
+  checkbuild:
+    runs-on: ubuntu-latest
+    name: Check Build for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkbuild
+      uses: tedd-an/action-checkbuild@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/checkbuild.yml
+++ b/.github/workflows/checkbuild.yml
@@ -13,3 +13,4 @@ jobs:
       uses: tedd-an/action-checkbuild@master
       with:
         github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,0 +1,15 @@
+name: Check Patch
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Patch for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkpatch
+      uses: tedd-an/action-checkpatch@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -13,3 +13,4 @@ jobs:
       uses: tedd-an/action-checkpatch@master
       with:
         github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -2,7 +2,7 @@ name: Scheduled Work
 
 on:
   schedule:
-  - cron:  "*/30 * * * *"
+  - cron:  "*/8 * * * *"
 
 jobs:
 

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,38 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "*/30 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/doc/advertisement-monitor-api.txt
+++ b/doc/advertisement-monitor-api.txt
@@ -89,7 +89,7 @@ Service		org.bluez
 Interface	org.bluez.AdvertisementMonitorManager1 [experimental]
 Object path	/org/bluez/{hci0,hci1,...}
 
-Methods		void RegisterApplication(object application)
+Methods		void RegisterMonitor(object application)
 
 			This registers a hierarchy of advertisement monitors.
 			The application object path together with the D-Bus
@@ -99,7 +99,7 @@ Methods		void RegisterApplication(object application)
 			Possible errors: org.bluez.Error.InvalidArguments
 					 org.bluez.Error.AlreadyExists
 
-		void UnregisterApplication(object application)
+		void UnregisterMonitor(object application)
 
 			This unregisters advertisement monitors that have been
 			previously registered. The object path parameter must
@@ -118,7 +118,7 @@ Properties	array{string} SupportedMonitorTypes [read-only]
 
 			Possible values for monitor types:
 
-			"patterns_with_logic_or"
+			"or_patterns"
 				Patterns with logic OR applied. With this type,
 				property "Patterns" must exist and has at least
 				one pattern.
@@ -130,7 +130,7 @@ Properties	array{string} SupportedMonitorTypes [read-only]
 
 			Possible values for features:
 
-			"controller-based-monitor-by-patterns"
+			"controller-patterns"
 				If the controller is capable of performing
 				advertisement monitoring by patterns, BlueZ
 				would offload the patterns to the controller to


### PR DESCRIPTION

This renames RegisterApplication/UnregisterApplication to
RegisterMonitor/UnregisterMonitor and shortens the strings used in some
properties.
