### PR TITLE
[PW_SID:282959] [BlueZ] tools/mesh-cfgclient: Fix model app list parsing


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,13 @@
+--no-tree
+--no-signoff
+--summary-file
+--show-types
+--max-line-length=80
+
+--ignore COMPLEX_MACRO
+--ignore SPLIT_STRING
+--ignore CONST_STRUCT
+--ignore FILE_PATH_CHANGES
+--ignore MISSING_SIGN_OFF
+--ignore PREFER_PACKED
+--ignore COMMIT_MESSAGE

--- a/.github/workflows/checkbuild.yml
+++ b/.github/workflows/checkbuild.yml
@@ -1,0 +1,15 @@
+name: Check Build
+
+on: [pull_request]
+
+jobs:
+  checkbuild:
+    runs-on: ubuntu-latest
+    name: Check Build for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkbuild
+      uses: tedd-an/action-checkbuild@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/checkbuild.yml
+++ b/.github/workflows/checkbuild.yml
@@ -13,3 +13,4 @@ jobs:
       uses: tedd-an/action-checkbuild@master
       with:
         github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,0 +1,15 @@
+name: Check Patch
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Patch for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkpatch
+      uses: tedd-an/action-checkpatch@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -13,3 +13,4 @@ jobs:
       uses: tedd-an/action-checkpatch@master
       with:
         github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -2,7 +2,7 @@ name: Scheduled Work
 
 on:
   schedule:
-  - cron:  "*/30 * * * *"
+  - cron:  "*/8 * * * *"
 
 jobs:
 

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,38 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "*/30 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/tools/mesh-cfgclient.c
+++ b/tools/mesh-cfgclient.c
@@ -338,12 +338,14 @@ static bool send_key(void *user_data, uint16_t dst, uint16_t key_idx,
 	}
 
 	if (!is_appkey && !keys_subnet_exists(key_idx)) {
-		bt_shell_printf("Local NetKey %u not found\n", key_idx);
+		bt_shell_printf("Local NetKey %u (%3.3x) not found\n",
+							key_idx, key_idx);
 		return false;
 	}
 
 	if (is_appkey && (keys_get_bound_key(key_idx) == NET_IDX_INVALID)) {
-		bt_shell_printf("Local AppKey %u not found\n", key_idx);
+		bt_shell_printf("Local AppKey %u (%3.3x) not found\n",
+							key_idx, key_idx);
 		return false;
 	}
 

--- a/tools/mesh/cfgcli.c
+++ b/tools/mesh/cfgcli.c
@@ -351,7 +351,8 @@ static void print_pub(uint16_t ele_addr, uint32_t mod_id,
 		bt_shell_printf("\tModel: %4.4x\n",
 				(uint16_t) (mod_id & 0xffff));
 
-	bt_shell_printf("\tApp Key Idx: %4.4x\n", pub->app_idx);
+	bt_shell_printf("\tApp Key Idx: %u (0x%3.3x)\n", pub->app_idx,
+								pub->app_idx);
 	bt_shell_printf("\tTTL: %2.2x\n", pub->ttl);
 }
 
@@ -374,6 +375,27 @@ static void print_sub_list(uint16_t addr, bool is_vendor, uint8_t *data,
 		bt_shell_printf("\t\t%4.4x\n ", get_le16(data + i));
 }
 
+static void print_appkey_list(uint16_t len, uint8_t *data)
+{
+	uint16_t app_idx;
+
+	bt_shell_printf("AppKeys:\n");
+
+	while (len >= 3) {
+		app_idx = l_get_le16(data) & 0xfff;
+		bt_shell_printf("\t%u (0x%3.3x)\n", app_idx, app_idx);
+		app_idx = l_get_le16(data + 1) >> 4;
+		bt_shell_printf("\t%u (0x%3.3x)\n", app_idx, app_idx);
+		data += 3;
+		len -= 3;
+	}
+
+	if (len == 2) {
+		app_idx = l_get_le16(data) & 0xfff;
+		bt_shell_printf("\t %u (0x%3.3x)\n", app_idx, app_idx);
+	}
+}
+
 static bool msg_recvd(uint16_t src, uint16_t idx, uint8_t *data,
 							uint16_t len)
 {
@@ -384,7 +406,6 @@ static bool msg_recvd(uint16_t src, uint16_t idx, uint8_t *data,
 	uint32_t mod_id;
 	struct model_pub pub;
 	int n;
-	uint16_t i;
 	struct pending_req *req;
 
 	if (mesh_opcode_get(data, len, &opcode, &n)) {
@@ -424,8 +445,8 @@ static bool msg_recvd(uint16_t src, uint16_t idx, uint8_t *data,
 		net_idx = get_le16(data + 1) & 0xfff;
 		app_idx = get_le16(data + 2) >> 4;
 
-		bt_shell_printf("NetKey\t%3.3x\n", net_idx);
-		bt_shell_printf("AppKey\t%3.3x\n", app_idx);
+		bt_shell_printf("NetKey\t%u (0x%3.3x)\n", net_idx, net_idx);
+		bt_shell_printf("AppKey\t%u (0x%3.3x)\n", app_idx, app_idx);
 
 		if (data[0] != MESH_STATUS_SUCCESS)
 			break;
@@ -455,18 +476,8 @@ static bool msg_recvd(uint16_t src, uint16_t idx, uint8_t *data,
 		if (data[0] != MESH_STATUS_SUCCESS)
 			break;
 
-		bt_shell_printf("AppKeys:\n");
 		data += 3;
-
-		while (len >= 3) {
-			bt_shell_printf("\t%3.3x\n", l_get_le16(data) & 0xfff);
-			bt_shell_printf("\t%3.3x\n", l_get_le16(data + 1) >> 4);
-			len -= 3;
-			data += 3;
-		}
-
-		if (len == 2)
-			bt_shell_printf("\t%3.3x\n", l_get_le16(data));
+		print_appkey_list(len, data);
 
 		break;
 
@@ -478,7 +489,7 @@ static bool msg_recvd(uint16_t src, uint16_t idx, uint8_t *data,
 						mesh_status_str(data[0]));
 		net_idx = get_le16(data + 1) & 0xfff;
 
-		bt_shell_printf("\tNetKey %3.3x\n", net_idx);
+		bt_shell_printf("\tNetKey %u (0x%3.3x)\n", net_idx, net_idx);
 
 		if (data[0] != MESH_STATUS_SUCCESS)
 			break;
@@ -504,15 +515,17 @@ static bool msg_recvd(uint16_t src, uint16_t idx, uint8_t *data,
 
 		while (len >= 3) {
 			net_idx = l_get_le16(data) & 0xfff;
-			bt_shell_printf("\t%3.3x\n", net_idx);
+			bt_shell_printf("\t%u (0x%3.3x)\n", net_idx, net_idx);
 			net_idx = l_get_le16(data + 1) >> 4;
-			bt_shell_printf("\t%3.3x\n", net_idx);
+			bt_shell_printf("\t%u (0x%3.3x)\n", net_idx, net_idx);
 			data += 3;
 			len -= 3;
 		}
 
-		if (len == 2)
-			bt_shell_printf("\t%3.3x\n", l_get_le16(data) & 0xfff);
+		if (len == 2) {
+			net_idx = l_get_le16(data) & 0xfff;
+			bt_shell_printf("\t %u (0x%3.3x)\n", net_idx, net_idx);
+		}
 
 		break;
 
@@ -524,7 +537,7 @@ static bool msg_recvd(uint16_t src, uint16_t idx, uint8_t *data,
 						mesh_status_str(data[0]));
 		net_idx = get_le16(data + 1) & 0xfff;
 
-		bt_shell_printf("\tNetKey %3.3x\n", net_idx);
+		bt_shell_printf("\tNetKey %u (0x%3.3x)\n", net_idx, net_idx);
 		bt_shell_printf("\tKR Phase %2.2x\n", data[3]);
 		break;
 
@@ -541,7 +554,7 @@ static bool msg_recvd(uint16_t src, uint16_t idx, uint8_t *data,
 
 		print_mod_id(data + 5, len == 9, "");
 
-		bt_shell_printf("AppIdx\t\t%3.3x\n ", app_idx);
+		bt_shell_printf("AppIdx\t\t%u (0x%3.3x)\n ", app_idx, app_idx);
 
 		break;
 
@@ -673,9 +686,9 @@ static bool msg_recvd(uint16_t src, uint16_t idx, uint8_t *data,
 		bt_shell_printf("Element Addr\t%4.4x\n", get_le16(data + 1));
 		bt_shell_printf("Model ID\t%4.4x\n", get_le16(data + 3));
 
-		for (i = 5; i < len; i += 2)
-			bt_shell_printf("Model AppIdx\t%4.4x\n",
-							get_le16(data + i));
+		data += 5;
+		print_appkey_list(len, data);
+
 		break;
 
 	case OP_VEND_MODEL_APP_LIST:
@@ -691,9 +704,9 @@ static bool msg_recvd(uint16_t src, uint16_t idx, uint8_t *data,
 		bt_shell_printf("Element Addr\t%4.4x\n", get_le16(data + 1));
 		print_mod_id(data + 3, true, "");
 
-		for (i = 7; i < len; i += 2)
-			bt_shell_printf("Model AppIdx\t%4.4x\n",
-							get_le16(data + i));
+		data += 7;
+		print_appkey_list(len, data);
+
 		break;
 
 	/* Per Mesh Profile 4.3.2.63 */
@@ -709,7 +722,8 @@ static bool msg_recvd(uint16_t src, uint16_t idx, uint8_t *data,
 		bt_shell_printf("Period\t\t%2.2x\n", data[4]);
 		bt_shell_printf("TTL\t\t%2.2x\n", data[5]);
 		bt_shell_printf("Features\t%4.4x\n", get_le16(data + 6));
-		bt_shell_printf("Net_Idx\t%4.4x\n", get_le16(data + 8));
+		net_idx = get_le16(data + 8);
+		bt_shell_printf("Net_Idx\t%u (0x%3.3x)\n", net_idx, net_idx);
 		break;
 
 	/* Per Mesh Profile 4.3.2.66 */
@@ -733,7 +747,7 @@ static bool msg_recvd(uint16_t src, uint16_t idx, uint8_t *data,
 		if (len != 1)
 			return true;
 
-		bt_shell_printf("Node %4.4x: Network transmit cnt %d, steps %d\n",
+		bt_shell_printf("Node %4.4x: Net transmit cnt %d, steps %d\n",
 				src, data[0] & 7, data[0] >> 3);
 		break;
 

--- a/tools/mesh/keys.c
+++ b/tools/mesh/keys.c
@@ -193,15 +193,15 @@ static void print_appkey(void *app_key, void *user_data)
 {
 	uint16_t app_idx = L_PTR_TO_UINT(app_key);
 
-	bt_shell_printf("0x%3.3x, ", app_idx);
+	bt_shell_printf("%u (0x%3.3x), ", app_idx, app_idx);
 }
 
 static void print_netkey(void *net_key, void *user_data)
 {
 	struct net_key *key = net_key;
 
-	bt_shell_printf(COLOR_YELLOW "NetKey: 0x%3.3x, phase: %u\n" COLOR_OFF,
-							key->idx, key->phase);
+	bt_shell_printf(COLOR_YELLOW "NetKey: %u (0x%3.3x), phase: %u\n"
+				COLOR_OFF, key->idx, key->idx, key->phase);
 
 	if (!key->app_keys || l_queue_isempty(key->app_keys))
 		return;

--- a/tools/mesh/remote.c
+++ b/tools/mesh/remote.c
@@ -217,11 +217,11 @@ uint16_t remote_get_subnet_idx(uint16_t addr)
 	return (uint16_t) net_idx;
 }
 
-static void print_key(void *net_key, void *user_data)
+static void print_key(void *key, void *user_data)
 {
-	uint16_t net_idx = L_PTR_TO_UINT(net_key);
+	uint16_t idx = L_PTR_TO_UINT(key);
 
-	bt_shell_printf("%3.3x, ", net_idx);
+	bt_shell_printf("%u (0x%3.3x), ", idx, idx);
 }
 
 static void print_node(void *rmt, void *user_data)


### PR DESCRIPTION

This fixes parsing of Model AppKey List & Vendor Model Appkey List
messages: taking into account the packt that AppKey indices are parked
two in three octets.

Also, when printing key indices, print in both decimal and hexadecimal
formats.
