### PR TITLE
[PW_SID:285071] Allow some composition fields update


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,13 @@
+--no-tree
+--no-signoff
+--summary-file
+--show-types
+--max-line-length=80
+
+--ignore COMPLEX_MACRO
+--ignore SPLIT_STRING
+--ignore CONST_STRUCT
+--ignore FILE_PATH_CHANGES
+--ignore MISSING_SIGN_OFF
+--ignore PREFER_PACKED
+--ignore COMMIT_MESSAGE

--- a/.github/workflows/checkbuild.yml
+++ b/.github/workflows/checkbuild.yml
@@ -1,0 +1,15 @@
+name: Check Build
+
+on: [pull_request]
+
+jobs:
+  checkbuild:
+    runs-on: ubuntu-latest
+    name: Check Build for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkbuild
+      uses: tedd-an/action-checkbuild@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/checkbuild.yml
+++ b/.github/workflows/checkbuild.yml
@@ -13,3 +13,4 @@ jobs:
       uses: tedd-an/action-checkbuild@master
       with:
         github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,0 +1,15 @@
+name: Check Patch
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Patch for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkpatch
+      uses: tedd-an/action-checkpatch@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -13,3 +13,4 @@ jobs:
       uses: tedd-an/action-checkpatch@master
       with:
         github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -2,7 +2,7 @@ name: Scheduled Work
 
 on:
   schedule:
-  - cron:  "*/30 * * * *"
+  - cron:  "*/8 * * * *"
 
 jobs:
 

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,38 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "*/30 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/mesh/mesh-config-json.c
+++ b/mesh/mesh-config-json.c
@@ -2057,6 +2057,38 @@ bool mesh_config_write_ttl(struct mesh_config *cfg, uint8_t ttl)
 	return save_config(cfg->jnode, cfg->node_dir_path);
 }
 
+bool mesh_config_update_company_id(struct mesh_config *cfg, uint16_t cid)
+{
+	if (!cfg || !write_uint16_hex(cfg->jnode, "cid", cid))
+		return false;
+
+	return save_config(cfg->jnode, cfg->node_dir_path);
+}
+
+bool mesh_config_update_product_id(struct mesh_config *cfg, uint16_t pid)
+{
+	if (!cfg || !write_uint16_hex(cfg->jnode, "pid", pid))
+		return false;
+
+	return save_config(cfg->jnode, cfg->node_dir_path);
+}
+
+bool mesh_config_update_version_id(struct mesh_config *cfg, uint16_t vid)
+{
+	if (!cfg || !write_uint16_hex(cfg->jnode, "vid", vid))
+		return false;
+
+	return save_config(cfg->jnode, cfg->node_dir_path);
+}
+
+bool mesh_config_update_crpl(struct mesh_config *cfg, uint16_t crpl)
+{
+	if (!cfg || !write_uint16_hex(cfg->jnode, "crpl", crpl))
+		return false;
+
+	return save_config(cfg->jnode, cfg->node_dir_path);
+}
+
 static bool load_node(const char *fname, const uint8_t uuid[16],
 				mesh_config_node_func_t cb, void *user_data)
 {

--- a/mesh/mesh-config-json.c
+++ b/mesh/mesh-config-json.c
@@ -105,7 +105,7 @@ static bool get_int(json_object *jobj, const char *keyword, int *value)
 	return true;
 }
 
-static bool add_u64_value(json_object *jobject, const char *desc,
+static bool add_u64_value(json_object *jobj, const char *desc,
 					const uint8_t u64[8])
 {
 	json_object *jstring;
@@ -116,11 +116,12 @@ static bool add_u64_value(json_object *jobject, const char *desc,
 	if (!jstring)
 		return false;
 
-	json_object_object_add(jobject, desc, jstring);
+	json_object_object_del(jobj, desc);
+	json_object_object_add(jobj, desc, jstring);
 	return true;
 }
 
-static bool add_key_value(json_object *jobject, const char *desc,
+static bool add_key_value(json_object *jobj, const char *desc,
 					const uint8_t key[16])
 {
 	json_object *jstring;
@@ -131,7 +132,8 @@ static bool add_key_value(json_object *jobject, const char *desc,
 	if (!jstring)
 		return false;
 
-	json_object_object_add(jobject, desc, jstring);
+	json_object_object_del(jobj, desc);
+	json_object_object_add(jobj, desc, jstring);
 	return true;
 }
 
@@ -1398,6 +1400,7 @@ static bool write_uint16_hex(json_object *jobj, const char *desc,
 	if (!jstring)
 		return false;
 
+	json_object_object_del(jobj, desc);
 	json_object_object_add(jobj, desc, jstring);
 	return true;
 }
@@ -1412,21 +1415,21 @@ static bool write_uint32_hex(json_object *jobj, const char *desc, uint32_t val)
 	if (!jstring)
 		return false;
 
+	json_object_object_del(jobj, desc);
 	json_object_object_add(jobj, desc, jstring);
 	return true;
 }
 
-static bool write_int(json_object *jobj, const char *keyword, int val)
+static bool write_int(json_object *jobj, const char *desc, int val)
 {
 	json_object *jvalue;
-
-	json_object_object_del(jobj, keyword);
 
 	jvalue = json_object_new_int(val);
 	if (!jvalue)
 		return false;
 
-	json_object_object_add(jobj, keyword, jvalue);
+	json_object_object_del(jobj, desc);
+	json_object_object_add(jobj, desc, jvalue);
 	return true;
 }
 
@@ -1442,7 +1445,7 @@ static const char *mode_to_string(int mode)
 	}
 }
 
-static bool write_mode(json_object *jobj, const char *keyword, int value)
+static bool write_mode(json_object *jobj, const char *desc, int value)
 {
 	json_object *jstring;
 
@@ -1451,7 +1454,8 @@ static bool write_mode(json_object *jobj, const char *keyword, int value)
 	if (!jstring)
 		return false;
 
-	json_object_object_add(jobj, keyword, jstring);
+	json_object_object_del(jobj, desc);
+	json_object_object_add(jobj, desc, jstring);
 
 	return true;
 }

--- a/mesh/mesh-config.h
+++ b/mesh/mesh-config.h
@@ -172,3 +172,7 @@ bool mesh_config_net_key_set_phase(struct mesh_config *cfg, uint16_t idx,
 bool mesh_config_write_address(struct mesh_config *cfg, uint16_t address);
 bool mesh_config_write_iv_index(struct mesh_config *cfg, uint32_t idx,
 								bool update);
+bool mesh_config_update_company_id(struct mesh_config *cfg, uint16_t cid);
+bool mesh_config_update_product_id(struct mesh_config *cfg, uint16_t pid);
+bool mesh_config_update_version_id(struct mesh_config *cfg, uint16_t vid);
+bool mesh_config_update_crpl(struct mesh_config *cfg, uint16_t crpl);

--- a/mesh/node.c
+++ b/mesh/node.c
@@ -1378,7 +1378,7 @@ static bool check_req_node(struct managed_obj_request *req)
 {
 	uint8_t node_comp[MAX_MSG_LEN - 2];
 	uint8_t attach_comp[MAX_MSG_LEN - 2];
-
+	uint16_t offset = 10;
 	uint16_t node_len = node_generate_comp(req->node, node_comp,
 							sizeof(node_comp));
 
@@ -1389,12 +1389,10 @@ static bool check_req_node(struct managed_obj_request *req)
 		uint16_t attach_len = node_generate_comp(req->attach,
 					attach_comp, sizeof(attach_comp));
 
-		/* Ignore feature bits in Composition Compare */
-		node_comp[8] = 0;
-		attach_comp[8] = 0;
-
+		/* Verify only element/models composition */
 		if (node_len != attach_len ||
-				memcmp(node_comp, attach_comp, node_len)) {
+				memcmp(&node_comp[offset], &attach_comp[offset],
+							node_len - offset)) {
 			l_debug("Failed to verify app's composition data");
 			return false;
 		}

--- a/mesh/node.c
+++ b/mesh/node.c
@@ -1374,6 +1374,21 @@ static bool add_local_node(struct mesh_node *node, uint16_t unicast, bool kr,
 	return true;
 }
 
+static void update_composition(struct mesh_node *node, struct mesh_node *attach)
+{
+	if (node->comp.cid != attach->comp.cid)
+		mesh_config_update_company_id(node->cfg, attach->comp.cid);
+
+	if (node->comp.pid != attach->comp.pid)
+		mesh_config_update_product_id(node->cfg, attach->comp.pid);
+
+	if (node->comp.vid != attach->comp.vid)
+		mesh_config_update_version_id(node->cfg, attach->comp.vid);
+
+	if (node->comp.crpl != attach->comp.crpl)
+		mesh_config_update_crpl(node->cfg, attach->comp.crpl);
+}
+
 static bool check_req_node(struct managed_obj_request *req)
 {
 	uint8_t node_comp[MAX_MSG_LEN - 2];
@@ -1443,6 +1458,8 @@ static bool attach_req_node(struct mesh_node *attach, struct mesh_node *node)
 
 	attach->owner = node->owner;
 	node->owner = NULL;
+
+	update_composition(node, attach);
 
 	node_remove(node);
 

--- a/mesh/node.c
+++ b/mesh/node.c
@@ -1366,8 +1366,6 @@ static bool add_local_node(struct mesh_node *node, uint16_t unicast, bool kr,
 
 	update_net_settings(node);
 
-	mesh_config_save(node->cfg, true, NULL, NULL);
-
 	/* Initialize configuration server model */
 	cfgmod_server_init(node, PRIMARY_ELE_IDX);
 


### PR DESCRIPTION

This patchset modifies how we verify the integrity of an existing
node when processing Attach() call.

The changes:
- Vericifaction includes only element/models relationship: this should
stay constant during node's lifetime.
- Allow updating of CID, PID, VID and CRPL.
- Some general cleanup related to saving node configuration.

Inga Stotland (4):
mesh: On node attach, verify element/model composition only
mesh: Avoid saving duplicate fields in node config
mesh: Allow updating CID, PID, VID & CRPL on node attach
mesh: Remove redundant call to save node configuration

