### PR TITLE
[PW_SID:288215] [BlueZ] mesh: Fix segfault caused by re-enabling of HCI controller


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,13 @@
+--no-tree
+--no-signoff
+--summary-file
+--show-types
+--max-line-length=80
+
+--ignore COMPLEX_MACRO
+--ignore SPLIT_STRING
+--ignore CONST_STRUCT
+--ignore FILE_PATH_CHANGES
+--ignore MISSING_SIGN_OFF
+--ignore PREFER_PACKED
+--ignore COMMIT_MESSAGE

--- a/.github/workflows/checkbuild.yml.disable
+++ b/.github/workflows/checkbuild.yml.disable
@@ -1,0 +1,16 @@
+name: Check Build
+
+on: [pull_request]
+
+jobs:
+  checkbuild:
+    runs-on: ubuntu-latest
+    name: Check Build for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkbuild
+      uses: tedd-an/action-checkbuild@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/checkpatch.yml.disable
+++ b/.github/workflows/checkpatch.yml.disable
@@ -1,0 +1,16 @@
+name: Check Patch
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Patch for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkpatch
+      uses: tedd-an/action-checkpatch@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,38 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/mesh/mesh-io-api.h
+++ b/mesh/mesh-io-api.h
@@ -22,6 +22,7 @@ struct mesh_io_private;
 typedef bool (*mesh_io_init_t)(struct mesh_io *io, void *opts,
 				mesh_io_ready_func_t cb, void *user_data);
 typedef bool (*mesh_io_destroy_t)(struct mesh_io *io);
+typedef bool (*mesh_io_restart_t)(struct mesh_io *io);
 typedef bool (*mesh_io_caps_t)(struct mesh_io *io, struct mesh_io_caps *caps);
 typedef bool (*mesh_io_send_t)(struct mesh_io *io,
 					struct mesh_io_send_info *info,
@@ -37,6 +38,7 @@ typedef bool (*mesh_io_tx_cancel_t)(struct mesh_io *io, const uint8_t *pattern,
 struct mesh_io_api {
 	mesh_io_init_t		init;
 	mesh_io_destroy_t	destroy;
+	mesh_io_restart_t	restart;
 	mesh_io_caps_t		caps;
 	mesh_io_send_t		send;
 	mesh_io_register_t	reg;

--- a/mesh/mesh-io.c
+++ b/mesh/mesh-io.c
@@ -96,6 +96,14 @@ fail:
 	return NULL;
 }
 
+void mesh_io_restart(struct mesh_io *io)
+{
+	io = l_queue_find(io_list, match_by_io, io);
+
+	if (io && io->api)
+		io->api->restart(io);
+}
+
 void mesh_io_destroy(struct mesh_io *io)
 {
 	io = l_queue_remove_if(io_list, match_by_io, io);

--- a/mesh/mesh-io.h
+++ b/mesh/mesh-io.h
@@ -83,6 +83,7 @@ typedef void (*mesh_io_ready_func_t)(void *user_data, bool result);
 
 struct mesh_io *mesh_io_new(enum mesh_io_type type, void *opts,
 				mesh_io_ready_func_t cb, void *user_data);
+void mesh_io_restart(struct mesh_io *io);
 void mesh_io_destroy(struct mesh_io *io);
 
 bool mesh_io_get_caps(struct mesh_io *io, struct mesh_io_caps *caps);

--- a/mesh/mesh.c
+++ b/mesh/mesh.c
@@ -66,6 +66,7 @@ struct bt_mesh {
 	uint16_t req_index;
 	uint8_t friend_queue_sz;
 	uint8_t max_filters;
+	bool initialized;
 };
 
 struct join_data{
@@ -91,7 +92,8 @@ static struct bt_mesh mesh = {
 	.lpn_support = false,
 	.proxy_support = false,
 	.crpl = DEFAULT_CRPL,
-	.friend_queue_sz = DEFAULT_FRIEND_QUEUE_SZ
+	.friend_queue_sz = DEFAULT_FRIEND_QUEUE_SZ,
+	.initialized = false
 };
 
 /* We allow only one outstanding Join request */
@@ -168,8 +170,16 @@ static void io_ready_callback(void *user_data, bool result)
 {
 	struct mesh_init_request *req = user_data;
 
+	if (mesh.initialized) {
+		if (result)
+			mesh_io_restart(mesh.io);
+		return;
+	}
+
 	if (result)
 		node_attach_io_all(mesh.io);
+
+	mesh.initialized = true;
 
 	req->cb(req->user_data, result);
 


### PR DESCRIPTION

This fixes a crash incase when a controller used by bluetooth-meshd
is removed and then added back again.

Add a "restart" operation to mesh-io API to deal with a distinct case
of re-adding a previously used controller.

Backtrace:
0x00005618e754d040 in ?? ()
0x00005618e6e12d9a in io_ready_callback (user_data=0x5618e75538a0, result=<optimized out>) at mesh/mesh.c:174
0x00005618e6e3d2c8 in l_queue_foreach (queue=<optimized out>, function=0x5618e6e158e0 <process_read_info_req>, user_data=0x0)
at ell/queue.c:441
0x00005618e6e37927 in request_complete (mgmt=mgmt@entry=0x5618e754ad50, status=<optimized out>, opcode=opcode@entry=4,
index=index@entry=0, length=length@entry=280, param=0x5618e754b389) at src/shared/mgmt.c:261
