### PR TITLE
[PW_SID:295451] Mesh clean up


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,13 @@
+--no-tree
+--no-signoff
+--summary-file
+--show-types
+--max-line-length=80
+
+--ignore COMPLEX_MACRO
+--ignore SPLIT_STRING
+--ignore CONST_STRUCT
+--ignore FILE_PATH_CHANGES
+--ignore MISSING_SIGN_OFF
+--ignore PREFER_PACKED
+--ignore COMMIT_MESSAGE

--- a/.github/workflows/checkbuild.yml.disable
+++ b/.github/workflows/checkbuild.yml.disable
@@ -1,0 +1,16 @@
+name: Check Build
+
+on: [pull_request]
+
+jobs:
+  checkbuild:
+    runs-on: ubuntu-latest
+    name: Check Build for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkbuild
+      uses: tedd-an/action-checkbuild@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/checkpatch.yml.disable
+++ b/.github/workflows/checkpatch.yml.disable
@@ -1,0 +1,16 @@
+name: Check Patch
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Patch for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkpatch
+      uses: tedd-an/action-checkpatch@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,38 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/mesh/main.c
+++ b/mesh/main.c
@@ -37,6 +37,7 @@
 #include "mesh/crypto.h"
 #include "mesh/dbus.h"
 #include "mesh/mesh-io.h"
+#include "mesh/util.h"
 
 static const char *config_dir;
 static const char *mesh_conf_fname;
@@ -210,7 +211,7 @@ int main(int argc, char *argv[])
 			detached = false;
 			break;
 		case 'd':
-			l_debug_enable("*");
+			enable_debug();
 			break;
 		case 'c':
 			config_dir = optarg;

--- a/mesh/manager.c
+++ b/mesh/manager.c
@@ -219,7 +219,7 @@ static void add_start(void *user_data, int err)
 {
 	struct l_dbus_message *reply;
 
-	l_info("Start callback");
+	l_debug("Start callback");
 
 	if (err == MESH_ERROR_NONE)
 		reply = l_dbus_message_new_method_return(add_pending->msg);
@@ -270,8 +270,8 @@ static struct l_dbus_message *add_node_call(struct l_dbus *dbus,
 	add_pending->agent = node_get_agent(node);
 
 	if (!node_is_provisioner(node) || (add_pending->agent == NULL)) {
-		l_info("Provisioner: %d", node_is_provisioner(node));
-		l_info("Agent: %p", add_pending->agent);
+		l_debug("Provisioner: %d", node_is_provisioner(node));
+		l_debug("Agent: %p", add_pending->agent);
 		reply = dbus_error(msg, MESH_ERROR_NOT_AUTHORIZED,
 							"Missing Interfaces");
 		goto fail;

--- a/mesh/mesh-io-generic.c
+++ b/mesh/mesh-io-generic.c
@@ -173,7 +173,7 @@ static void event_callback(const void *buf, uint8_t size, void *user_data)
 		break;
 
 	default:
-		l_info("Other Meta Evt - %d", event);
+		l_debug("Other Meta Evt - %d", event);
 	}
 }
 
@@ -804,7 +804,6 @@ static bool recv_register(struct mesh_io *io, const uint8_t *filter,
 	if (!cb || !filter || !len)
 		return false;
 
-	l_info("%s %2.2x", __func__, filter[0]);
 	rx_reg = l_queue_remove_if(pvt->rx_regs, find_by_filter, filter);
 
 	l_free(rx_reg);

--- a/mesh/model.c
+++ b/mesh/model.c
@@ -508,29 +508,6 @@ static int virt_packet_decrypt(struct mesh_net *net, const uint8_t *data,
 	return -1;
 }
 
-static void cmplt(uint16_t remote, uint8_t status,
-					void *data, uint16_t size,
-					void *user_data)
-{
-	struct timeval tx_end;
-
-	gettimeofday(&tx_end, NULL);
-
-	if (tx_end.tv_sec == tx_start.tv_sec) {
-		l_debug("Duration 0.%6.6lu seconds",
-				tx_end.tv_usec - tx_start.tv_usec);
-	} else {
-		if (tx_start.tv_usec > tx_end.tv_usec)
-			l_debug("Duration %lu.%6.6lu seconds",
-				tx_end.tv_sec - tx_start.tv_sec - 1,
-				tx_end.tv_usec + 1000000 - tx_start.tv_usec);
-		else
-			l_debug("Duration %lu.%6.6lu seconds",
-					tx_end.tv_sec - tx_start.tv_sec,
-					tx_end.tv_usec - tx_start.tv_usec);
-	}
-}
-
 static bool msg_send(struct mesh_node *node, bool credential, uint16_t src,
 		uint32_t dst, uint16_t app_idx, uint16_t net_idx,
 		uint8_t *label, uint8_t ttl, bool segmented,
@@ -585,9 +562,9 @@ static bool msg_send(struct mesh_node *node, bool credential, uint16_t src,
 		goto done;
 	}
 
-	ret = mesh_net_app_send(net, credential, src, dst, key_aid, net_idx,
+	ret =  mesh_net_app_send(net, credential, src, dst, key_aid, net_idx,
 					ttl, seq_num, iv_index, segmented,
-					szmic, out, out_len, cmplt, NULL);
+					szmic, out, out_len);
 done:
 	l_free(out);
 	return ret;

--- a/mesh/model.c
+++ b/mesh/model.c
@@ -514,15 +514,8 @@ static void cmplt(uint16_t remote, uint8_t status,
 {
 	struct timeval tx_end;
 
-	if (status)
-		l_debug("Tx-->%4.4x (%d octets) Failed (%d)",
-				remote, size, status);
-	else
-		l_debug("Tx-->%4.4x (%d octets) Succeeded", remote, size);
-
-	/* print_packet("Sent Data", data, size); */
-
 	gettimeofday(&tx_end, NULL);
+
 	if (tx_end.tv_sec == tx_start.tv_sec) {
 		l_debug("Duration 0.%6.6lu seconds",
 				tx_end.tv_usec - tx_start.tv_usec);
@@ -580,21 +573,17 @@ static bool msg_send(struct mesh_node *node, bool credential, uint16_t src,
 		net_idx = appkey_net_idx(node_get_net(node), app_idx);
 	}
 
-	l_debug("(%x) %p", app_idx, key);
-	l_debug("net_idx %x", net_idx);
-
 	out = l_malloc(out_len);
 
 	iv_index = mesh_net_get_iv_index(net);
 
 	seq_num = mesh_net_next_seq_num(net);
+
 	if (!mesh_crypto_payload_encrypt(label, msg, out, msg_len, src, dst,
 				key_aid, seq_num, iv_index, szmic, key)) {
 		l_error("Failed to Encrypt Payload");
 		goto done;
 	}
-
-	/* print_packet("Encrypted with", key, 16); */
 
 	ret = mesh_net_app_send(net, credential, src, dst, key_aid, net_idx,
 					ttl, seq_num, iv_index, segmented,
@@ -646,8 +635,6 @@ static void model_bind_idx(struct mesh_node *node, struct mesh_model *mod,
 		mod->bindings = l_queue_new();
 
 	l_queue_push_tail(mod->bindings, L_UINT_TO_PTR(idx));
-
-	l_debug("Add %4.4x to model %8.8x", idx, mod->id);
 
 	if (!mod->cbs)
 		/* External model */
@@ -781,7 +768,6 @@ static int add_virt_sub(struct mesh_net *net, struct mesh_model *mod,
 
 		l_queue_push_head(mod->virtuals, virt);
 		mesh_net_dst_reg(net, virt->addr);
-		l_debug("Added virtual sub addr %4.4x", virt->addr);
 	}
 
 	if (dst)
@@ -809,7 +795,6 @@ static int add_sub(struct mesh_net *net, struct mesh_model *mod,
 
 		l_queue_push_tail(mod->subs, L_UINT_TO_PTR(grp));
 		mesh_net_dst_reg(net, grp);
-		l_debug("Added group subscription %4.4x", grp);
 	}
 
 	return MESH_STATUS_SUCCESS;
@@ -929,6 +914,7 @@ bool mesh_model_rx(struct mesh_node *node, bool szmict, uint32_t seq0,
 
 	/* Don't process if already in RPL */
 	crpl = node_get_crpl(node);
+
 	if (net_msg_check_replay_cache(net, src, crpl, seq, iv_index))
 		return false;
 
@@ -1064,8 +1050,6 @@ int mesh_model_publish(struct mesh_node *node, uint32_t mod_id,
 	bool result;
 	int status;
 
-	/* print_packet("Mod Tx", msg, msg_len); */
-
 	if (!net || msg_len > 380)
 		return MESH_ERROR_INVALID_ARGS;
 
@@ -1092,8 +1076,6 @@ int mesh_model_publish(struct mesh_node *node, uint32_t mod_id,
 	if (mod->pub->virt)
 		label = mod->pub->virt->label;
 
-	l_debug("publish dst=%x", mod->pub->addr);
-
 	net_idx = appkey_net_idx(net, mod->pub->idx);
 
 	result = msg_send(node, mod->pub->credential != 0, src,
@@ -1108,8 +1090,6 @@ bool mesh_model_send(struct mesh_node *node, uint16_t src, uint16_t dst,
 					uint8_t ttl, bool segmented,
 					const void *msg, uint16_t msg_len)
 {
-	/* print_packet("Mod Tx", msg, msg_len); */
-
 	/* If SRC is 0, use the Primary Element */
 	if (src == 0)
 		src = node_get_primary(node);
@@ -1279,14 +1259,12 @@ void mesh_model_app_key_delete(struct mesh_node *node, struct l_queue *models,
 int mesh_model_binding_del(struct mesh_node *node, uint16_t addr, uint32_t id,
 						uint16_t app_idx)
 {
-	l_debug("0x%x, 0x%x, %d", addr, id, app_idx);
 	return update_binding(node, addr, id, app_idx, true);
 }
 
 int mesh_model_binding_add(struct mesh_node *node, uint16_t addr, uint32_t id,
 						uint16_t app_idx)
 {
-	l_debug("0x%x, 0x%x, %d", addr, id, app_idx);
 	return update_binding(node, addr, id, app_idx, false);
 }
 

--- a/mesh/net.c
+++ b/mesh/net.c
@@ -520,7 +520,8 @@ uint32_t mesh_net_next_seq_num(struct mesh_net *net)
 {
 	uint32_t seq = net->seq_num++;
 
-	/* Cap out-of-range seq_num max value to +1. Out of range
+	/*
+	 * Cap out-of-range seq_num max value to +1. Out of range
 	 * seq_nums will not be sent as they would violate spec.
 	 * This condition signals a runaway seq_num condition, and
 	 * the node must wait for a completed IV Index update procedure
@@ -539,9 +540,7 @@ static struct mesh_sar *mesh_sar_new(size_t len)
 	struct mesh_sar *sar;
 
 	sar = l_malloc(size);
-
 	memset(sar, 0, size);
-
 	return sar;
 }
 
@@ -1372,19 +1371,17 @@ enqueue:
 			void *old = l_queue_remove_if(frnd->pkt_cache,
 							match_ack, rx);
 
-			if (old) {
-				if (old_head == old) {
-					/*
-					 * If we are discarding head for any
-					 * reason, reset FRND SEQ
-					 */
-					frnd->u.active.last =
-							frnd->u.active.seq;
-				}
-
-				l_free(old);
-			} else
+			if (!old)
 				break;
+
+			if (old_head == old)
+				/*
+				 * If we are discarding head for any
+				 * reason, reset FRND SEQ
+				 */
+				frnd->u.active.last = frnd->u.active.seq;
+
+			l_free(old);
 
 		} while (true);
 	}
@@ -1465,6 +1462,7 @@ static bool friend_packet_queue(struct mesh_net *net,
 			data += 12;
 			hdr += (1 << SEGO_HDR_SHIFT);
 		}
+
 		frnd_msg->u.s12[seg_max].seq = seq;
 		frnd_msg->cnt_in = seg_max;
 		frnd_msg->last_len = size % 12;
@@ -1488,6 +1486,7 @@ static bool friend_packet_queue(struct mesh_net *net,
 			memcpy(frnd_msg->u.one[0].data, data, size);
 			frnd_msg->last_len = size;
 		}
+
 		frnd_msg->u.one[0].hdr = hdr;
 		frnd_msg->u.one[0].seq = seq;
 	}
@@ -1640,7 +1639,6 @@ static void inmsg_to(struct l_timeout *msg_timeout, void *user_data)
 		return;
 
 	sar->msg_timeout = NULL;
-
 	mesh_sar_free(sar);
 }
 
@@ -2034,10 +2032,8 @@ static bool seg_rxed(struct mesh_net *net, bool frnd, uint32_t iv_index,
 		send_net_ack(net, sar_in, expected);
 
 		msg_rxed(net, frnd, iv_index, ttl, seq, net_idx,
-				sar_in->remote, dst,
-				key_aid, true, szmic,
-				sar_in->seqZero,
-				sar_in->buf, sar_in->len);
+				sar_in->remote, dst, key_aid, true, szmic,
+				sar_in->seqZero, sar_in->buf, sar_in->len);
 
 		/* Kill Inter-Seg timeout */
 		l_timeout_remove(sar_in->seg_timeout);
@@ -2080,12 +2076,8 @@ static bool ctl_received(struct mesh_net *net, uint16_t key_id,
 		uint32_t hdr = opcode << OPCODE_HDR_SHIFT;
 		uint8_t frnd_ttl = ttl - 1;
 
-		if (friend_packet_queue(net, iv_index,
-					true, frnd_ttl,
-					seq,
-					src, dst,
-					hdr,
-					pkt, len))
+		if (friend_packet_queue(net, iv_index, true, frnd_ttl, seq,
+						src, dst, hdr, pkt, len))
 			return true;
 	}
 
@@ -2103,10 +2095,8 @@ static bool ctl_received(struct mesh_net *net, uint16_t key_id,
 			return false;
 
 		print_packet("Rx-NET_OP_FRND_POLL", pkt, len);
-		friend_poll(net, src, !!(pkt[0]),
-				l_queue_find(net->friends,
-						match_by_friend,
-						L_UINT_TO_PTR(src)));
+		friend_poll(net, src, !!(pkt[0]), l_queue_find(net->friends,
+					match_by_friend, L_UINT_TO_PTR(src)));
 		break;
 
 	case NET_OP_FRND_REQUEST:
@@ -2142,8 +2132,7 @@ static bool ctl_received(struct mesh_net *net, uint16_t key_id,
 
 		print_packet("Rx-NET_OP_FRND_CLEAR", pkt, len);
 		friend_clear(net, src, l_get_be16(pkt), l_get_be16(pkt + 2),
-				l_queue_find(net->friends,
-					match_by_friend,
+				l_queue_find(net->friends, match_by_friend,
 					L_UINT_TO_PTR(l_get_be16(pkt))));
 		l_debug("Remaining Friends: %d", l_queue_length(net->friends));
 		break;
@@ -2163,9 +2152,8 @@ static bool ctl_received(struct mesh_net *net, uint16_t key_id,
 			return false;
 
 		print_packet("Rx-NET_OP_PROXY_SUB_REMOVE", pkt, len);
-		friend_sub_del(net, l_queue_find(net->friends,
-					match_by_friend, L_UINT_TO_PTR(src)),
-				pkt, len);
+		friend_sub_del(net, l_queue_find(net->friends, match_by_friend,
+						L_UINT_TO_PTR(src)), pkt, len);
 		break;
 
 	case NET_OP_PROXY_SUB_CONFIRM:
@@ -2199,12 +2187,10 @@ static bool ctl_received(struct mesh_net *net, uint16_t key_id,
 		break;
 	}
 
-	if (n) {
-		mesh_net_transport_send(net, 0, 0,
-				mesh_net_get_iv_index(net), rsp_ttl,
-				0, dst & 0x8000 ? 0 : dst, src,
-				msg, n);
-	}
+	if (n)
+		mesh_net_transport_send(net, 0, 0, mesh_net_get_iv_index(net),
+					rsp_ttl, 0, dst & 0x8000 ? 0 : dst,
+					src, msg, n);
 
 	return true;
 }
@@ -2335,17 +2321,12 @@ static enum _relay_advice packet_received(void *user_data,
 
 	print_packet("RX: Network [clr] :", packet + 2, size);
 
-	if (!mesh_crypto_packet_parse(packet + 2, size,
-					&net_ctl, &net_ttl,
-					&net_seq,
-					&net_src, &net_dst,
-					&cache_cookie,
-					&net_opcode,
-					&net_segmented,
-					&net_key_id,
-					&net_szmic, &net_relay, &net_seqZero,
-					&net_segO, &net_segN,
-					&msg, &app_msg_len)) {
+	if (!mesh_crypto_packet_parse(packet + 2, size, &net_ctl, &net_ttl,
+					&net_seq, &net_src, &net_dst,
+					&cache_cookie, &net_opcode,
+					&net_segmented, &net_key_id, &net_szmic,
+					&net_relay, &net_seqZero, &net_segO,
+					&net_segN, &msg, &app_msg_len)) {
 		l_error("Failed to parse packet content");
 		return RELAY_NONE;
 	}
@@ -2360,8 +2341,10 @@ static enum _relay_advice packet_received(void *user_data,
 	if (is_us(net, net_src, true))
 		return RELAY_NONE;
 
-	/* As a Relay, suppress repeats of last N packets that pass through */
-	/* The "cache_cookie" should be unique part of App message */
+	/*
+	 * As a Relay, suppress repeats of last N packets that pass through
+	 * The "cache_cookie" should be unique part of App message.
+	 */
 	if (msg_in_cache(net, net_src, net_seq, cache_cookie))
 		return RELAY_NONE;
 
@@ -2388,57 +2371,48 @@ static enum _relay_advice packet_received(void *user_data,
 				/* If this is an ACK to our friend queue-only */
 				if (is_lpn_friend(net, net_dst))
 					friend_ack_rxed(net, iv_index, net_seq,
-							net_src, net_dst,
-							msg);
+							net_src, net_dst, msg);
 				else
 					ack_received(net, false,
 							net_src, net_dst,
 							net_seqZero,
 							l_get_be32(msg + 3));
 			} else {
-				ctl_received(net, key_id,
-						iv_index,
-						net_ttl, net_seq, net_src,
-						net_dst, net_opcode, rssi,
-						msg, app_msg_len);
+				ctl_received(net, key_id, iv_index, net_ttl,
+						net_seq, net_src, net_dst,
+						net_opcode, rssi, msg,
+								app_msg_len);
 			}
 		} else if (net_segmented) {
-			/* If we accept SAR packets to non-Unicast, then
+			/*
+			 * If we accept SAR packets to non-Unicast, then
 			 * Friend Sar at least needs to be Unicast Only
 			 */
 			if (is_lpn_friend(net, net_dst) &&
 							!(net_dst & 0x8000)) {
-				/* Check TTL >= 2 before accepting segments
+				/*
+				 * Check TTL >= 2 before accepting segments
 				 * for Friends
 				 */
 				if (net_ttl >= 2) {
-					friend_seg_rxed(net, iv_index,
-						net_ttl, net_seq,
-						net_src, net_dst,
+					friend_seg_rxed(net, iv_index, net_ttl,
+						net_seq, net_src, net_dst,
 						l_get_be32(packet + 2 + 9),
 						msg, app_msg_len);
 				}
 			} else {
 				seg_rxed(net, NULL, iv_index, net_ttl,
-						net_seq, net_idx,
-						net_src, net_dst,
-						net_key_id,
-						net_szmic, net_seqZero,
-						net_segO, net_segN,
+						net_seq, net_idx, net_src,
+						net_dst, net_key_id, net_szmic,
+						net_seqZero, net_segO, net_segN,
 						msg, app_msg_len);
 			}
 
 		} else {
-			msg_rxed(net, NULL,
-						iv_index,
-						net_ttl,
-						net_seq,
-						net_idx,
-						net_src, net_dst,
-						net_key_id,
-						false, false,
-						net_seq & SEQ_ZERO_MASK,
-						msg, app_msg_len);
+			msg_rxed(net, NULL, iv_index, net_ttl, net_seq, net_idx,
+					net_src, net_dst, net_key_id, false,
+					false, net_seq & SEQ_ZERO_MASK, msg,
+					app_msg_len);
 		}
 
 		/* If this is one of our Unicast addresses, disallow relay */
@@ -2495,8 +2469,8 @@ static void net_rx(void *net_ptr, void *user_data)
 		rssi = data->info->rssi;
 	}
 
-	relay_advice = packet_received(net, key_id, iv_index,
-							out, out_size, rssi);
+	relay_advice = packet_received(net, key_id, iv_index, out, out_size,
+									rssi);
 	if (relay_advice > data->relay_advice) {
 		data->iv_index = iv_index;
 		data->relay_advice = relay_advice;
@@ -2560,6 +2534,7 @@ static void iv_upd_to(struct l_timeout *upd_timeout, void *user_data)
 		l_debug("iv_upd_state = IV_UPD_NORMAL_HOLD");
 		net->iv_upd_state = IV_UPD_NORMAL_HOLD;
 		l_timeout_modify(net->iv_update_timeout, IV_IDX_UPD_MIN);
+
 		if (net->iv_update)
 			mesh_net_set_seq_num(net, 0);
 
@@ -2578,10 +2553,12 @@ static void iv_upd_to(struct l_timeout *upd_timeout, void *user_data)
 		net->iv_update_timeout = NULL;
 		l_debug("iv_upd_state = IV_UPD_NORMAL");
 		net->iv_upd_state = IV_UPD_NORMAL;
+
 		if (net->iv_update)
 			mesh_net_set_seq_num(net, 0);
 
 		net->iv_update = false;
+
 		if (net->seq_num > IV_UPDATE_SEQ_TRIGGER)
 			mesh_net_iv_index_update(net);
 		break;
@@ -2605,7 +2582,8 @@ static int key_refresh_phase_two(struct mesh_net *net, uint16_t idx)
 	l_debug("Key refresh procedure phase 2: start using new net TX keys");
 	subnet->key_refresh = 1;
 	subnet->net_key_tx = subnet->net_key_upd;
-	/* TODO: Provisioner may need to stay in phase three until
+	/*
+	 * TODO: Provisioner may need to stay in phase three until
 	 * it hears beacons from all the nodes
 	 */
 	subnet->kr_phase = KEY_REFRESH_PHASE_TWO;
@@ -2686,7 +2664,8 @@ static void update_iv_ivu_state(struct mesh_net *net, uint32_t iv_index,
 			if (iv_index == net->iv_index && !net->iv_update)
 				return;
 
-			/* Other devices will be accepting old or new iv_index,
+			/*
+			 * Other devices will be accepting old or new iv_index,
 			 * but we don't know how far through update they are.
 			 * Starting permissive state will allow us maximum
 			 * (96 hours) to resync
@@ -2694,7 +2673,7 @@ static void update_iv_ivu_state(struct mesh_net *net, uint32_t iv_index,
 			l_debug("iv_upd_state = IV_UPD_UPDATING");
 			net->iv_upd_state = IV_UPD_UPDATING;
 			net->iv_update_timeout = l_timeout_create(
-				IV_IDX_UPD_MIN, iv_upd_to, net, NULL);
+					IV_IDX_UPD_MIN, iv_upd_to, net, NULL);
 		} else {
 			l_debug("iv_upd_state = IV_UPD_NORMAL");
 			net->iv_upd_state = IV_UPD_NORMAL;
@@ -2771,8 +2750,8 @@ static void process_beacon(void *net_ptr, void *user_data)
 	 * Ignore the beacon if it doesn't change anything, unless we're
 	 * doing IV Recovery
 	 */
-	if (net->iv_upd_state == IV_UPD_INIT ||
-				ivi != net->iv_index || ivu != net->iv_update)
+	if (net->iv_upd_state == IV_UPD_INIT || ivi != net->iv_index ||
+							ivu != net->iv_update)
 		update_iv_ivu_state(net, ivi, ivu);
 
 	if (kr != local_kr)
@@ -2879,6 +2858,7 @@ bool mesh_net_set_key(struct mesh_net *net, uint16_t idx, const uint8_t *key,
 	if (phase == KEY_REFRESH_PHASE_TWO) {
 		subnet->key_refresh = 1;
 		subnet->net_key_tx = subnet->net_key_upd;
+
 		if (net->beacon_enable) {
 			/* Switch beaconing key */
 			net_key_beacon_disable(subnet->net_key_cur);
@@ -2958,6 +2938,7 @@ bool mesh_net_iv_index_update(struct mesh_net *net)
 
 	l_debug("iv_upd_state = IV_UPD_UPDATING");
 	mesh_net_flush_msg_queues(net);
+
 	if (!mesh_config_write_iv_index(node_config_get(net->node),
 						net->iv_index + 1, true))
 		return false;
@@ -3077,7 +3058,7 @@ static bool send_seg(struct mesh_net *net, struct mesh_sar *msg, uint8_t segO)
 		return false;
 
 	if (!net_key_encrypt(subnet->net_key_tx, msg->iv_index, packet + 1,
-							     packet_len)) {
+								packet_len)) {
 		l_error("Failed to encode packet");
 		return false;
 	}
@@ -3090,12 +3071,9 @@ static bool send_seg(struct mesh_net *net, struct mesh_sar *msg, uint8_t segO)
 }
 
 void mesh_net_send_seg(struct mesh_net *net, uint32_t net_key_id,
-				uint32_t iv_index,
-				uint8_t ttl,
-				uint32_t seq,
-				uint16_t src, uint16_t dst,
-				uint32_t hdr,
-				const void *seg, uint16_t seg_len)
+			uint32_t iv_index, uint8_t ttl, uint32_t seq,
+			uint16_t src, uint16_t dst, uint32_t hdr,
+			const void *seg, uint16_t seg_len)
 {
 	uint8_t packet[30];
 	uint8_t packet_len;
@@ -3112,15 +3090,10 @@ void mesh_net_send_seg(struct mesh_net *net, uint32_t net_key_id,
 	l_debug("SEQ0: %6.6x", seq);
 	l_debug("segO: %d", segO);
 
-	if (!mesh_crypto_packet_build(false, ttl,
-				seq,
-				src, dst,
-				0,
-				segmented, app_key_id,
-				szmic, false, seqZero,
-				segO, segN,
-				seg, seg_len,
-				packet + 1, &packet_len)) {
+	if (!mesh_crypto_packet_build(false, ttl, seq, src, dst, 0,
+					segmented, app_key_id, szmic, false,
+					seqZero, segO, segN, seg, seg_len,
+					packet + 1, &packet_len)) {
 		l_error("Failed to build packet");
 		return;
 	}
@@ -3166,12 +3139,8 @@ bool mesh_net_app_send(struct mesh_net *net, bool frnd_cred, uint16_t src,
 	segmented |= !!(seg_max);
 
 	/* First enqueue to any Friends and internal models */
-	result = msg_rxed(net, false, iv_index, ttl,
-				seq,
-				net_idx,
-				src, dst,
-				key_aid, segmented,
-				szmic, seq & SEQ_ZERO_MASK,
+	result = msg_rxed(net, false, iv_index, ttl, seq, net_idx, src, dst,
+				key_aid, segmented, szmic, seq & SEQ_ZERO_MASK,
 				msg, msg_len);
 
 	/*
@@ -3203,7 +3172,7 @@ bool mesh_net_app_send(struct mesh_net *net, bool frnd_cred, uint16_t src,
 		payload->id = ++net->sar_id_next;
 
 		/* Single thread SAR messages to same Unicast DST */
-		if (NULL != l_queue_find(net->sar_out, match_sar_remote,
+		if (l_queue_find(net->sar_out, match_sar_remote,
 							L_UINT_TO_PTR(dst))) {
 			/* Delay sending Outbound SAR unless prior
 			 * SAR to same DST has completed */
@@ -3242,13 +3211,9 @@ bool mesh_net_app_send(struct mesh_net *net, bool frnd_cred, uint16_t src,
 	return result;
 }
 
-void mesh_net_ack_send(struct mesh_net *net, uint32_t key_id,
-				uint32_t iv_index,
-				uint8_t ttl,
-				uint32_t seq,
-				uint16_t src, uint16_t dst,
-				bool rly, uint16_t seqZero,
-				uint32_t ack_flags)
+void mesh_net_ack_send(struct mesh_net *net, uint32_t key_id, uint32_t iv_index,
+			uint8_t ttl, uint32_t seq, uint16_t src, uint16_t dst,
+			bool rly, uint16_t seqZero, uint32_t ack_flags)
 {
 	uint32_t hdr;
 	uint8_t data[7];
@@ -3260,18 +3225,13 @@ void mesh_net_ack_send(struct mesh_net *net, uint32_t key_id,
 	hdr |= (seqZero & SEQ_ZERO_MASK) << SEQ_ZERO_HDR_SHIFT;
 	l_put_be32(hdr, data);
 	l_put_be32(ack_flags, data + 3);
-	if (!mesh_crypto_packet_build(true, ttl,
-					seq,
-					src, dst,
-					NET_OP_SEG_ACKNOWLEDGE,
-					false, /* Not Segmented */
-					0,	/* No Key ID associated */
-					false, rly, seqZero,
-					0, 0,	/* no segO or segN */
-					data + 1, 6,
-					pkt + 1, &pkt_len)) {
+
+	/* Not Segmented, no Key ID associated, no segO or segN */
+	if (!mesh_crypto_packet_build(true, ttl, seq, src, dst,
+					NET_OP_SEG_ACKNOWLEDGE, false, 0, false,
+					rly, seqZero, 0, 0, data + 1, 6,
+					pkt + 1, &pkt_len))
 		return;
-	}
 
 	if (!key_id) {
 		struct mesh_subnet *subnet = get_primary_subnet(net);
@@ -3323,24 +3283,17 @@ void mesh_net_transport_send(struct mesh_net *net, uint32_t key_id,
 		uint32_t hdr = msg[0] << OPCODE_HDR_SHIFT;
 		uint8_t frnd_ttl = ttl;
 
-		if (friend_packet_queue(net, iv_index,
-					true, frnd_ttl,
-					mesh_net_next_seq_num(net),
-					src, dst,
-					hdr,
-					msg + 1, msg_len - 1)) {
+		if (friend_packet_queue(net, iv_index, true, frnd_ttl,
+					mesh_net_next_seq_num(net), src, dst,
+					hdr, msg + 1, msg_len - 1))
 			return;
-		}
 	}
 
 	/* Deliver to Local entities if applicable */
-	if (!(dst & 0x8000) && src >= net->src_addr && src <= net->last_addr) {
-		result = ctl_received(net, key_id,
-					iv_index, ttl,
-					mesh_net_next_seq_num(net),
-					src, dst,
+	if (!(dst & 0x8000) && src >= net->src_addr && src <= net->last_addr)
+		result = ctl_received(net, key_id, iv_index, ttl,
+					mesh_net_next_seq_num(net), src, dst,
 					msg[0], 0, msg + 1, msg_len - 1);
-	}
 
 	if (!key_id) {
 		struct mesh_subnet *subnet = l_queue_find(net->subnets,
@@ -3355,15 +3308,9 @@ void mesh_net_transport_send(struct mesh_net *net, uint32_t key_id,
 			return;
 	}
 
-	if (!mesh_crypto_packet_build(true, ttl,
-				use_seq,
-				src, dst,
-				msg[0],
-				false, 0,
-				false, false, 0,
-				0, 0,
-				msg + 1, msg_len - 1,
-				pkt + 1, &pkt_len))
+	if (!mesh_crypto_packet_build(true, ttl, use_seq, src, dst, msg[0],
+				false, 0, false, false, 0, 0, 0, msg + 1,
+				msg_len - 1, pkt + 1, &pkt_len))
 		return;
 
 	if (!net_key_encrypt(key_id, iv_index, pkt + 1, pkt_len)) {
@@ -3517,7 +3464,7 @@ void mesh_net_heartbeat_send(struct mesh_net *net)
 	n += 2;
 
 	mesh_net_transport_send(net, 0, 0, mesh_net_get_iv_index(net),
-				hb->pub_ttl, 0, 0, hb->pub_dst, msg, n);
+					hb->pub_ttl, 0, 0, hb->pub_dst, msg, n);
 }
 
 void mesh_net_heartbeat_init(struct mesh_net *net)
@@ -3575,7 +3522,7 @@ uint16_t mesh_net_get_primary_idx(struct mesh_net *net)
 uint32_t mesh_net_friend_timeout(struct mesh_net *net, uint16_t addr)
 {
 	struct mesh_friend *frnd = l_queue_find(net->friends, match_by_friend,
-						L_UINT_TO_PTR(addr));
+							L_UINT_TO_PTR(addr));
 
 	if (!frnd)
 		return 0;

--- a/mesh/net.h
+++ b/mesh/net.h
@@ -120,12 +120,6 @@ struct mesh_node;
 #define DEFAULT_MIN_DELAY		0
 #define DEFAULT_MAX_DELAY		25
 
-struct mesh_net_addr_range {
-	uint16_t low;
-	uint16_t high;
-	uint16_t next;
-};
-
 struct mesh_net_prov_caps {
 	uint8_t num_ele;
 	uint16_t algorithms;
@@ -264,7 +258,6 @@ typedef void (*mesh_status_func_t)(void *user_data, bool result);
 struct mesh_net *mesh_net_new(struct mesh_node *node);
 void mesh_net_free(void *net);
 void mesh_net_cleanup(void);
-void mesh_net_flush_msg_queues(struct mesh_net *net);
 void mesh_net_set_iv_index(struct mesh_net *net, uint32_t index, bool update);
 bool mesh_net_iv_index_update(struct mesh_net *net);
 bool mesh_net_set_seq_num(struct mesh_net *net, uint32_t number);
@@ -300,7 +293,6 @@ bool mesh_net_attach(struct mesh_net *net, struct mesh_io *io);
 struct mesh_io *mesh_net_detach(struct mesh_net *net);
 struct l_queue *mesh_net_get_app_keys(struct mesh_net *net);
 
-bool mesh_net_flush(struct mesh_net *net);
 void mesh_net_transport_send(struct mesh_net *net, uint32_t key_id,
 				uint16_t net_idx, uint32_t iv_index,
 				uint8_t ttl, uint32_t seq, uint16_t src,
@@ -316,17 +308,9 @@ void mesh_net_ack_send(struct mesh_net *net, uint32_t key_id,
 				uint32_t iv_index, uint8_t ttl, uint32_t seq,
 				uint16_t src, uint16_t dst, bool rly,
 				uint16_t seqZero, uint32_t ack_flags);
-struct mesh_net_prov_caps *mesh_net_prov_caps_get(struct mesh_net *net);
-uint8_t *mesh_net_priv_key_get(struct mesh_net *net);
-bool mesh_net_priv_key_set(struct mesh_net *net, uint8_t key[32]);
-uint8_t *mesh_net_prov_rand(struct mesh_net *net);
-uint16_t mesh_net_prov_uni(struct mesh_net *net, uint8_t ele_cnt);
-bool mesh_net_id_uuid_set(struct mesh_net *net, uint8_t uuid[16]);
-uint8_t *mesh_net_test_addr(struct mesh_net *net);
 int mesh_net_get_identity_mode(struct mesh_net *net, uint16_t idx,
 								uint8_t *mode);
 char *mesh_net_id_name(struct mesh_net *net);
-bool mesh_net_test_mode(struct mesh_net *net);
 bool mesh_net_dst_reg(struct mesh_net *net, uint16_t dst);
 bool mesh_net_dst_unreg(struct mesh_net *net, uint16_t dst);
 struct mesh_friend *mesh_friend_new(struct mesh_net *net, uint16_t dst,
@@ -348,13 +332,9 @@ void mesh_net_send_seg(struct mesh_net *net, uint32_t key_id,
 				uint32_t iv_index, uint8_t ttl, uint32_t seq,
 				uint16_t src, uint16_t dst, uint32_t hdr,
 				const void *seg, uint16_t seg_len);
-uint16_t mesh_net_get_features(struct mesh_net *net);
 struct mesh_net_heartbeat *mesh_net_heartbeat_get(struct mesh_net *net);
 void mesh_net_heartbeat_init(struct mesh_net *net);
 void mesh_net_heartbeat_send(struct mesh_net *net);
-void mesh_net_uni_range_set(struct mesh_net *net,
-				struct mesh_net_addr_range *range);
-struct mesh_net_addr_range mesh_net_uni_range_get(struct mesh_net *net);
 void mesh_net_provisioner_mode_set(struct mesh_net *net, bool mode);
 bool mesh_net_provisioner_mode_get(struct mesh_net *net);
 bool mesh_net_key_list_get(struct mesh_net *net, uint8_t *buf, uint16_t *count);
@@ -365,7 +345,6 @@ struct mesh_node *mesh_net_node_get(struct mesh_net *net);
 bool mesh_net_have_key(struct mesh_net *net, uint16_t net_idx);
 bool mesh_net_is_local_address(struct mesh_net *net, uint16_t src,
 							uint16_t count);
-void mesh_net_set_window_accuracy(struct mesh_net *net, uint8_t accuracy);
 void mesh_net_transmit_params_set(struct mesh_net *net, uint8_t count,
 							uint16_t interval);
 void mesh_net_transmit_params_get(struct mesh_net *net, uint8_t *count,

--- a/mesh/net.h
+++ b/mesh/net.h
@@ -260,9 +260,6 @@ struct mesh_friend_msg {
 };
 
 typedef void (*mesh_status_func_t)(void *user_data, bool result);
-typedef void (*mesh_net_status_func_t)(uint16_t remote, uint8_t status,
-					void *data, uint16_t size,
-					void *user_data);
 
 struct mesh_net *mesh_net_new(struct mesh_node *node);
 void mesh_net_free(void *net);
@@ -313,10 +310,8 @@ void mesh_net_transport_send(struct mesh_net *net, uint32_t key_id,
 bool mesh_net_app_send(struct mesh_net *net, bool frnd_cred, uint16_t src,
 				uint16_t dst, uint8_t key_id, uint16_t net_idx,
 				uint8_t ttl, uint32_t seq, uint32_t iv_index,
-				bool segmented, bool szmic,
-				const void *msg, uint16_t msg_len,
-				mesh_net_status_func_t status_func,
-				void *user_data);
+				bool segmented, bool szmic, const void *msg,
+				uint16_t msg_len);
 void mesh_net_ack_send(struct mesh_net *net, uint32_t key_id,
 				uint32_t iv_index, uint8_t ttl, uint32_t seq,
 				uint16_t src, uint16_t dst, bool rly,

--- a/mesh/pb-adv.c
+++ b/mesh/pb-adv.c
@@ -157,8 +157,6 @@ static void send_adv_segs(struct pb_adv_session *session, const uint8_t *data,
 		init_size = size;
 	}
 
-	/* print_packet("FULL-TX", data, size); */
-
 	l_debug("Sending %u fragments for %u octets", max_seg + 1, size);
 
 	buf[6] = max_seg << 2;
@@ -168,7 +166,6 @@ static void send_adv_segs(struct pb_adv_session *session, const uint8_t *data,
 
 	l_debug("max_seg: %2.2x", max_seg);
 	l_debug("size: %2.2x, CRC: %2.2x", size, buf[9]);
-	/* print_packet("PB-TX", buf + 1, init_size + 9); */
 
 	pb_adv_send(session, MESH_IO_TX_COUNT_UNLIMITED, 200,
 							buf, init_size + 10);
@@ -185,8 +182,6 @@ static void send_adv_segs(struct pb_adv_session *session, const uint8_t *data,
 
 		buf[6] = (i << 2) | 0x02;
 		memcpy(buf + 7, data + consumed, seg_size);
-
-		/* print_packet("PB-TX", buf + 1, seg_size + 6); */
 
 		pb_adv_send(session, MESH_IO_TX_COUNT_UNLIMITED, 200,
 							buf, seg_size + 7);
@@ -225,7 +220,7 @@ static void tx_timeout(struct l_timeout *timeout, void *user_data)
 
 	mesh_send_cancel(filter, sizeof(filter));
 
-	l_info("TX timeout");
+	l_debug("TX timeout");
 	cb = session->close_cb;
 	user_data = session->user_data;
 	cb(user_data, 1);

--- a/mesh/prov-initiator.c
+++ b/mesh/prov-initiator.c
@@ -770,7 +770,7 @@ static void int_prov_rx(void *user_data, const uint8_t *data, uint16_t len)
 		break;
 
 	case PROV_COMPLETE: /* Complete */
-		l_info("Provisioning Complete");
+		l_debug("Provisioning Complete");
 		prov->state = INT_PROV_IDLE;
 		int_prov_close(prov, PROV_ERR_SUCCESS);
 		break;

--- a/mesh/util.c
+++ b/mesh/util.c
@@ -34,9 +34,14 @@
 
 #include "mesh/util.h"
 
+static bool debug_enabled;
+
 void print_packet(const char *label, const void *data, uint16_t size)
 {
 	struct timeval pkt_time;
+
+	if (!debug_enabled)
+		return;
 
 	gettimeofday(&pkt_time, NULL);
 
@@ -153,4 +158,10 @@ static int del_fobject(const char *fpath, const struct stat *sb, int typeflag,
 void del_path(const char *path)
 {
 	nftw(path, del_fobject, 5, FTW_DEPTH | FTW_PHYS);
+}
+
+void enable_debug(void)
+{
+	debug_enabled = true;
+	l_debug_enable("*");
 }

--- a/mesh/util.h
+++ b/mesh/util.h
@@ -24,3 +24,4 @@ size_t hex2str(uint8_t *in, size_t in_len, char *out, size_t out_len);
 void print_packet(const char *label, const void *data, uint16_t size);
 int create_dir(const char *dir_name);
 void del_path(const char *path);
+void enable_debug(void);


### PR DESCRIPTION

No functional changes: cleaned up debug output so that
hex print is not executed if debug is not enabled.

Style cleanup in net.c. Removed unused functions from net.h/net.c

Inga Stotland (5):
mesh: Make helper packet print depends on debug setting
mesh: Debug output clean up
mesh: Remove debug-only related callback for packet send
mesh: Clean up style in net.c
mesh: Remove unused functions from net.c

mesh/main.c            |   3 +-
mesh/manager.c         |   6 +-
mesh/mesh-io-generic.c |   3 +-
