### PR TITLE
[PW_SID:295775] Load default system configuration from file.


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,13 @@
+--no-tree
+--no-signoff
+--summary-file
+--show-types
+--max-line-length=80
+
+--ignore COMPLEX_MACRO
+--ignore SPLIT_STRING
+--ignore CONST_STRUCT
+--ignore FILE_PATH_CHANGES
+--ignore MISSING_SIGN_OFF
+--ignore PREFER_PACKED
+--ignore COMMIT_MESSAGE

--- a/.github/workflows/checkbuild.yml.disable
+++ b/.github/workflows/checkbuild.yml.disable
@@ -1,0 +1,16 @@
+name: Check Build
+
+on: [pull_request]
+
+jobs:
+  checkbuild:
+    runs-on: ubuntu-latest
+    name: Check Build for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkbuild
+      uses: tedd-an/action-checkbuild@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/checkpatch.yml.disable
+++ b/.github/workflows/checkpatch.yml.disable
@@ -1,0 +1,16 @@
+name: Check Patch
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Patch for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkpatch
+      uses: tedd-an/action-checkpatch@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,38 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/lib/mgmt.h
+++ b/lib/mgmt.h
@@ -628,6 +628,24 @@ struct mgmt_rp_set_exp_feature {
 	uint32_t flags;
 } __packed;
 
+#define MGMT_OP_READ_DEFAULT_SYSTEM_PARAMETERS	0x004b
+
+struct mgmt_system_parameter_tlv {
+	uint16_t parameter_type;
+	uint8_t length;
+	uint8_t value[];
+} __packed;
+
+struct mgmt_rp_read_default_system_parameters {
+	uint8_t parameters[0]; // mgmt_system_parameter_tlv
+} __packed;
+
+#define MGMT_OP_SET_DEFAULT_SYSTEM_PARAMETERS	0x004c
+
+struct mgmt_cp_set_default_system_parameters {
+	uint8_t parameters[0]; // mgmt_system_parameter_tlv
+} __packed;
+
 #define MGMT_EV_CMD_COMPLETE		0x0001
 struct mgmt_ev_cmd_complete {
 	uint16_t opcode;
@@ -933,6 +951,8 @@ static const char *mgmt_op[] = {
 	"Read Security Information",			/* 0x0048 */
 	"Read Experimental Features Information",
 	"Set Experimental Feature",
+	"Read Default System Configuration",
+	"Set Default System Configuration",
 };
 
 static const char *mgmt_ev[] = {

--- a/src/hcid.h
+++ b/src/hcid.h
@@ -49,6 +49,45 @@ struct main_opts {
 	uint32_t	discovto;
 	uint8_t		privacy;
 
+	struct {
+		uint16_t	num_set_params;
+
+		uint16_t	br_page_scan_type;
+		uint16_t	br_page_scan_interval;
+		uint16_t	br_page_scan_window;
+
+		uint16_t	br_inquiry_scan_type;
+		uint16_t	br_inquiry_scan_interval;
+		uint16_t	br_inquiry_scan_window;
+
+		uint16_t	br_link_supervision_timeout;
+		uint16_t	br_page_timeout;
+
+		uint16_t	br_min_sniff_interval;
+		uint16_t	br_max_sniff_interval;
+
+		uint16_t	le_min_adv_interval;
+		uint16_t	le_max_adv_interval;
+		uint16_t	le_multi_adv_rotation_interval;
+
+		uint16_t	le_scan_interval_autoconnect;
+		uint16_t	le_scan_window_autoconnect;
+		uint16_t	le_scan_interval_suspend;
+		uint16_t	le_scan_window_suspend;
+		uint16_t	le_scan_interval_discovery;
+		uint16_t	le_scan_window_discovery;
+		uint16_t	le_scan_interval_adv_monitor;
+		uint16_t	le_scan_window_adv_monitor;
+		uint16_t	le_scan_interval_connect;
+		uint16_t	le_scan_window_connect;
+
+		uint16_t	le_min_connection_interval;
+		uint16_t	le_max_connection_interval;
+		uint16_t	le_connection_latency;
+		uint16_t	le_connection_lsto;
+	} default_params;
+
+
 	gboolean	reverse_discovery;
 	gboolean	name_resolv;
 	gboolean	debug_keys;

--- a/src/main.c
+++ b/src/main.c
@@ -80,7 +80,7 @@ static enum {
 	MPS_MULTIPLE,
 } mps = MPS_OFF;
 
-static const char *supported_options[] = {
+static const char * const supported_options[] = {
 	"Name",
 	"Class",
 	"DiscoverableTimeout",
@@ -129,7 +129,7 @@ static const char * const controller_options[] = {
 	NULL
 };
 
-static const char *policy_options[] = {
+static const char * const policy_options[] = {
 	"ReconnectUUIDs",
 	"ReconnectAttempts",
 	"ReconnectIntervals",
@@ -137,7 +137,7 @@ static const char *policy_options[] = {
 	NULL
 };
 
-static const char *gatt_options[] = {
+static const char * const gatt_options[] = {
 	"Cache",
 	"KeySize",
 	"ExchangeMTU",
@@ -146,8 +146,8 @@ static const char *gatt_options[] = {
 };
 
 static const struct group_table {
-	const char *name;
-	const char **options;
+	const char * const name;
+	const char * const * const options;
 } valid_groups[] = {
 	{ "General",	supported_options },
 	{ "Controller", controller_options },
@@ -243,7 +243,7 @@ static enum jw_repairing_t parse_jw_repairing(const char *jw_repairing)
 
 
 static void check_options(GKeyFile *config, const char *group,
-						const char **options)
+					const char * const * const options)
 {
 	char **keys;
 	int i;

--- a/src/main.c
+++ b/src/main.c
@@ -54,6 +54,7 @@
 #include "shared/att-types.h"
 #include "shared/mainloop.h"
 #include "lib/uuid.h"
+#include "shared/util.h"
 #include "hcid.h"
 #include "sdpd.h"
 #include "adapter.h"
@@ -97,6 +98,37 @@ static const char *supported_options[] = {
 	NULL
 };
 
+static const char * const controller_options[] = {
+	"BRPageScanType",
+	"BRPageScanInterval",
+	"BRPageScanWindow",
+	"BRInquiryScanType",
+	"BRInquiryScanInterval",
+	"BRInquiryScanWindow",
+	"BRLinkSupervisionTimeout",
+	"BRPageTimeout",
+	"BRMinSniffInterval",
+	"BRMaxSniffInterval",
+	"LEMinAdvertisementInterval",
+	"LEMaxAdvertisementInterval",
+	"LEMultiAdvertisementRotationInterval",
+	"LEScanIntervalAutoConnect",
+	"LEScanWindowAutoConnect",
+	"LEScanIntervalSuspend",
+	"LEScanWindowSuspend",
+	"LEScanIntervalDiscovery",
+	"LEScanWindowDiscovery",
+	"LEScanIntervalAdvMonitoring",
+	"LEScanWindowAdvMonitoring",
+	"LEScanIntervalConnect",
+	"LEScanWindowConnect",
+	"LEMinConnectionInterval",
+	"LEMaxConnectionInterval",
+	"LEConnectionLatency",
+	"LEConnectionSupervisionTimeout",
+	NULL
+};
+
 static const char *policy_options[] = {
 	"ReconnectUUIDs",
 	"ReconnectAttempts",
@@ -118,6 +150,7 @@ static const struct group_table {
 	const char **options;
 } valid_groups[] = {
 	{ "General",	supported_options },
+	{ "Controller", controller_options },
 	{ "Policy",	policy_options },
 	{ "GATT",	gatt_options },
 	{ }
@@ -281,6 +314,129 @@ static int get_mode(const char *str)
 	error("Unknown controller mode \"%s\"", str);
 
 	return BT_MODE_DUAL;
+}
+
+static void parse_controller_config(GKeyFile *config)
+{
+	static const struct {
+		const char * const val_name;
+		uint16_t * const val;
+		const uint16_t min;
+		const uint16_t max;
+	} params[] = {
+		{ "BRPageScanType",
+		  &main_opts.default_params.br_page_scan_type,
+		  0,
+		  1},
+		{ "BRPageScanInterval",
+		  &main_opts.default_params.br_page_scan_interval,
+		  0x0012,
+		  0x1000},
+		{ "BRPageScanWindow",
+		  &main_opts.default_params.br_page_scan_window,
+		  0x0011,
+		  0x1000},
+		{ "BRInquiryScanType",
+		  &main_opts.default_params.br_inquiry_scan_type,
+		  0,
+		  1},
+		{ "BRInquiryScanInterval",
+		  &main_opts.default_params.br_inquiry_scan_interval,
+		  0x0012,
+		  0x1000},
+		{ "BRInquiryScanWindow",
+		  &main_opts.default_params.br_inquiry_scan_window,
+		  0x0011,
+		  0x1000},
+		{ "BRLinkSupervisionTimeout",
+		  &main_opts.default_params.br_link_supervision_timeout,
+		  0x0001,
+		  0xFFFF},
+		{ "BRPageTimeout",
+		  &main_opts.default_params.br_page_timeout,
+		  0x0001,
+		  0xFFFF},
+		{ "BRMinSniffInterval",
+		  &main_opts.default_params.br_min_sniff_interval,
+		  0x0001,
+		  0xFFFE},
+		{ "BRMaxSniffInterval",
+		  &main_opts.default_params.br_max_sniff_interval,
+		  0x0001,
+		  0xFFFE},
+		{ "LEMinAdvertisementInterval",
+		  &main_opts.default_params.le_min_adv_interval,
+		  0x0020,
+		  0x4000},
+		{ "LEMaxAdvertisementInterval",
+		  &main_opts.default_params.le_max_adv_interval,
+		  0x0020,
+		  0x4000},
+		{ "LEMultiAdvertisementRotationInterval",
+		  &main_opts.default_params.le_multi_adv_rotation_interval,
+		  0x0001,
+		  0xFFFF},
+		{ "LEScanIntervalAutoConnect",
+		  &main_opts.default_params.le_scan_interval_autoconnect,
+		  0x0004,
+		  0x4000},
+		{ "LEScanWindowAutoConnect",
+		  &main_opts.default_params.le_scan_window_autoconnect,
+		  0x0004,
+		  0x4000},
+		{ "LEScanIntervalSuspend",
+		  &main_opts.default_params.le_scan_interval_suspend,
+		  0x0004,
+		  0x4000},
+		{ "LEScanWindowSuspend",
+		  &main_opts.default_params.le_scan_window_suspend,
+		  0x0004,
+		  0x4000},
+		{ "LEScanIntervalDiscovery",
+		  &main_opts.default_params.le_scan_interval_discovery,
+		  0x0004,
+		  0x4000},
+		{ "LEScanWindowDiscovery",
+		  &main_opts.default_params.le_scan_window_discovery,
+		  0x0004,
+		  0x4000},
+		{ "LEScanIntervalAdvMonitor",
+		  &main_opts.default_params.le_scan_interval_adv_monitor,
+		  0x0004,
+		  0x4000},
+		{ "LEScanWindowAdvMonitor",
+		  &main_opts.default_params.le_scan_window_adv_monitor,
+		  0x0004,
+		  0x4000},
+		{ "LEScanIntervalConnect",
+		  &main_opts.default_params.le_scan_interval_connect,
+		  0x0004,
+		  0x4000},
+		{ "LEScanWindowConnect",
+		  &main_opts.default_params.le_scan_window_connect,
+		  0x0004,
+		  0x4000},
+	};
+	uint16_t i;
+
+	if (!config)
+		return;
+
+	for (i = 0; i < ARRAY_SIZE(params); ++i) {
+		GError *err = NULL;
+		int val = g_key_file_get_integer(config, "Controller",
+						params[i].val_name, &err);
+		if (err) {
+			g_clear_error(&err);
+		} else {
+			DBG("%s=%d", params[i].val_name, val);
+
+			val = MIN(val, params[i].min);
+			val = MAX(val, params[i].max);
+			*params[i].val = val;
+			++main_opts.default_params.num_set_params;
+		}
+	}
 }
 
 static void parse_config(GKeyFile *config)
@@ -484,6 +640,8 @@ static void parse_config(GKeyFile *config)
 		val = MAX(val, 1);
 		main_opts.gatt_channels = val;
 	}
+
+	parse_controller_config(config);
 }
 
 static void init_defaults(void)
@@ -499,6 +657,10 @@ static void init_defaults(void)
 	main_opts.reverse_discovery = TRUE;
 	main_opts.name_resolv = TRUE;
 	main_opts.debug_keys = FALSE;
+
+	main_opts.default_params.num_set_params = 0;
+	main_opts.default_params.br_page_scan_type = 0xFFFF;
+	main_opts.default_params.br_inquiry_scan_type = 0xFFFF;
 
 	if (sscanf(VERSION, "%hhu.%hhu", &major, &minor) != 2)
 		return;

--- a/src/main.conf
+++ b/src/main.conf
@@ -77,6 +77,71 @@
 # Defaults to "never"
 #JustWorksRepairing = never
 
+[Controller]
+# The following values are used to load default adapter parameters.  BlueZ loads
+# the values into the kernel before the adapter is powered if the kernel
+# supports the MGMT_LOAD_DEFAULT_PARAMETERS command. If a value isn't provided,
+# the kernel will be initialized to it's default value.  The actual value will
+# vary based on the kernel version and thus aren't provided here.
+# The Bluetooth Core Specification should be consulted for the meaning and valid
+# domain of each of these values.
+
+# BR/EDR Page scan activity configuration
+#BRPageScanType=
+#BRPageScanInterval=
+#BRPageScanWindow=
+
+# BR/EDR Inquiry scan activity configuration
+#BRInquiryScanType=
+#BRInquiryScanInterval=
+#BRInquiryScanWindow=
+
+# BR/EDR Link supervision timeout
+#BRLinkSupervisionTimeout=
+
+# BR/EDR Page Timeout
+#BRPageTimeout=
+
+# BR/EDR Sniff Intervals
+#BRMinSniffInterval=
+#BRMaxSniffInterval=
+
+# LE advertisement interval (used for legacy advertisement interface only)
+#LEMinAdvertisementInterval=
+#LEMaxAdvertisementInterval=
+#LEMultiAdvertisementRotationInterval=
+
+# LE scanning parameters used for passive scanning supporting auto connect
+# scenarios
+#LEScanIntervalAutoConnect=
+#LEScanWindowAutoConnect=
+
+# LE scanning parameters used for passive scanning supporting wake from suspend
+# scenarios
+#LEScanIntervalSuspend=
+#LEScanWindowSuspend=
+
+# LE scanning parameters used for active scanning supporting discovery
+# proceedure
+#LEScanIntervalDiscovery=
+#LEScanWindowDiscovery=
+
+# LE scanning parameters used for passive scanning supporting the advertisement
+# monitor Apis
+#LEScanIntervalAdvMonitor=
+#LEScanWindowAdvMonitor=
+
+# LE scanning parameters used for connection establishment.
+#LEScanIntervalConnect=
+#LEScanWindowConnect=
+
+# LE default connection parameters.  These values are superceeded by any
+# specific values provided via the Load Connection Parameters interface
+#LEMinConnectionInterval=
+#LEMaxConnectionInterval=
+#LEConnectionLatency=
+#LEConnectionSupervisionTimeout=
+
 [GATT]
 # GATT attribute cache.
 # Possible values:


### PR DESCRIPTION

This series adds supports for reading default system configurations from
a configuration file.  This allows a system to override what are
currently kernel hardcoded values from a conf file.

The dependent kernel patch will be posted after some additional parsing
validation on the tlv is completed.

Changes in v3:
- Fixing const decoration warnings on options.

Changes in v2:
- Fixing checkpatch warning that are applicable.

Alain Michaud (4):
mgmt:adding load default system configuration definitions
adapter:set default system configuration if available
main:read default system configuration from the conf file.
fixing const decoration warnins on options.

lib/mgmt.h    |  20 ++++
src/adapter.c | 251 ++++++++++++++++++++++++++++++++++++++++++++++++++
src/hcid.h    |  39 ++++++++
src/main.c    | 174 ++++++++++++++++++++++++++++++++--
src/main.conf |  65 +++++++++++++
5 files changed, 543 insertions(+), 6 deletions(-)
