### PR TITLE
[PW_SID:299233] Segmentation fault in the mesh/node.c


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,13 @@
+--no-tree
+--no-signoff
+--summary-file
+--show-types
+--max-line-length=80
+
+--ignore COMPLEX_MACRO
+--ignore SPLIT_STRING
+--ignore CONST_STRUCT
+--ignore FILE_PATH_CHANGES
+--ignore MISSING_SIGN_OFF
+--ignore PREFER_PACKED
+--ignore COMMIT_MESSAGE

--- a/.github/workflows/checkbuild.yml.disable
+++ b/.github/workflows/checkbuild.yml.disable
@@ -1,0 +1,16 @@
+name: Check Build
+
+on: [pull_request]
+
+jobs:
+  checkbuild:
+    runs-on: ubuntu-latest
+    name: Check Build for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkbuild
+      uses: tedd-an/action-checkbuild@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/checkpatch.yml.disable
+++ b/.github/workflows/checkpatch.yml.disable
@@ -1,0 +1,16 @@
+name: Check Patch
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    name: Check Patch for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: Checkpatch
+      uses: tedd-an/action-checkpatch@master
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,38 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}


### PR DESCRIPTION

Hi,


After rebase on the latest BlueZ version our functional tests failed on 
SEGV in the `node.c` file. Seems that call two D-Bus functions `join` 
and `leave` one after the other (before receive `join_complete`) causes 
SEGV.

In the attached files there is the backtrace and the diff with my 
changes (adds extra some logs).


Best regards,

Przemysław Fierek
11:58:15  =================================== FAILURES ===================================
11:58:15  _______________________ test_remove_storage_after_leave ________________________
11:58:15  
11:58:15  application = <bluez_tests.fixtures.application.<locals>._Application object at 0x7f0cf3fb1050>
11:58:15  meshd = <bluez_tests.daemon.Daemon object at 0x7f0cf4125710>
11:58:15  node_storage = <class 'bluez_tests.fixtures.node_storage.<locals>.NodeStorage'>
11:58:15  
11:58:15      async def test_remove_storage_after_leave(application, meshd, node_storage):
11:58:15          await application.import_node()
11:58:15      
11:58:15          assert application.token_ring.token
11:58:15      
11:58:15          with node_storage() as storage, node_storage(backup=True) as backup:
11:58:15              assert storage["token"] == application.token_ring.token
11:58:15              assert backup["token"] == application.token_ring.token
11:58:15      
11:58:15  >       await application.leave()
11:58:15  
11:58:15  bluez_tests/test_storage.py:230: 
11:58:15  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
11:58:15  /usr/local/lib/python3.7/dist-packages/bluetooth_mesh/application.py:721: in leave
11:58:15      await self.network_interface.leave(self.token_ring.token)
11:58:15  /usr/local/lib/python3.7/dist-packages/bluetooth_mesh/interfaces.py:309: in leave
11:58:15      await self._interface.call_leave(token)
11:58:15  /usr/local/lib/python3.7/dist-packages/dbus_next/aio/proxy_object.py:79: in method_fn
11:58:15      BaseProxyInterface._check_method_return(msg, intr_method.out_signature)
11:58:15  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
11:58:15  
11:58:15  msg = <dbus_next.message.Message object at 0x7f0cf41a8fd0>, signature = ''
11:58:15  
11:58:15      @staticmethod
11:58:15      def _check_method_return(msg, signature=None):
11:58:15          if msg.message_type == MessageType.ERROR:
11:58:15  >           raise DBusError._from_message(msg)
11:58:15  E           dbus_next.errors.DBusError: Message recipient disconnected from message bus without replying
11:58:15  
11:58:15  /usr/local/lib/python3.7/dist-packages/dbus_next/proxy_object.py:59: DBusError
