### PR TITLE
[PW_SID:305865] Blacklist addresses of deleted nodes


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "*/8 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/mesh/net.c
+++ b/mesh/net.c
@@ -2566,6 +2566,8 @@ static void update_iv_ivu_state(struct mesh_net *net, uint32_t iv_index,
 		rpl_init(net->node, iv_index);
 	}
 
+	node_property_changed(net->node, "IVIndex");
+
 	net->iv_index = iv_index;
 	net->iv_update = ivu;
 }

--- a/mesh/node.c
+++ b/mesh/node.c
@@ -2280,6 +2280,15 @@ static void setup_node_interface(struct l_dbus_interface *iface)
 									NULL);
 }
 
+void node_property_changed(struct mesh_node *node, const char *property)
+{
+	struct l_dbus *bus = dbus_get_bus();
+
+	if (bus)
+		l_dbus_property_changed(dbus_get_bus(), node->obj_path,
+						MESH_NODE_INTERFACE, property);
+}
+
 bool node_dbus_init(struct l_dbus *bus)
 {
 	if (!l_dbus_register_interface(bus, MESH_NODE_INTERFACE,

--- a/mesh/node.h
+++ b/mesh/node.h
@@ -99,3 +99,4 @@ struct mesh_agent *node_get_agent(struct mesh_node *node);
 const char *node_get_storage_dir(struct mesh_node *node);
 bool node_load_from_storage(const char *storage_dir);
 void node_finalize_new_node(struct mesh_node *node, struct mesh_io *io);
+void node_property_changed(struct mesh_node *node, const char *property);

--- a/tools/mesh-cfgclient.c
+++ b/tools/mesh-cfgclient.c
@@ -699,6 +699,7 @@ static void attach_node_reply(struct l_dbus_proxy *proxy,
 							ivi != iv_index) {
 		iv_index = ivi;
 		mesh_db_set_iv_index(ivi);
+		remote_clear_blacklisted_addresses(ivi);
 	}
 
 	return;
@@ -1823,6 +1824,7 @@ static void property_changed(struct l_dbus_proxy *proxy, const char *name,
 
 			iv_index = ivi;
 			mesh_db_set_iv_index(ivi);
+			remote_clear_blacklisted_addresses(ivi);
 		}
 	}
 }

--- a/tools/mesh/mesh-db.c
+++ b/tools/mesh/mesh-db.c
@@ -1232,6 +1232,29 @@ bool mesh_db_set_addr_range(uint16_t low, uint16_t high)
 	return save_config();
 }
 
+uint32_t mesh_db_get_iv_index(void)
+{
+	int ivi;
+
+	if (!cfg || !cfg->jcfg)
+		return 0;
+
+	if (!get_int(cfg->jcfg, "ivIndex", &ivi))
+		return 0;
+
+	return (uint32_t) ivi;
+}
+
+bool mesh_db_set_iv_index(uint32_t ivi)
+{
+	if (!cfg || !cfg->jcfg)
+		return false;
+
+	write_int(cfg->jcfg, "ivIndex", ivi);
+
+	return save_config();
+}
+
 bool mesh_db_create(const char *fname, const uint8_t token[8],
 							const char *mesh_name)
 {
@@ -1281,6 +1304,8 @@ bool mesh_db_create(const char *fname, const uint8_t token[8],
 		goto fail;
 
 	json_object_object_add(jcfg, "appKeys", jarray);
+
+	write_int(jcfg, "ivIndex", 0);
 
 	if (!save_config())
 		goto fail;

--- a/tools/mesh/mesh-db.h
+++ b/tools/mesh/mesh-db.h
@@ -58,3 +58,5 @@ bool mesh_db_node_model_binding_del(uint16_t unicast, uint8_t ele, bool vendor,
 					uint32_t mod_id, uint16_t app_idx);
 struct l_queue *mesh_db_load_groups(void);
 bool mesh_db_add_group(struct mesh_group *grp);
+bool mesh_db_add_blacklisted_addr(uint16_t unicast, uint32_t iv_index);
+bool mesh_db_clear_blacklisted(uint32_t iv_index);

--- a/tools/mesh/mesh-db.h
+++ b/tools/mesh/mesh-db.h
@@ -26,7 +26,8 @@ bool mesh_db_create(const char *fname, const uint8_t token[8],
 bool mesh_db_load(const char *fname);
 
 bool mesh_db_get_token(uint8_t token[8]);
-
+bool mesh_db_set_iv_index(uint32_t ivi);
+uint32_t mesh_db_get_iv_index(void);
 bool mesh_db_net_key_add(uint16_t idx);
 bool mesh_db_net_key_del(uint16_t idx);
 bool mesh_db_net_key_phase_set(uint16_t net_idx, uint8_t phase);

--- a/tools/mesh/remote.h
+++ b/tools/mesh/remote.h
@@ -22,6 +22,9 @@ bool remote_add_node(const uint8_t uuid[16], uint16_t unicast,
 uint8_t remote_del_node(uint16_t unicast);
 bool remote_set_model(uint16_t unicast, uint8_t ele_idx, uint32_t mod_id,
 								bool vendor);
+void remote_add_blacklisted_address(uint16_t addr, uint32_t iv_index,
+								bool save);
+void remote_clear_blacklisted_addresses(uint32_t iv_index);
 uint16_t remote_get_next_unicast(uint16_t low, uint16_t high, uint8_t ele_cnt);
 bool remote_add_net_key(uint16_t addr, uint16_t net_idx);
 bool remote_del_net_key(uint16_t addr, uint16_t net_idx);


### PR DESCRIPTION

This patch set adds a notion of blacklisted addresses for nodes that
have been removed from mesh network.
The addresses of nodes that have been removed should not be added
back into available unicast addresses pool (for assigning to newly
provisioned nodes) until mesh-wide IV Index is changed at least twice 

Inga Stotland (3):
mesh: Emit PropertiesChanged when IV Index changes
tools/mesh-cfgclient: get/set IV index
tools/mesh-cfgclient: add list of blacklisted addresses

mesh/net.c             |   2 +
mesh/node.c            |   9 +++
mesh/node.h            |   1 +
tools/mesh-cfgclient.c |  41 +++++++++-
tools/mesh/mesh-db.c   | 170 +++++++++++++++++++++++++++++++++++++++++
tools/mesh/mesh-db.h   |   5 +-
