### PR TITLE
[PW_SID:310851] [Bluez,v1] device - If HFP is supported, ignore HSP


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-modernist

--- a/src/device.c
+++ b/src/device.c
@@ -4370,6 +4370,11 @@ static struct btd_service *probe_service(struct btd_device *device,
 	if (!device_match_profile(device, profile, uuids))
 		return NULL;
 
+	/* If device supports HFP, don't bother create service for HSP. */
+	if (g_slist_find_custom(uuids, HFP_HS_UUID, bt_uuid_strcmp) &&
+		bt_uuid_strcmp(profile->remote_uuid, HSP_HS_UUID) == 0)
+		return NULL;
+
 	l = find_service_with_profile(device->services, profile);
 	if (l)
 		return l->data;


### PR DESCRIPTION

From: Hsin-Yu Chao <hychao@google.com>

For a BT headset that supports both HSP and HFP, BlueZ creates
service instances for these two profiles and connects them.
It's uncertain that which of HSP and HFP eventually get connected
and being used for SCO audio. And we start observing some problem
because of this uncertainty:

- For headset that supports WBS, we need HFP connect for codec
negotiation. If HSP connects but not HFP, WBS cannot be used.
- For WH-1000XM3, if BlueZ ever initiated HFP connection but failed,
headset won't have working SCO audio even HSP is connected.

Fix this at when device probes services, if HFP is in the uuid list,
don't bother create one for HSP.

Reviewed-by: Sonny Sasaka <sonnysasaka@chromium.org>
