### PR TITLE
[PW_SID:317601] Per-device option to enable/disable internal profiles


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-modernist

--- a/client/main.c
+++ b/client/main.c
@@ -1678,6 +1678,7 @@ static void cmd_info(int argc, char *argv[])
 	print_property(proxy, "Connected");
 	print_property(proxy, "WakeAllowed");
 	print_property(proxy, "LegacyPairing");
+	print_property(proxy, "AllowInternalProfiles");
 	print_uuids(proxy);
 	print_property(proxy, "Modalias");
 	print_property(proxy, "ManufacturerData");
@@ -1831,6 +1832,39 @@ static void cmd_unblock(int argc, char *argv[])
 	if (g_dbus_proxy_set_property_basic(proxy, "Blocked",
 					DBUS_TYPE_BOOLEAN, &blocked,
 					generic_callback, str, g_free) == TRUE)
+		return;
+
+	g_free(str);
+
+	return bt_shell_noninteractive_quit(EXIT_FAILURE);
+}
+
+static void cmd_set_allow_internal_profiles(int argc, char *argv[])
+{
+	GDBusProxy *proxy;
+	dbus_bool_t allow_internal_profiles;
+	char *str;
+
+	proxy = find_device(argc, argv);
+	if (!proxy)
+		return bt_shell_noninteractive_quit(EXIT_FAILURE);
+
+	if (strcmp(argv[2], "true") != 0 && strcmp(argv[2], "false") != 0) {
+		bt_shell_printf("Invalid argument: %s\n", argv[2]);
+		return bt_shell_noninteractive_quit(EXIT_FAILURE);
+	}
+
+	allow_internal_profiles = strcmp(argv[2], "true") == 0 ? true : false;
+
+	str = g_strdup_printf("%s allow internal profiles",
+				proxy_address(proxy));
+
+	if (g_dbus_proxy_set_property_basic(proxy, "AllowInternalProfiles",
+						DBUS_TYPE_BOOLEAN,
+						&allow_internal_profiles,
+						generic_callback,
+						str,
+						g_free) == TRUE)
 		return;
 
 	g_free(str);
@@ -2824,6 +2858,10 @@ static const struct bt_shell_menu main_menu = {
 								dev_generator },
 	{ "unblock",      "[dev]",    cmd_unblock, "Unblock device",
 								dev_generator },
+	{ "set-allow-internal-profiles", "<dev> <true/false>",
+					cmd_set_allow_internal_profiles,
+					"Set allow internal profiles",
+					dev_generator },
 	{ "remove",       "<dev>",    cmd_remove, "Remove device",
 							dev_generator },
 	{ "connect",      "<dev>",    cmd_connect, "Connect device",

--- a/doc/device-api.txt
+++ b/doc/device-api.txt
@@ -189,6 +189,19 @@ Properties	string Address [readonly]
 			drivers will also be removed and no new ones will
 			be probed as long as the device is blocked.
 
+		boolean AllowInternalProfiles [readwrite]
+
+			If set to true, connection to this device will activate
+			BlueZ internal profiles (e.g. A2DP, HOG, Battery).
+			If set to false, internal profiles will not be activated
+			allowing the client to handle profiles which would
+			otherwise be controlled by internal handlers.
+			The default is configurable in main.conf.
+
+			Write operation to this property can only be accepted
+			when the device is not connected, otherwise
+			org.bluez.Error.Failed is returned.
+
 		boolean WakeAllowed [readwrite]
 
 			If set to true this device will be allowed to wake the

--- a/src/hcid.h
+++ b/src/hcid.h
@@ -114,6 +114,8 @@ struct main_opts {
 	uint8_t		key_size;
 
 	enum jw_repairing_t jw_repairing;
+
+	gboolean	default_allow_internal_profiles;
 };
 
 extern struct main_opts main_opts;

--- a/src/main.c
+++ b/src/main.c
@@ -89,6 +89,7 @@ static const char *supported_options[] = {
 	"FastConnectable",
 	"Privacy",
 	"JustWorksRepairing",
+	"DefaultAllowInternalProfiles",
 	NULL
 };
 
@@ -615,6 +616,13 @@ static void parse_config(GKeyFile *config)
 	else
 		main_opts.fast_conn = boolean;
 
+	boolean = g_key_file_get_boolean(config, "General",
+					"DefaultAllowInternalProfiles", &err);
+	if (err)
+		g_clear_error(&err);
+	else
+		main_opts.default_allow_internal_profiles = boolean;
+
 	str = g_key_file_get_string(config, "GATT", "Cache", &err);
 	if (err) {
 		DBG("%s", err->message);
@@ -691,6 +699,8 @@ static void init_defaults(void)
 	main_opts.gatt_cache = BT_GATT_CACHE_ALWAYS;
 	main_opts.gatt_mtu = BT_ATT_MAX_LE_MTU;
 	main_opts.gatt_channels = 3;
+
+	main_opts.default_allow_internal_profiles = true;
 }
 
 static void log_handler(const gchar *log_domain, GLogLevelFlags log_level,

--- a/src/main.conf
+++ b/src/main.conf
@@ -77,6 +77,10 @@
 # Defaults to "never"
 #JustWorksRepairing = never
 
+# The default value of "AllowInternalProfiles" property in org.bluez.Device1
+# interface. Defaults to 'true'.
+#DefaultAllowInternalProfiles = true
+
 [Controller]
 # The following values are used to load default adapter parameters.  BlueZ loads
 # the values into the kernel before the adapter is powered if the kernel


### PR DESCRIPTION

This patch series adds a mechanism for clients to choose whether to
enable BlueZ internal profiles (e.g. A2DP, Battery) for specific
devices.

The motivation behind this feature is that some applications (e.g. Web
Bluetooth or Android apps) need to have control over all remove GATT
services, like Battery service. With "battery" plugin being enabled on
BlueZ, it becomes not possible for those apps to work properly because
BlueZ "hides" the Battery-related attributes from its GATT Client API.
Disabling the "battery" plugin won't solve the problem either, since we
do also need to enable the plugin so that we can use org.bluez.Battery1
API.

The solution that we propose is that clients can choose whether to
enable internal profiles for each device. Clients know when to enable
internal profiles (such as when a user chooses to pair/connect via a UI)
and when to disable internal profiles (such as when the connection is
initiated by a generic application).

Sonny Sasaka (3):
doc: Add "AllowInternalProfiles" property to org.bluez.Device1
device: Add "AllowInternalProfiles" property to org.bluez.Device1
client: Add set-allow-internal-profiles command

client/main.c      | 38 ++++++++++++++++++
doc/device-api.txt | 13 +++++++
src/device.c       | 96 ++++++++++++++++++++++++++++++++++++++++++++++
src/hcid.h         |  2 +
src/main.c         | 10 +++++
src/main.conf      |  4 ++
6 files changed, 163 insertions(+)
