### PR TITLE
[PW_SID:318957] [BlueZ,1/2] device: Add timer for removing temporary devices


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-modernist

--- a/src/hcid.h
+++ b/src/hcid.h
@@ -53,6 +53,7 @@ struct main_opts {
 	gboolean	pairable;
 	uint32_t	pairto;
 	uint32_t	discovto;
+	uint32_t	tmpto;
 	uint8_t		privacy;
 
 	struct {

--- a/src/main.c
+++ b/src/main.c
@@ -67,6 +67,7 @@
 
 #define DEFAULT_PAIRABLE_TIMEOUT       0 /* disabled */
 #define DEFAULT_DISCOVERABLE_TIMEOUT 180 /* 3 minutes */
+#define DEFAULT_TEMPORARY_TIMEOUT     30 /* 30 seconds */
 
 #define SHUTDOWN_GRACE_SECONDS 10
 
@@ -89,6 +90,7 @@ static const char *supported_options[] = {
 	"FastConnectable",
 	"Privacy",
 	"JustWorksRepairing",
+	"TemporaryTimeout",
 	NULL
 };
 
@@ -531,6 +533,16 @@ static void parse_config(GKeyFile *config)
 		g_free(str);
 	}
 
+	val = g_key_file_get_integer(config, "General",
+						"TemporaryTimeout", &err);
+	if (err) {
+		DBG("%s", err->message);
+		g_clear_error(&err);
+	} else {
+		DBG("tmpto=%d", val);
+		main_opts.tmpto = val;
+	}
+
 	str = g_key_file_get_string(config, "General", "Name", &err);
 	if (err) {
 		DBG("%s", err->message);
@@ -672,6 +684,7 @@ static void init_defaults(void)
 	main_opts.class = 0x000000;
 	main_opts.pairto = DEFAULT_PAIRABLE_TIMEOUT;
 	main_opts.discovto = DEFAULT_DISCOVERABLE_TIMEOUT;
+	main_opts.tmpto = DEFAULT_TEMPORARY_TIMEOUT;
 	main_opts.reverse_discovery = TRUE;
 	main_opts.name_resolv = TRUE;
 	main_opts.debug_keys = FALSE;

--- a/src/main.conf
+++ b/src/main.conf
@@ -77,6 +77,11 @@
 # Defaults to "never"
 #JustWorksRepairing = never
 
+# How long to keep temporary devices around
+# The value is in seconds. Default is 30.
+# 0 = disable timer, i.e. never keep temporary devices
+#TemporaryTimeout = 30
+
 [Controller]
 # The following values are used to load default adapter parameters.  BlueZ loads
 # the values into the kernel before the adapter is powered if the kernel


### PR DESCRIPTION

From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This adds a timer for how long to keep temporary devices, it is updated
everytime the device is seen so devices will be removed even during an
active discovery session which means the discovering for a long period
will no longer just grow without removing devices that disappeared.
