### PR TITLE
[PW_SID:318989] [BlueZ] profile: Add exception from being claimed internally


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-modernist

--- a/profiles/battery/battery.c
+++ b/profiles/battery/battery.c
@@ -354,6 +354,7 @@ static struct btd_profile batt_profile = {
 	.device_remove	= batt_remove,
 	.accept		= batt_accept,
 	.disconnect	= batt_disconnect,
+	.claim_service_exception = true,
 };
 
 static int batt_init(void)

--- a/src/device.c
+++ b/src/device.c
@@ -3818,7 +3818,7 @@ done:
 	profile = btd_service_get_profile(service);
 
 	/* Claim attributes of internal profiles */
-	if (!profile->external) {
+	if (!profile->external && !profile->claim_service_exception) {
 		/* Mark the service as claimed by the existing profile. */
 		gatt_db_service_set_claimed(attr, true);
 	}

--- a/src/profile.h
+++ b/src/profile.h
@@ -36,6 +36,11 @@ struct btd_profile {
 
 	bool auto_connect;
 	bool external;
+	/* Some profiles are considered safe to be handled internally and also
+	 * be exposed in the GATT API. This flag give such profiles exception
+	 * from being claimed internally.
+	 */
+	bool claim_service_exception;
 
 	int (*device_probe) (struct btd_service *service);
 	void (*device_remove) (struct btd_service *service);


### PR DESCRIPTION

This adds a flag to give exception to profiles that are considered safe
to be both handled internally and externally via GATT API. Currently
this includes the battery profile.
