### PR TITLE
[PW_SID:320405] [BlueZ] Add a presubmit configuration file for Chromium OS repo


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/PRESUBMIT.cfg
+++ b/PRESUBMIT.cfg
@@ -1,0 +1,8 @@
+# This is a configuration for Chromium OS repo pre-upload hooks.
+# repohooks doc: https://chromium.googlesource.com/chromiumos/repohooks/
+# Chromium OS BlueZ git repo: https://chromium.googlesource.com/chromiumos/third_party/bluez/
+
+[Hook Overrides]
+cros_license_check: false
+tab_check: false
+checkpatch_check: true

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-modernist


### PR DESCRIPTION

Chromium OS developers use gerrit and repo in their workflow.
(https://gerrit.googlesource.com/git-repo/). This configuration file
makes it easier when uploading patches to gerrit with the repo tool.
