### PR TITLE
[PW_SID:321537] [BlueZ] tools/mesh-cfgclient: Fix segfault on remote node reset


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-modernist

--- a/tools/mesh/remote.c
+++ b/tools/mesh/remote.c
@@ -134,10 +134,11 @@ uint8_t remote_del_node(uint16_t unicast)
 		l_queue_destroy(rmt->els[i], NULL);
 		remote_add_blacklisted_address(unicast + i, iv_index, true);
 	}
+
 	l_free(rmt->els);
 
-	l_queue_destroy(rmt->net_keys, l_free);
-	l_queue_destroy(rmt->app_keys, l_free);
+	l_queue_destroy(rmt->net_keys, NULL);
+	l_queue_destroy(rmt->app_keys, NULL);
 	l_free(rmt);
 
 	mesh_db_del_node(unicast);


### PR DESCRIPTION

This fixes a segfault that is caused by freeeing non-allocated memory.
Happens upon the removal of a remote node when remote's net key and/or
app key queues are destroyed.

__GI___libc_free (mem=0x1) at malloc.c:3102
destroy=destroy@entry=0x55761f63a3b0 <l_free>) at ell/queue.c:107
destroy=destroy@entry=0x55761f63a3b0 <l_free>) at ell/queue.c:82
at tools/mesh/remote.c:140
at tools/mesh/cfgcli.c:764
at tools/mesh/cfgcli.c:764
msg=0x5576213aa6f0, user_data=<optimized out>)
at tools/mesh-cfgclient.c:1522
dbus=dbus@entry=0x55762132f860, message=message@entry=0x5576213aa6f0)
at ell/dbus-service.c:1793
user_data=0x55762132f860) at ell/dbus.c:285
user_data=0x55762132f940) at ell/io.c:126
