### PR TITLE
[PW_SID:322721] [Bluez,v1,1/2] input: authenticate when connecting to a bonded device


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-modernist

--- a/profiles/input/device.c
+++ b/profiles/input/device.c
@@ -109,6 +109,11 @@ void input_set_classic_bonded_only(bool state)
 	classic_bonded_only = state;
 }
 
+bool input_get_classic_bonded_only(void)
+{
+	return classic_bonded_only;
+}
+
 static void input_device_enter_reconnect_mode(struct input_device *idev);
 static int connection_disconnect(struct input_device *idev, uint32_t flags);
 

--- a/profiles/input/device.h
+++ b/profiles/input/device.h
@@ -30,6 +30,7 @@ struct input_conn;
 void input_set_idle_timeout(int timeout);
 void input_enable_userspace_hid(bool state);
 void input_set_classic_bonded_only(bool state);
+bool input_get_classic_bonded_only(void);
 void input_set_auto_sec(bool state);
 
 int input_device_register(struct btd_service *service);

--- a/profiles/input/server.c
+++ b/profiles/input/server.c
@@ -283,6 +283,8 @@ int server_start(const bdaddr_t *src)
 {
 	struct input_server *server;
 	GError *err = NULL;
+	BtIOSecLevel sec_level = input_get_classic_bonded_only() ?
+					BT_IO_SEC_MEDIUM : BT_IO_SEC_LOW;
 
 	server = g_new0(struct input_server, 1);
 	bacpy(&server->src, src);
@@ -291,7 +293,7 @@ int server_start(const bdaddr_t *src)
 				server, NULL, &err,
 				BT_IO_OPT_SOURCE_BDADDR, src,
 				BT_IO_OPT_PSM, L2CAP_PSM_HIDP_CTRL,
-				BT_IO_OPT_SEC_LEVEL, BT_IO_SEC_LOW,
+				BT_IO_OPT_SEC_LEVEL, sec_level,
 				BT_IO_OPT_INVALID);
 	if (!server->ctrl) {
 		error("Failed to listen on control channel");
@@ -304,7 +306,7 @@ int server_start(const bdaddr_t *src)
 				server, NULL, &err,
 				BT_IO_OPT_SOURCE_BDADDR, src,
 				BT_IO_OPT_PSM, L2CAP_PSM_HIDP_INTR,
-				BT_IO_OPT_SEC_LEVEL, BT_IO_SEC_LOW,
+				BT_IO_OPT_SEC_LEVEL, sec_level,
 				BT_IO_OPT_INVALID);
 	if (!server->intr) {
 		error("Failed to listen on interrupt channel");


### PR DESCRIPTION

From: Archie Pusaka <apusaka@chromium.org>

According to bluetooth HID1.1 spec, part 5.4.3.4.3:
If the Bluetooth HID Host is bonded to a Bluetooth HID device:
If encryption is not already enabled, the Bluetooth HID Host shall
enable encryption with the Bluetooth HID device before sending an
L2CAP Connect Request to open the HID L2CAP Control channel.

When creating connection, this patch checks whether the target
device is bonded, if yes then we use the medium security level
instead of the low one to enable encryption.

Reviewed-by: Alain Michaud <alainm@chromium.org>
