### PR TITLE
[PW_SID:322989] [Bluez,v5,1/2] audio/transport: change volume to 8bit


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-modernist

--- a/profiles/audio/avrcp.h
+++ b/profiles/audio/avrcp.h
@@ -116,3 +116,5 @@ void avrcp_player_event(struct avrcp_player *player, uint8_t id,
 
 size_t avrcp_handle_vendor_reject(uint8_t *code, uint8_t *operands);
 size_t avrcp_browsing_general_reject(uint8_t *operands);
+
+struct avrcp_player *avrcp_get_target_player_by_device(struct btd_device *dev);

--- a/profiles/audio/avrcp.h
+++ b/profiles/audio/avrcp.h
@@ -83,27 +83,27 @@
 #define AVRCP_EVENT_LAST			AVRCP_EVENT_VOLUME_CHANGED
 
 struct avrcp_player_cb {
-	GList *(*list_settings) (void *user_data);
-	const char *(*get_setting) (const char *key, void *user_data);
-	int (*set_setting) (const char *key, const char *value,
+	GList *(*list_settings)(void *user_data);
+	const char *(*get_setting)(const char *key, void *user_data);
+	int (*set_setting)(const char *key, const char *value,
 							void *user_data);
-	uint64_t (*get_uid) (void *user_data);
-	const char *(*get_metadata) (const char *key, void *user_data);
-	GList *(*list_metadata) (void *user_data);
-	const char *(*get_status) (void *user_data);
-	uint32_t (*get_position) (void *user_data);
-	uint32_t (*get_duration) (void *user_data);
-	const char *(*get_name) (void *user_data);
-	void (*set_volume) (uint8_t volume, struct btd_device *dev,
+	uint64_t (*get_uid)(void *user_data);
+	const char *(*get_metadata)(const char *key, void *user_data);
+	GList *(*list_metadata)(void *user_data);
+	const char *(*get_status)(void *user_data);
+	uint32_t (*get_position)(void *user_data);
+	uint32_t (*get_duration)(void *user_data);
+	const char *(*get_name)(void *user_data);
+	void (*set_volume)(int8_t volume, struct btd_device *dev,
 							void *user_data);
-	bool (*play) (void *user_data);
-	bool (*stop) (void *user_data);
-	bool (*pause) (void *user_data);
-	bool (*next) (void *user_data);
-	bool (*previous) (void *user_data);
+	bool (*play)(void *user_data);
+	bool (*stop)(void *user_data);
+	bool (*pause)(void *user_data);
+	bool (*next)(void *user_data);
+	bool (*previous)(void *user_data);
 };
 
-int avrcp_set_volume(struct btd_device *dev, uint8_t volume, bool notify);
+int avrcp_set_volume(struct btd_device *dev, int8_t volume, bool notify);
 
 struct avrcp_player *avrcp_register_player(struct btd_adapter *adapter,
 						struct avrcp_player_cb *cb,
@@ -113,7 +113,6 @@ void avrcp_unregister_player(struct avrcp_player *player);
 
 void avrcp_player_event(struct avrcp_player *player, uint8_t id,
 							const void *data);
-
 
 size_t avrcp_handle_vendor_reject(uint8_t *code, uint8_t *operands);
 size_t avrcp_browsing_general_reject(uint8_t *operands);

--- a/profiles/audio/media.c
+++ b/profiles/audio/media.c
@@ -120,7 +120,7 @@ struct media_player {
 	char			*status;
 	uint32_t		position;
 	uint32_t		duration;
-	uint8_t			volume;
+	int8_t			volume;
 	GTimer			*timer;
 	bool			play;
 	bool			pause;
@@ -1199,7 +1199,7 @@ static uint32_t get_duration(void *user_data)
 	return mp->duration;
 }
 
-static void set_volume(uint8_t volume, struct btd_device *dev, void *user_data)
+static void set_volume(int8_t volume, struct btd_device *dev, void *user_data)
 {
 	struct media_player *mp = user_data;
 

--- a/profiles/audio/media.h
+++ b/profiles/audio/media.h
@@ -33,3 +33,5 @@ void media_unregister(struct btd_adapter *btd_adapter);
 struct a2dp_sep *media_endpoint_get_sep(struct media_endpoint *endpoint);
 const char *media_endpoint_get_uuid(struct media_endpoint *endpoint);
 uint8_t media_endpoint_get_codec(struct media_endpoint *endpoint);
+
+int8_t media_player_get_device_volume(struct btd_device *device);

--- a/profiles/audio/transport.c
+++ b/profiles/audio/transport.c
@@ -977,7 +977,7 @@ void media_transport_update_device_volume(struct btd_device *dev,
 {
 	GSList *l;
 
-	if (dev == NULL)
+	if (dev == NULL || volume < 0)
 		return;
 
 	for (l = transports; l; l = l->next) {

--- a/profiles/audio/transport.h
+++ b/profiles/audio/transport.h
@@ -32,14 +32,14 @@ struct media_transport *media_transport_create(struct btd_device *device,
 void media_transport_destroy(struct media_transport *transport);
 const char *media_transport_get_path(struct media_transport *transport);
 struct btd_device *media_transport_get_dev(struct media_transport *transport);
-uint16_t media_transport_get_volume(struct media_transport *transport);
+int8_t media_transport_get_volume(struct media_transport *transport);
 void media_transport_update_delay(struct media_transport *transport,
 							uint16_t delay);
 void media_transport_update_volume(struct media_transport *transport,
-								uint8_t volume);
+								int8_t volume);
 void transport_get_properties(struct media_transport *transport,
 							DBusMessageIter *iter);
 
-uint8_t media_transport_get_device_volume(struct btd_device *dev);
+int8_t media_transport_get_device_volume(struct btd_device *dev);
 void media_transport_update_device_volume(struct btd_device *dev,
-								uint8_t volume);
+								int8_t volume);


### PR DESCRIPTION

From: Archie Pusaka <apusaka@chromium.org>

The valid range of volume is 0 - 127, yet it is stored in 16bit
data type. This patch modifies it so we use 8bit data type to
store volume instead. Furthermore we also use signed type, so
negative values can be used to indicate invalid volume.

Reviewed-by: Michael Sun <michaelfsun@google.com>
