### PR TITLE
[PW_SID:323721] [BlueZ] main: add missing comma after AlwaysPairable


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-modernist

--- a/src/main.c
+++ b/src/main.c
@@ -79,7 +79,7 @@ static const char *supported_options[] = {
 	"Name",
 	"Class",
 	"DiscoverableTimeout",
-	"AlwaysPairable"
+	"AlwaysPairable",
 	"PairableTimeout",
 	"DeviceID",
 	"ReverseServiceDiscovery",


### PR DESCRIPTION

Commit 1880b2990866598 added a new key to supported_options but didn't
add a comma. This leads to the following error message on startup if the
key 'PairableTimeout' is present:

Unknown key PairableTimeout for group General in /etc/bluetooth/main.conf

This probably also leads to ignoring the setting.

Fixes: 1880b2990866598 ("core: Add AlwaysPairable to main.conf")
