### PR TITLE
[PW_SID:324893] [Bluez] main: adding configurable eir_max_name_len


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/doc/mgmt-api.txt
+++ b/doc/mgmt-api.txt
@@ -3279,6 +3279,7 @@ Read Default System Configuration Command
 		0x0019	LE Connection Latency
 		0x001a	LE Connection Supervision Timeout
 		0x001b	LE Autoconnect Timeout
+		0x001c	Max EIR Name Length
 
 	This command can be used at any time and will return a list of
 	supported default parameters as well as their current value.

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -2375,7 +2375,7 @@ static bool parse_pathloss(DBusMessageIter *value,
 	return true;
 }
 
-static bool parse_transport(DBusMessageIter *value, 
+static bool parse_transport(DBusMessageIter *value,
 					struct discovery_filter *filter)
 {
 	char *transport_str;
@@ -4431,6 +4431,14 @@ static void load_default_system_params(struct btd_adapter *adapter)
 		params[i].entry.type = 0x001b;
 		params[i].entry.length = sizeof(params[i].u16);
 		params[i].u16 = main_opts.default_params.le_autoconnect_timeout;
+		++i;
+		len += sizeof(params[i].u16);
+	}
+
+	if (main_opts.default_params.eir_max_name_len) {
+		params[i].entry.type = 0x001c;
+		params[i].entry.length = sizeof(params[i].u16);
+		params[i].u16 = main_opts.default_params.eir_max_name_len;
 		++i;
 		len += sizeof(params[i].u16);
 	}

--- a/src/hcid.h
+++ b/src/hcid.h
@@ -93,6 +93,7 @@ struct main_opts {
 		uint16_t	le_conn_latency;
 		uint16_t	le_conn_lsto;
 		uint16_t	le_autoconnect_timeout;
+		uint16_t	eir_max_name_len;
 	} default_params;
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -123,6 +123,7 @@ static const char *controller_options[] = {
 	"LEConnectionLatency",
 	"LEConnectionSupervisionTimeout",
 	"LEAutoconnecttimeout",
+	"EirMaxNameLength",
 	NULL
 };
 
@@ -433,6 +434,10 @@ static void parse_controller_config(GKeyFile *config)
 		  &main_opts.default_params.le_autoconnect_timeout,
 		  0x0001,
 		  0x4000},
+		{ "EirMaxNameLength",
+		  &main_opts.default_params.eir_max_name_len,
+		  0x0001,
+		  0x00EE},
 	};
 	uint16_t i;
 

--- a/src/main.conf
+++ b/src/main.conf
@@ -152,6 +152,11 @@
 #LEConnectionSupervisionTimeout=
 #LEAutoconnecttimeout=
 
+# EIR Max Name. This is the maximum length for the COMPLETE_NAME EIR section.
+# If the name length exceeds this size, a SHORT_NAME section is used.
+# Default: 48
+#EirMaxNameLength = 48
+
 [GATT]
 # GATT attribute cache.
 # Possible values:


### PR DESCRIPTION

This change adds support for a configurable eir_max_name_len for
platforms which requires a larger than 48 bytes complete name in EIR.

From bluetoothctl:
[bluetooth]# system-alias
012345678901234567890123456789012345678901234567890123456789
Changing 012345678901234567890123456789012345678901234567890123456789
succeeded
[CHG] Controller DC:71:96:69:02:89 Alias:
012345678901234567890123456789012345678901234567890123456789

From btmon:
< HCI Command: Write Local Name (0x03|0x0013) plen 248             #109
[hci0] 88.567990
        Name:
012345678901234567890123456789012345678901234567890123456789
> HCI Event: Command Complete (0x0e) plen 4                             
   #110 [hci0] 88.663854
      Write Local Name (0x03|0x0013) ncmd 1
        Status: Success (0x00)
@ MGMT Event: Local Name Changed (0x0008) plen 260               
{0x0004} [hci0] 88.663948
        Name:
012345678901234567890123456789012345678901234567890123456789
        Short name:
< HCI Command: Write Extended Inquiry Response (0x03|0x0052) plen 241 
        FEC: Not required (0x00)
        Name (complete):
012345678901234567890123456789012345678901234567890123456789
        TX power: 12 dBm
        Device ID: Bluetooth SIG assigned (0x0001)
          Vendor: Google (224)
          Product: 0xc405
          Version: 0.5.6 (0x0056)
        16-bit Service UUIDs (complete): 7 entries
          Generic Access Profile (0x1800)
          Generic Attribute Profile (0x1801)
          Device Information (0x180a)
          A/V Remote Control (0x110e)
          A/V Remote Control Target (0x110c)
          Handsfree Audio Gateway (0x111f)
          Audio Source (0x110a)
> HCI Event: Command Complete (0x0e) plen 4                           
      Write Extended Inquiry Response (0x03|0x0052) ncmd 1
        Status: Success (0x00)

Reviewed-by: Sonny Sasaka <sonnysasaka@chromium.org>
Signed-off-by: Alain Michaud <alainm@chromium.org>
