### PR TITLE
[PW_SID:325913] [BlueZ] device: Don't mark services resolved on error


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/src/device.c
+++ b/src/device.c
@@ -2596,7 +2596,8 @@ static void device_svc_resolved(struct btd_device *dev, uint8_t browse_type,
 
 	DBG("%s err %d", dev->path, err);
 
-	state->svc_resolved = true;
+	if (err == 0)
+		state->svc_resolved = true;
 
 	/* Disconnection notification can happen before this function
 	 * gets called, so don't set svc_refreshed for a disconnected


### PR DESCRIPTION

This fixes a bug where the service UUIDs were not rediscovered after a
failed bonding attempt because the svc_resolved flag remained set even
though the uuids list was empty.
