### PR TITLE
[PW_SID:335341] Add support for LE profiles (LE-L2CAP)


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/doc/profile-api.txt
+++ b/doc/profile-api.txt
@@ -112,6 +112,16 @@ Object path	/org/bluez
 
 					Profile features (for SDP record)
 
+				uint16 AddressType
+
+					Allows the Address Type to be
+					selected, can be either
+					BDADDR_BREDR, BDADDR_LE_PUBLIC
+					or BDADDR_LE_RANDOM.  If an LE
+					address is selected and the
+					device is not found, the other
+					sort of LE address is tried.
+
 			Possible errors: org.bluez.Error.InvalidArguments
 			                 org.bluez.Error.AlreadyExists
 

--- a/doc/profile-api.txt
+++ b/doc/profile-api.txt
@@ -133,6 +133,19 @@ Object path	/org/bluez
 
 			Possible errors: org.bluez.Error.DoesNotExist
 
+		options GetProfileInfo(object profile, object adapter)
+
+			This returns a dictionary of options for the
+			profile.  Values returned are: UUID, Name,
+			Path, Service, Mode and AddressType.  The
+			adapter parameter is optional - if it is
+			non-empty, then two additional values might be
+			returned, if the profile is active on the
+			specified adapter: PSM and Channel.
+
+			Possible errors: org.bluez.Error.InvalidArguments
+			                 org.bluez.Error.DoesNotExist
+
 
 Profile hierarchy
 =================


### PR DESCRIPTION

I wanted to create a custom profile that used LE-L2CAP, and I found
that there were a couple features missing that I needed.

1)
It is not possible to set the Address Type in the profile.  
2)
It is not possible to discover the "Auto Chosen" PSM value.

The first patch allows the address type to be specified in the DBus
API.

The second patch allows information about the profile to be read back.
This is needed because, on both Andorid and iOS, when using LE-L2CAP,
the application must inform the OS about which PSM to use.  It is
possible for the server to advertise this value with GATT, but the
applciation has to read it from somewhere.


Mark Marshall (2):
src/profile.c: Allow the "Address Type" to be set
src/profile.c: Add a GetProfileInfo method

doc/profile-api.txt |  23 +++++++++
src/profile.c       | 113 +++++++++++++++++++++++++++++++++++++++++++-
2 files changed, 135 insertions(+), 1 deletion(-)
