### PR TITLE
[PW_SID:336221] [BlueZ,1/2] gatt: StartNotify is not allowed when device is disconnecting


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/doc/gatt-api.txt
+++ b/doc/gatt-api.txt
@@ -186,6 +186,7 @@ Methods		array{byte} ReadValue(dict options)
 			Possible Errors: org.bluez.Error.Failed
 					 org.bluez.Error.NotPermitted
 					 org.bluez.Error.InProgress
+					 org.bluez.Error.NotConnected
 					 org.bluez.Error.NotSupported
 
 		void StopNotify()

--- a/src/gatt-client.c
+++ b/src/gatt-client.c
@@ -1545,6 +1545,12 @@ static DBusMessage *characteristic_start_notify(DBusConnection *conn,
 	const char *sender = dbus_message_get_sender(msg);
 	struct async_dbus_op *op;
 	struct notify_client *client;
+	struct btd_device *device = chrc->service->client->device;
+
+	if (device_is_disconnecting(device)) {
+		error("Device is disconnecting. StartNotify is not allowed.");
+		return btd_error_not_connected(msg);
+	}
 
 	if (chrc->notify_io)
 		return btd_error_not_permitted(msg, "Notify acquired");


### PR DESCRIPTION

From: Joseph Hwang <josephsih@chromium.org>

This patch fixed a bluetoothd crash in register_notify_cb(). The
crash is incurred by an exception that under some situation, a
characteristic may be freed when register_notify_cb() is invoked.

When a device is disconnecting, the device interface would hold valid
for a while until the disconnection procedure between the client and
the server is completed. If another process happens to request to start
notification of a characteristic on the disconnecting device, it may
incur a problem. In this case, the client would still send the
StartNotify request since the characteristic object is still valid.
However, the characteristic may be freed soon and become invalid
when the corresponding callback function is invoked later. This
leads to the bluetoothd crash due to the segmentation fault.

To handle the exception, if another process requests to start
notification when the device is disconnecting, it should reject the
request.

Tested on Chrome OS that this patch fixes bluetoothd crash in
register_notify_cb().
