### PR TITLE
[PW_SID:336255] [BlueZ] adapter: remove eir_data.flags in device_update_last_seen()


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -6642,14 +6642,8 @@ static void update_found_devices(struct btd_adapter *adapter,
 
 	device_update_last_seen(dev, bdaddr_type);
 
-	/*
-	 * FIXME: We need to check for non-zero flags first because
-	 * older kernels send separate adv_ind and scan_rsp. Newer
-	 * kernels send them merged, so once we know which mgmt version
-	 * supports this we can make the non-zero check conditional.
-	 */
-	if (bdaddr_type != BDADDR_BREDR && eir_data.flags &&
-					!(eir_data.flags & EIR_BREDR_UNSUP)) {
+	if (bdaddr_type != BDADDR_BREDR &&
+			!(eir_data.flags & EIR_BREDR_UNSUP)) {
 		device_set_bredr_support(dev);
 		/* Update last seen for BR/EDR in case its flag is set */
 		device_update_last_seen(dev, BDADDR_BREDR);


### PR DESCRIPTION

From: Joseph Hwang <josephsih@chromium.org>

Bluez has difficulty in pairing with Apple Airpods. This issue is
caused by the incorrect selection of BD address type due to two factors:

(1) The LE advertising reports emitted by Airpods do not carry eir
data flags.
(2) If the eir data flags is missing, the found device would not be
considered as coming with bredr address for some historical
obsolete reason.

This patch fixes (2) above.

Tested on Chrome OS by pairing with Airpods.
Without this patch, the pairing success rate is about 20%.
With this patch, the pairing success rate becomes almost 100%.
