### PR TITLE
[PW_SID:336257] [BlueZ] gap: Enable the external flag


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/profiles/gap/gas.c
+++ b/profiles/gap/gas.c
@@ -310,6 +310,7 @@ static int gap_disconnect(struct btd_service *service)
 static struct btd_profile gap_profile = {
 	.name		= "gap-profile",
 	.remote_uuid	= GAP_UUID,
+	.external	= true,
 	.device_probe	= gap_probe,
 	.device_remove	= gap_remove,
 	.accept		= gap_accept,


### PR DESCRIPTION

From: Joseph Hwang <josephsih@chromium.org>

This patch enables the external flag for gap so that the gap service can
be exported over D-Bus.

Tested on Chrome OS that this fixes https://crbug.com/722987 so that GAP
API can be propagated to Android apps.

Test Method 1:
- Connect to a peripheral.
- Use dbus methods to query the org.bluez.GattService1
interface in managed objects.
- Confirm that the gap 0x1800 profile was exported like:
GattService1 path: /org/bluez/hci0/dev_xx/service0001
service_props: dbus.String(u'UUID'):
dbus.String(u'00001800-0000-1000-8000-00805f9b34fb'

Test Method 2:
- Install BleManager APK attached in C#0 of https://crbug.com/722987
to ARC++ in a chromebook.
- Launch the application.
- Connect to a Dash robot. Confirm that there are 3 services
instead of 2.

Reviewed-by: Sonny Sasaka <sonnysasaka@chromium.org>
