### PR TITLE
[PW_SID:341117] Mesh HCI interface init scan interval fixed


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/AUTHORS
+++ b/AUTHORS
@@ -107,3 +107,4 @@ Michał Lowas-Rzechonek <michal.lowas-rzechonek@silvair.com>
 Jakub Witowski <jakub.witowski@silvair.com>
 Rafał Gajda <rafal.gajda@silvair.com>
 Szymon Czapracki <szymon.czapracki@codecoup.pl>
+Daan Pape <daan@dptechnics.com>

--- a/mesh/mesh-io-generic.c
+++ b/mesh/mesh-io-generic.c
@@ -213,8 +213,8 @@ static void configure_hci(struct mesh_io_private *io)
 
 	/* Set scan parameters */
 	cmd.type = 0x00; /* Passive Scanning. No scanning PDUs shall be sent */
-	cmd.interval = 0x0030; /* Scan Interval = N * 0.625ms */
-	cmd.window = 0x0030; /* Scan Window = N * 0.625ms */
+	cmd.interval = L_CPU_TO_LE16(0x0010); /* Scan Interval = N * 0.625ms */
+	cmd.window = L_CPU_TO_LE16(0x0010); /* Scan Window = N * 0.625ms */
 	cmd.own_addr_type = 0x00; /* Public Device Address */
 	/* Accept all advertising packets except directed advertising packets
 	 * not addressed to this device (default).


### PR DESCRIPTION

The HCI initialization function of bluetooth-meshd was not converting
to the correct byte order when initializing the LE Scan Parameters. This
is now fixed.

Daan Pape (1):
Mesh HCI interface init scan interval fixed

AUTHORS                | 1 +
mesh/mesh-io-generic.c | 4 ++--
2 files changed, 3 insertions(+), 2 deletions(-)
