### PR TITLE
[PW_SID:341327] [Bluez,v2] device: don't wait for timeout if RemoveDevice is called


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -79,8 +79,6 @@
 #include "advertising.h"
 #include "eir.h"
 
-#define ADAPTER_INTERFACE	"org.bluez.Adapter1"
-
 #define MODE_OFF		0x00
 #define MODE_CONNECTABLE	0x01
 #define MODE_DISCOVERABLE	0x02

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -26,6 +26,8 @@
 #include <dbus/dbus.h>
 #include <glib.h>
 
+#define ADAPTER_INTERFACE	"org.bluez.Adapter1"
+
 #define MAX_NAME_LENGTH		248
 
 /* Invalid SSP passkey value used to indicate negative replies */


### PR DESCRIPTION

From: Archie Pusaka <apusaka@chromium.org>

RemoveDevice on adapter interface used to remove a device, even when
the device is connected. However, since the introduction of the new
30 seconds timeout when setting a device as temporary, RemoveDevice
doesn't immediately remove a connected device, but only disconnects
it and waits for the timer to expire before effectively removes it.

This patch removes the device as soon as it gets disconnected,
provided the disconnection is triggered by a call to RemoveDevice.
The regular timeout still applies for other cases.

Tested manually by calling RemoveDevice on a connected device,
and with ChromeOS autotest setup.

Reviewed-by: Daniel Winkler <danielwinkler@google.com>

Signed-off-by: Archie Pusaka <apusaka@chromium.org>
