### PR TITLE
[PW_SID:350277] [BlueZ] a2dp: Keep track of ref ownership of a2dp_setup


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/profiles/audio/avdtp.h
+++ b/profiles/audio/avdtp.h
@@ -260,6 +260,9 @@ gboolean avdtp_stream_has_capabilities(struct avdtp_stream *stream,
 					GSList *caps);
 struct avdtp_remote_sep *avdtp_stream_get_remote_sep(
 						struct avdtp_stream *stream);
+void avdtp_stream_set_pending_open_data(struct avdtp_stream *stream,
+					void *data);
+void *avdtp_stream_get_pending_open_data(struct avdtp_stream *stream);
 
 unsigned int avdtp_add_state_cb(struct btd_device *dev,
 				avdtp_session_state_cb cb, void *user_data);


### PR DESCRIPTION

Currently transport_cb and abort_cfm make assumption that they have an
a2dp_setup reference held as a result of open_ind invocation. In the
field this is not always true, for example when the peer device opens an
L2CAP channel for AVDTP transport channel without sending AVDTP_OPEN
request through the AVDTP signaling channel first. Although in this case
the peer device does not behave correctly, we should protect this
possible crash from happening by making sure that transport_cb and
abort_cfm are really holding a reference of a2dp_setup object before
trying to unref them.

After grabbing a reference, open_ind stores the pointer in
stream->pending_open_data. If this field is set, that means there is a
pending AVDTP_OPEN command and it needs to be unref-fed later once and
only once: when the transport channel is created (transport_cb) or when
the AVDTP_OPEN command is aborted (abort_cfm). If this field is not set,
nothing should unref it. This enforces that the reference counting is
correct regardless of the behavior of the peer device.

A sample crash stack trace from Chrome OS:
* thread #1, stop reason = signal SIGSEGV
* frame #0: 0x0c64f0e8 bluetoothd`queue_remove_all at queue.c:351
frame #1: 0x0c64f086 bluetoothd`queue_destroy at queue.c:73
frame #2: 0x0c6022b0 bluetoothd`setup_unref at a2dp.c:222
frame #3: 0x0c604942 bluetoothd`transport_cb at a2dp.c:2229
frame #4: 0x0c61e35c bluetoothd`accept_cb at btio.c:203
frame #5: 0xf679523c libglib-2.0.so.0`g_main_context_dispatch at gmain.c:3182
frame #6: 0xf67954aa libglib-2.0.so.0`g_main_context_iterate at gmain.c:3920
frame #7: 0xf679569a libglib-2.0.so.0`g_main_loop_run at gmain.c:4116
frame #8: 0x0c65a5a0 bluetoothd`mainloop_run at mainloop-glib.c:79
frame #9: 0x0c65a7ea bluetoothd`mainloop_run_with_signal at mainloop-notify.c:201
frame #10: 0x0c6477ec bluetoothd`main at main.c:772
frame #11: 0xf65bc0a2 libc.so.6`__libc_start_main at libc-start.c:308
