### PR TITLE
[PW_SID:356703] [Bluez] hog: null-check attrib channel at report_map_read_cb


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/profiles/input/hog-lib.c
+++ b/profiles/input/hog-lib.c
@@ -932,6 +932,7 @@ static void report_map_read_cb(guint8 status, const guint8 *pdu, guint16 plen,
 	char itemstr[20]; /* 5x3 (data) + 4 (continuation) + 1 (null) */
 	int i, err;
 	GError *gerr = NULL;
+	GIOChannel *io = NULL;
 
 	destroy_gatt_req(req);
 
@@ -975,7 +976,13 @@ static void report_map_read_cb(guint8 status, const guint8 *pdu, guint16 plen,
 	memset(&ev, 0, sizeof(ev));
 	ev.type = UHID_CREATE;
 
-	bt_io_get(g_attrib_get_channel(hog->attrib), &gerr,
+	io = g_attrib_get_channel(hog->attrib);
+	if (!io) {
+		error("Get channel failed");
+		return;
+	}
+
+	bt_io_get(io, &gerr,
 			BT_IO_OPT_SOURCE, ev.u.create.phys,
 			BT_IO_OPT_DEST, ev.u.create.uniq,
 			BT_IO_OPT_INVALID);


### PR DESCRIPTION

According to user reported crash dumps, function 'report_map_read_cb'
can pass down a null channel pointer, which will cause a segfault later
at g_io_channel_unix_get_fd upon dereferencing. Add null check to
prevent crashes.

thread #1, stop reason = signal SIGSEGV
frame #0: 0x00007ac089e199f7 libglib-2.0.so.0`g_io_channel_unix_get_fd at giounix.c:655
frame #1: 0x00005cdb60776a52 bluetoothd`bt_io_get_type at btio.c:105
frame #2: 0x00005cdb60777224 bluetoothd`bt_io_get at btio.c:1548
frame #3: 0x00005cdb607706ca bluetoothd`report_map_read_cb at hog-lib.c:993
frame #4: 0x00005cdb60775a60 bluetoothd`read_blob_helper at gatt.c:804
frame #5: 0x00005cdb60775f13 bluetoothd`attrib_callback_result at gattrib.c:273
frame #6: 0x00005cdb607bf30b bluetoothd`can_read_data at att.c:820
frame #7: 0x00005cdb607ca58f bluetoothd`watch_callback at io-glib.c:170
frame #8: 0x00007ac089dda73b libglib-2.0.so.0`g_main_context_dispatch at gmain.c:3182
frame #9: 0x00007ac089ddaa5a libglib-2.0.so.0`g_main_context_iterate at gmain.c:3920
frame #10: 0x00007ac089ddac9f libglib-2.0.so.0`g_main_loop_run at gmain.c:4116
frame #11: 0x00005cdb607ca712 bluetoothd`mainloop_run at mainloop-glib.c:79
frame #12: 0x00005cdb607ca9fe bluetoothd`mainloop_run_with_signal at mainloop-notify.c:201
frame #13: 0x00005cdb607b04bb bluetoothd`main at main.c:969
frame #14: 0x00007ac0894c0ad4 libc.so.6`__libc_start_main at libc-start.c:308
frame #15: 0x00005cdb6074eb0a bluetoothd`_start + 42

Reviewed-by: Abhishek Pandit-Subedi <abhishekpandit@chromium.org>
Reviewed-by: Archie Pusaka <apusaka@chromium.org>
Signed-off-by: Michael Sun <michaelfsun@google.com>
