### PR TITLE
[PW_SID:359581] [BlueZ] shared/timeout-ell: Fix timeout wrapper implementation


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/src/shared/timeout-ell.c
+++ b/src/shared/timeout-ell.c
@@ -12,12 +12,22 @@
 
 #include "timeout.h"
 
+static struct l_queue *timeout_q;
+
 struct timeout_data {
 	timeout_func_t func;
 	timeout_destroy_func_t destroy;
-	unsigned int timeout;
 	void *user_data;
+	unsigned int timeout;
 };
+
+static bool match_id(const void *a, const void *b)
+{
+	unsigned int to_id = L_PTR_TO_UINT(a);
+	unsigned int id = L_PTR_TO_UINT(b);
+
+	return (to_id == id);
+}
 
 static void timeout_callback(struct l_timeout *timeout, void *user_data)
 {
@@ -43,7 +53,12 @@ unsigned int timeout_add(unsigned int timeout, timeout_func_t func,
 			void *user_data, timeout_destroy_func_t destroy)
 {
 	struct timeout_data *data;
-	uint32_t id;
+	unsigned int id = 0;
+	struct l_timeout *to;
+	int tries = 0;
+
+	if (!timeout_q)
+		timeout_q = l_queue_new();
 
 	data = l_new(struct timeout_data, 1);
 
@@ -52,12 +67,37 @@ unsigned int timeout_add(unsigned int timeout, timeout_func_t func,
 	data->user_data = user_data;
 	data->timeout = timeout;
 
-	id = L_PTR_TO_UINT(l_timeout_create(timeout, timeout_callback,
-						user_data, timeout_destroy));
+	while (id == 0 && tries < 3) {
+		to = l_timeout_create(timeout, timeout_callback,
+							data, timeout_destroy);
+		if (!to)
+			break;
+
+		tries++;
+		id = L_PTR_TO_UINT(to);
+
+		if (id == 0 ||
+			l_queue_find(timeout_q, match_id, L_UINT_TO_PTR(id))) {
+
+			l_timeout_remove(to);
+			continue;
+		}
+
+		l_queue_push_tail(timeout_q, to);
+	}
+
+	if (id == 0)
+		l_free(data);
+
 	return id;
 }
 
 void timeout_remove(unsigned int id)
 {
-	l_timeout_remove(L_UINT_TO_PTR(id));
+	struct l_timeout *to;
+
+	to = l_queue_remove_if(timeout_q, match_id, L_UINT_TO_PTR(id));
+
+	if (to)
+		l_timeout_remove(to);
 }


### PR DESCRIPTION

This fixes the following issues:
- Correct user data is passed around to l_timeout_create():
locally allocated timeout data is a valid "user data" to
associate with a newly created timeout. Previously, user_data
passed as an argument to timeout_add() was incorrectly used as
an argument to l_timeout_create()
- To maintain common API and work around the issue when the conversion
of a pointer to an unsigned int truncates the initial value, a queue
of active timeouts is maintained where pointer each l_timeout structure
is associate with a unique id. This id is returned when timeout_create()
API is called and can be subsequently used with timeout_remove().
