### PR TITLE
[PW_SID:360353] [BlueZ,v3] tools: fix forgotten index->mgmt_index renaming in btmgmt.c


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/tools/btmgmt.c
+++ b/tools/btmgmt.c
@@ -1212,8 +1212,9 @@ static void cmd_config(int argc, char **argv)
 		return;
 	}
 
-	if (!mgmt_send(mgmt, MGMT_OP_READ_CONFIG_INFO, mgmt_index, 0, NULL,
-				config_info_rsp, UINT_TO_PTR(index), NULL)) {
+	if (!mgmt_send(mgmt, MGMT_OP_READ_CONFIG_INFO, mgmt_index,
+				0, NULL, config_info_rsp,
+				UINT_TO_PTR(mgmt_index), NULL)) {
 		error("Unable to send read_config_info cmd");
 		return bt_shell_noninteractive_quit(EXIT_FAILURE);
 	}


### PR DESCRIPTION

Commit 6523d168a7c1 ("tools/btmgmt: Port to use bt_shell") seem to
have missed this.  When trying to compile bluez I get:

```
tools/btmgmt.c:1229:34: warning: implicitly declaring library function 'index' \
with type 'char *(const char *, int)' [-Wimplicit-function-declaration]
config_info_rsp, UINT_TO_PTR(index), NULL)) {
^
tools/btmgmt.c:1229:34: note: include the header <strings.h> or explicitly \
provide a declaration for 'index'
[...]
aarch64-linux-android-ld: tools/btmgmt.o: in function `cmd_config':
btmgmt.c:(.text+0x544): undefined reference to `index'
aarch64-linux-android-ld: btmgmt.c:(.text+0x548): undefined reference to `index'
```

Probably only happens on system (like android) where the obsolete
index function does not exist.
