### PR TITLE
[PW_SID:360615] [BlueZ] adv_monitor: parse AD type as hex value


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/client/adv_monitor.c
+++ b/client/adv_monitor.c
@@ -435,7 +435,7 @@ static struct pattern *parse_pattern(char *parameter_list[])
 	}
 
 	pat->start_pos = atoi(parameter_list[0]);
-	pat->ad_data_type = atoi(parameter_list[1]);
+	pat->ad_data_type = strtol(parameter_list[1], NULL, 16);
 	pat->content_len = str2bytearray(parameter_list[2], pat->content);
 	if (pat->content_len == 0) {
 		free_pattern(pat);
@@ -542,7 +542,7 @@ static void print_adv_monitor(struct adv_monitor *adv_monitor)
 			bt_shell_printf("\tpattern %d:\n", idx);
 			bt_shell_printf("\t\tstart position: %hhu\n",
 							pattern->start_pos);
-			bt_shell_printf("\t\tAD data type: %hhu\n",
+			bt_shell_printf("\t\tAD data type: 0x%02x\n",
 							pattern->ad_data_type);
 			print_bytearray("\t\tcontent: ", pattern->content,
 							pattern->content_len);

--- a/client/main.c
+++ b/client/main.c
@@ -2724,6 +2724,8 @@ static void print_add_or_pattern_with_rssi_usage(void)
 						RSSI_DEFAULT_HIGH_TIMEOUT);
 	bt_shell_printf("pattern format:\n"
 			"\t<start_position> <ad_data_type> <content_of_pattern>\n");
+	bt_shell_printf("Note: both ad_data_type and content_of_pattern are "
+			"hex string\n");
 	bt_shell_printf("e.g.\n"
 			"\tadd-or-pattern-rssi -10, ,10 1 2 01ab55\n");
 	bt_shell_printf("or\n"
@@ -2734,6 +2736,8 @@ static void print_add_or_pattern_usage(void)
 {
 	bt_shell_printf("pattern format:\n"
 			"\t<start_position> <ad_data_type> <content_of_pattern>\n");
+	bt_shell_printf("Note: both ad_data_type and content_of_pattern are "
+			"hex string\n");
 	bt_shell_printf("e.g.\n"
 			"\tadd-or-pattern 1 2 01ab55 3 4 23cd66\n");
 }


### PR DESCRIPTION

Currently bluetoothctl parse pattern as a decimal string, but the
Bluetooth SIG website uses hex value instead.
(https://www.bluetooth.com/specifications/assigned-numbers/generic-access-
profile/)

Reviewed-by: Manish Mandlik <mmandlik@chromium.org>
