### PR TITLE
[PW_SID:364897] 100% CPU usage on keyboard disconnect


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/attrib/interactive.c
+++ b/attrib/interactive.c
@@ -51,6 +51,7 @@ static int opt_psm = 0;
 static int opt_mtu = 0;
 static int start;
 static int end;
+static guint gsrc;
 
 static void cmd_help(int argcp, char **argvp);
 
@@ -180,6 +181,7 @@ static void disconnect_io()
 	attrib = NULL;
 	opt_mtu = 0;
 
+	g_source_remove(gsrc);
 	g_io_channel_shutdown(iochannel, FALSE, NULL);
 	g_io_channel_unref(iochannel);
 	iochannel = NULL;
@@ -402,7 +404,7 @@ static void cmd_connect(int argcp, char **argvp)
 		error("%s\n", gerr->message);
 		g_error_free(gerr);
 	} else
-		g_io_add_watch(iochannel, G_IO_HUP, channel_watcher, NULL);
+		gsrc = g_io_add_watch(iochannel, G_IO_HUP, channel_watcher, NULL);
 }
 
 static void cmd_disconnect(int argcp, char **argvp)

--- a/profiles/input/device.c
+++ b/profiles/input/device.c
@@ -1097,7 +1097,8 @@ static int hidp_add_connection(struct input_device *idev)
 		}
 
 		idev->req = req;
-		idev->sec_watch = g_io_add_watch(idev->intr_io, G_IO_OUT,
+		if (!idev->sec_watch)
+			idev->sec_watch = g_io_add_watch(idev->intr_io, G_IO_IN,
 							encrypt_notify, idev);
 
 		return 0;


### PR DESCRIPTION

There are a couple of issues with g_io_channel usage in bluez which
cause CPUs to spin on half-closed channels.

This patch fixes bugs where bluetooth keyboards fail to work on initial
connection, and cause 100% cpu on disconnect.

Also fix bug with similar symptoms triggered by some other HID devices
such as Sony PS3 BD Remotes.

In the previous discussion on the kernel bugzilla below, it was
suggested to remove sec_watch, and I attached a follow-up patch to do
so, however that change causes problems with current bluez-5 releases
where a fd is used after being closed.

See https://bugzilla.kernel.org/show_bug.cgi?id=204275

Signed-off-by: Steven Newbury <steve@snewbury.org.uk>
