### PR TITLE
[PW_SID:367425] [Bluez] device: fix temporary_timer double free


### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -4477,8 +4477,10 @@ void device_remove(struct btd_device *device, gboolean remove_stored)
 		disconnect_all(device);
 	}
 
-	if (device->temporary_timer > 0)
+	if (device->temporary_timer > 0) {
 		g_source_remove(device->temporary_timer);
+		device->temporary_timer = 0;
+	}
 
 	if (device->store_id > 0) {
 		g_source_remove(device->store_id);


### PR DESCRIPTION

From: Archie Pusaka <apusaka@chromium.org>

One instance of freeing temporary_timer is not followed by setting
the variable to 0, causing potential double free.

Reviewed-by: Yun-Hao Chung <howardchung@google.com>
