### PR TITLE
[PW_SID:370939] [BlueZ] tools/mesh-cfgclient: Fix errors found by static analysis


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/tools/mesh/cfgcli.c
+++ b/tools/mesh/cfgcli.c
@@ -410,8 +410,8 @@ static bool msg_recvd(uint16_t src, uint16_t idx, uint8_t *data,
 	req = get_req_by_rsp(src, opcode);
 	if (req) {
 		cmd = req->cmd;
-		free_request(req);
 		l_queue_remove(requests, req);
+		free_request(req);
 	} else
 		cmd = NULL;
 
@@ -1470,14 +1470,13 @@ static void subscription_cmd(int argc, char *argv[], uint32_t opcode)
 
 	grp = l_queue_find(groups, match_group_addr, L_UINT_TO_PTR(sub_addr));
 
-	if (!grp && opcode != OP_CONFIG_MODEL_SUB_DELETE) {
-		grp = add_group(sub_addr);
-
-		if (!grp && IS_VIRTUAL(sub_addr)) {
-			print_virtual_not_found(sub_addr);
-			return bt_shell_noninteractive_quit(EXIT_FAILURE);
-		}
+	if (!grp && IS_VIRTUAL(sub_addr)) {
+		print_virtual_not_found(sub_addr);
+		return bt_shell_noninteractive_quit(EXIT_FAILURE);
 	}
+
+	if (!grp && opcode != OP_CONFIG_MODEL_SUB_DELETE)
+		grp = add_group(sub_addr);
 
 	if (IS_VIRTUAL(sub_addr)) {
 		if (opcode == OP_CONFIG_MODEL_SUB_ADD)


### PR DESCRIPTION

This fixes a NULL pointer dereference error in subscription_cmd().

Also re-order calling sequence for l_free() & l_queue_remove()
in msg_recvd(): even though technically it is not a bug to pass
a value of a freed pointer to l_queue_remove(), it's a poor form
and confuses the analyzer.
