### PR TITLE
[PW_SID:372435] [Bluez] adapter: Use initial temporary status to decide device removal


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -8877,6 +8877,7 @@ static void connect_failed_callback(uint16_t index, uint16_t length,
 	struct btd_adapter *adapter = user_data;
 	struct btd_device *device;
 	char addr[18];
+	bool initially_temporary = true;
 
 	if (length < sizeof(*ev)) {
 		btd_error(adapter->dev_id, "Too small connect failed event");
@@ -8897,6 +8898,11 @@ static void connect_failed_callback(uint16_t index, uint16_t length,
 		 * request structure. */
 		if (device_is_bonding(device, NULL))
 			device_cancel_authentication(device, FALSE);
+
+		/* Store whether device is temporary before the attribute is
+		 * cleared in bonding_attempt_complete
+		 */
+		initially_temporary = device_is_temporary(device);
 	}
 
 	/* In the case of security mode 3 devices */
@@ -8914,8 +8920,7 @@ static void connect_failed_callback(uint16_t index, uint16_t length,
 
 	/* In the case the bonding was canceled or did exists, remove the device
 	 * when it is temporary. */
-	if (device && !device_is_bonding(device, NULL)
-						&& device_is_temporary(device))
+	if (device && !device_is_bonding(device, NULL) && initially_temporary)
 		btd_adapter_remove_device(adapter, device);
 }
 


### PR DESCRIPTION

When a connection fails, the temporary attribute of the device is used
to decide if the device should be removed altogether. However, a recent
change to device_bonding_complete resets the temporary attribute so that
it will be treated as a new device which will eventually time out. A
side effect, though, is that the device will now always be removed in
connect_failed_callback immediately, regardless of whether the device
was marked as temporary to begin with.

This change stores the device's temporary attribute before
device_bonding_complete is called to ensure it is only removed if the
device was temporary to begin with. Otherwise it will timeout, as I
think the author intended.

Reviewed-by: Abhishek Pandit-Subedi <abhishekpandit@chromium.org>
