### PR TITLE
[PW_SID:373507] [BlueZ,1/3] emulator/btdev: Add debug support


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/emulator/btdev.h
+++ b/emulator/btdev.h
@@ -66,6 +66,11 @@ struct btdev;
 struct btdev *btdev_create(enum btdev_type type, uint16_t id);
 void btdev_destroy(struct btdev *btdev);
 
+typedef void (*btdev_debug_func_t)(const char *str, void *user_data);
+typedef void (*btdev_destroy_func_t)(void *user_data);
+bool btdev_set_debug(struct btdev *btdev, btdev_debug_func_t callback,
+			void *user_data, btdev_destroy_func_t destroy);
+
 const uint8_t *btdev_get_bdaddr(struct btdev *btdev);
 uint8_t *btdev_get_features(struct btdev *btdev);
 

--- a/emulator/bthost.c
+++ b/emulator/bthost.c
@@ -24,6 +24,7 @@
 #include "lib/bluetooth.h"
 
 #include "src/shared/util.h"
+#include "src/shared/tester.h"
 #include "monitor/bt.h"
 #include "monitor/rfcomm.h"
 #include "bthost.h"
@@ -213,6 +214,10 @@ struct bthost {
 	bool conn_init;
 	bool le;
 	bool sc;
+
+	bthost_debug_func_t debug_callback;
+	bthost_destroy_func_t debug_destroy;
+	void *debug_data;
 };
 
 struct bthost *bthost_create(void)
@@ -487,8 +492,19 @@ static void queue_command(struct bthost *bthost, const struct iovec *iov,
 static void send_packet(struct bthost *bthost, const struct iovec *iov,
 								int iovlen)
 {
+	int i;
+
 	if (!bthost->send_handler)
 		return;
+
+	for (i = 0; i < iovlen; i++) {
+		if (!i)
+			util_hexdump('<', iov[i].iov_base, iov[i].iov_len,
+				bthost->debug_callback, bthost->debug_data);
+		else
+			util_hexdump(' ', iov[i].iov_base, iov[i].iov_len,
+				bthost->debug_callback, bthost->debug_data);
+	}
 
 	bthost->send_handler(iov, iovlen, bthost->send_data);
 }
@@ -675,6 +691,9 @@ static void send_command(struct bthost *bthost, uint16_t opcode,
 	uint8_t pkt = BT_H4_CMD_PKT;
 	struct iovec iov[3];
 
+	util_debug(bthost->debug_callback, bthost->debug_data,
+				"command 0x%02x", opcode);
+
 	iov[0].iov_base = &pkt;
 	iov[0].iov_len = sizeof(pkt);
 
@@ -759,6 +778,22 @@ void bthost_notify_ready(struct bthost *bthost, bthost_ready_cb cb)
 	bthost->ready_cb = cb;
 }
 
+bool bthost_set_debug(struct bthost *bthost, bthost_debug_func_t callback,
+			void *user_data, bthost_destroy_func_t destroy)
+{
+	if (!bthost)
+		return false;
+
+	if (bthost->debug_destroy)
+		bthost->debug_destroy(bthost->debug_data);
+
+	bthost->debug_callback = callback;
+	bthost->debug_destroy = destroy;
+	bthost->debug_data = user_data;
+
+	return true;
+}
+
 static void read_local_features_complete(struct bthost *bthost,
 						const void *data, uint8_t len)
 {
@@ -835,7 +870,8 @@ static void evt_cmd_complete(struct bthost *bthost, const void *data,
 	case BT_HCI_CMD_LE_SET_EXT_ADV_ENABLE:
 		break;
 	default:
-		printf("Unhandled cmd_complete opcode 0x%04x\n", opcode);
+		util_debug(bthost->debug_callback, bthost->debug_data,
+				"Unhandled cmd_complete opcode 0x%04x", opcode);
 		break;
 	}
 
@@ -1259,7 +1295,8 @@ static void evt_le_meta_event(struct bthost *bthost, const void *data,
 		evt_le_ext_conn_complete(bthost, evt_data, len - 1);
 		break;
 	default:
-		printf("Unsupported LE Meta event 0x%2.2x\n", *event);
+		util_debug(bthost->debug_callback, bthost->debug_data,
+				"Unsupported LE Meta event 0x%2.2x", *event);
 		break;
 	}
 }
@@ -1276,6 +1313,9 @@ static void process_evt(struct bthost *bthost, const void *data, uint16_t len)
 		return;
 
 	param = data + sizeof(*hdr);
+
+	util_debug(bthost->debug_callback, bthost->debug_data,
+				"event 0x%04x", hdr->evt);
 
 	switch (hdr->evt) {
 	case BT_HCI_EVT_CMD_COMPLETE:
@@ -1343,7 +1383,8 @@ static void process_evt(struct bthost *bthost, const void *data, uint16_t len)
 		break;
 
 	default:
-		printf("Unsupported event 0x%2.2x\n", hdr->evt);
+		util_debug(bthost->debug_callback, bthost->debug_data,
+				"Unsupported event 0x%2.2x", hdr->evt);
 		break;
 	}
 }
@@ -1674,7 +1715,8 @@ static void l2cap_sig(struct bthost *bthost, struct btconn *conn,
 		break;
 
 	default:
-		printf("Unknown L2CAP code 0x%02x\n", hdr->code);
+		util_debug(bthost->debug_callback, bthost->debug_data,
+				"Unknown L2CAP code 0x%02x", hdr->code);
 		ret = false;
 	}
 
@@ -1892,7 +1934,8 @@ static void l2cap_le_sig(struct bthost *bthost, struct btconn *conn,
 		break;
 
 	default:
-		printf("Unknown L2CAP code 0x%02x\n", hdr->code);
+		util_debug(bthost->debug_callback, bthost->debug_data,
+				"Unknown L2CAP code 0x%02x", hdr->code);
 		ret = false;
 	}
 
@@ -2232,7 +2275,8 @@ static void process_rfcomm(struct bthost *bthost, struct btconn *conn,
 		rfcomm_uih_recv(bthost, conn, l2conn, data, len);
 		break;
 	default:
-		printf("Unknown frame type\n");
+		util_debug(bthost->debug_callback, bthost->debug_data,
+					"Unknown frame type");
 		break;
 	}
 }
@@ -2257,7 +2301,8 @@ static void process_acl(struct bthost *bthost, const void *data, uint16_t len)
 	handle = acl_handle(acl_hdr->handle);
 	conn = bthost_find_conn(bthost, handle);
 	if (!conn) {
-		printf("ACL data for unknown handle 0x%04x\n", handle);
+		util_debug(bthost->debug_callback, bthost->debug_data,
+				"ACL data for unknown handle 0x%04x", handle);
 		return;
 	}
 
@@ -2293,8 +2338,9 @@ static void process_acl(struct bthost *bthost, const void *data, uint16_t len)
 		if (l2conn && l2conn->psm == 0x0003)
 			process_rfcomm(bthost, conn, l2conn, l2_data, l2_len);
 		else
-			printf("Packet for unknown CID 0x%04x (%u)\n", cid,
-									cid);
+			util_debug(bthost->debug_callback, bthost->debug_data,
+					"Packet for unknown CID 0x%04x (%u)",
+					cid, cid);
 		break;
 	}
 }
@@ -2309,6 +2355,9 @@ void bthost_receive_h4(struct bthost *bthost, const void *data, uint16_t len)
 	if (len < 1)
 		return;
 
+	util_hexdump('>', data, len, bthost->debug_callback,
+					bthost->debug_data);
+
 	pkt_type = ((const uint8_t *) data)[0];
 
 	switch (pkt_type) {
@@ -2319,7 +2368,8 @@ void bthost_receive_h4(struct bthost *bthost, const void *data, uint16_t len)
 		process_acl(bthost, data + 1, len - 1);
 		break;
 	default:
-		printf("Unsupported packet 0x%2.2x\n", pkt_type);
+		util_debug(bthost->debug_callback, bthost->debug_data,
+				"Unsupported packet 0x%2.2x", pkt_type);
 		break;
 	}
 }

--- a/emulator/bthost.h
+++ b/emulator/bthost.h
@@ -23,6 +23,11 @@ void bthost_destroy(struct bthost *bthost);
 typedef void (*bthost_ready_cb) (void);
 void bthost_notify_ready(struct bthost *bthost, bthost_ready_cb cb);
 
+typedef void (*bthost_debug_func_t)(const char *str, void *user_data);
+typedef void (*bthost_destroy_func_t)(void *user_data);
+bool bthost_set_debug(struct bthost *bthost, bthost_debug_func_t callback,
+			void *user_data, bthost_destroy_func_t destroy);
+
 void bthost_set_send_handler(struct bthost *bthost, bthost_send_func handler,
 							void *user_data);
 

--- a/emulator/hciemu.c
+++ b/emulator/hciemu.c
@@ -45,6 +45,10 @@ struct hciemu {
 	guint client_source;
 	struct queue *post_command_hooks;
 	char bdaddr_str[18];
+
+	hciemu_debug_func_t debug_callback;
+	hciemu_destroy_func_t debug_destroy;
+	void *debug_data;
 };
 
 struct hciemu_command_hook {
@@ -383,6 +387,50 @@ void hciemu_unref(struct hciemu *hciemu)
 	btdev_destroy(hciemu->master_dev);
 
 	free(hciemu);
+}
+
+static void bthost_debug(const char *str, void *user_data)
+{
+	struct hciemu *hciemu = user_data;
+
+	util_debug(hciemu->debug_callback, hciemu->debug_data,
+					"bthost: %s", str);
+}
+
+static void btdev_master_debug(const char *str, void *user_data)
+{
+	struct hciemu *hciemu = user_data;
+
+	util_debug(hciemu->debug_callback, hciemu->debug_data,
+					"btdev[0]: %s", str);
+}
+
+static void btdev_client_debug(const char *str, void *user_data)
+{
+	struct hciemu *hciemu = user_data;
+
+	util_debug(hciemu->debug_callback, hciemu->debug_data,
+					"btdev[1]: %s", str);
+}
+
+bool hciemu_set_debug(struct hciemu *hciemu, hciemu_debug_func_t callback,
+			void *user_data, hciemu_destroy_func_t destroy)
+{
+	if (!hciemu)
+		return false;
+
+	if (hciemu->debug_destroy)
+		hciemu->debug_destroy(hciemu->debug_data);
+
+	hciemu->debug_callback = callback;
+	hciemu->debug_destroy = destroy;
+	hciemu->debug_data = user_data;
+
+	btdev_set_debug(hciemu->master_dev, btdev_master_debug, hciemu, NULL);
+	btdev_set_debug(hciemu->client_dev, btdev_client_debug, hciemu, NULL);
+	bthost_set_debug(hciemu->host_stack, bthost_debug, hciemu, NULL);
+
+	return true;
 }
 
 const char *hciemu_get_address(struct hciemu *hciemu)

--- a/emulator/hciemu.h
+++ b/emulator/hciemu.h
@@ -34,6 +34,11 @@ struct hciemu *hciemu_new(enum hciemu_type type);
 struct hciemu *hciemu_ref(struct hciemu *hciemu);
 void hciemu_unref(struct hciemu *hciemu);
 
+typedef void (*hciemu_debug_func_t)(const char *str, void *user_data);
+typedef void (*hciemu_destroy_func_t)(void *user_data);
+bool hciemu_set_debug(struct hciemu *hciemu, hciemu_debug_func_t callback,
+			void *user_data, hciemu_destroy_func_t destroy);
+
 struct bthost *hciemu_client_get_host(struct hciemu *hciemu);
 
 const char *hciemu_get_address(struct hciemu *hciemu);


### PR DESCRIPTION

From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This adds btdev_set_debug which can be used to debug internals of
btdev.
