### PR TITLE
[PW_SID:373895] [BlueZ,v2,1/3] core: Add parmas to set interleaving durations


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -4187,157 +4187,157 @@ static void load_default_system_params(struct btd_adapter *adapter)
 	}
 
 	if (btd_opts.defaults.br.page_scan_win) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0002,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0002,
 					&btd_opts.defaults.br.page_scan_win))
 			goto done;
 	}
 
 	if (btd_opts.defaults.br.scan_type != 0xFFFF) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0003,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0003,
 					&btd_opts.defaults.br.scan_type))
 			goto done;
 	}
 
 	if (btd_opts.defaults.br.scan_interval) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0004,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0004,
 					&btd_opts.defaults.br.scan_interval))
 			goto done;
 	}
 
 	if (btd_opts.defaults.br.scan_win) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0005,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0005,
 					&btd_opts.defaults.br.scan_win))
 			goto done;
 	}
 
 	if (btd_opts.defaults.br.link_supervision_timeout) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0006,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0006,
 			&btd_opts.defaults.br.link_supervision_timeout))
 			goto done;
 	}
 
 	if (btd_opts.defaults.br.page_timeout) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0007,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0007,
 					&btd_opts.defaults.br.page_timeout))
 			goto done;
 	}
 
 	if (btd_opts.defaults.br.min_sniff_interval) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0008,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0008,
 				&btd_opts.defaults.br.min_sniff_interval))
 			goto done;
 	}
 
 	if (btd_opts.defaults.br.max_sniff_interval) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0009,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0009,
 				&btd_opts.defaults.br.max_sniff_interval))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.min_adv_interval) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x000a,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x000a,
 				&btd_opts.defaults.le.min_adv_interval))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.max_adv_interval) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x000b,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x000b,
 				&btd_opts.defaults.le.max_adv_interval))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.adv_rotation_interval) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x000c,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x000c,
 				&btd_opts.defaults.le.adv_rotation_interval))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.scan_interval_autoconnect) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x000d,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x000d,
 			&btd_opts.defaults.le.scan_interval_autoconnect))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.scan_win_autoconnect) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x000e,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x000e,
 				&btd_opts.defaults.le.scan_win_autoconnect))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.scan_interval_suspend) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x000f,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x000f,
 				&btd_opts.defaults.le.scan_interval_suspend))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.scan_win_suspend) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0010,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0010,
 				&btd_opts.defaults.le.scan_win_suspend))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.scan_interval_discovery) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0011,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0011,
 				&btd_opts.defaults.le.scan_interval_discovery))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.scan_win_discovery) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0012,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0012,
 				&btd_opts.defaults.le.scan_win_discovery))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.scan_interval_adv_monitor) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0013,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0013,
 			&btd_opts.defaults.le.scan_interval_adv_monitor))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.scan_win_adv_monitor) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0014,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0014,
 				&btd_opts.defaults.le.scan_win_adv_monitor))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.scan_interval_connect) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0015,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0015,
 				&btd_opts.defaults.le.scan_interval_connect))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.scan_win_connect) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0016,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0016,
 				&btd_opts.defaults.le.scan_win_connect))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.min_conn_interval) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0017,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0017,
 				&btd_opts.defaults.le.min_conn_interval))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.max_conn_interval) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0018,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0018,
 				&btd_opts.defaults.le.max_conn_interval))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.conn_latency) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x0019,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x0019,
 					&btd_opts.defaults.le.conn_latency))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.conn_lsto) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x001a,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x001a,
 					&btd_opts.defaults.le.conn_lsto))
 			goto done;
 	}
 
 	if (btd_opts.defaults.le.autoconnect_timeout) {
-		if (mgmt_tlv_add_fixed(tlv_list, 0x001b,
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x001b,
 				&btd_opts.defaults.le.autoconnect_timeout))
 			goto done;
 	}

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -4354,6 +4354,12 @@ static void load_default_system_params(struct btd_adapter *adapter)
 			goto done;
 	}
 
+	if (btd_opts.defaults.le.enable_advmon_interleave_scan != 0xFF) {
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x001f,
+				&btd_opts.defaults.le.enable_advmon_interleave_scan))
+			goto done;
+	}
+
 	err = mgmt_send_tlv(adapter->mgmt, MGMT_OP_SET_DEF_SYSTEM_CONFIG,
 			adapter->dev_id, tlv_list, NULL, NULL, NULL);
 

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -4342,6 +4342,18 @@ static void load_default_system_params(struct btd_adapter *adapter)
 			goto done;
 	}
 
+	if (btd_opts.defaults.le.advmon_allowlist_scan_duration) {
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x001d,
+				&btd_opts.defaults.le.advmon_allowlist_scan_duration))
+			goto done;
+	}
+
+	if (btd_opts.defaults.le.advmon_no_filter_scan_duration) {
+		if (!mgmt_tlv_add_fixed(tlv_list, 0x001e,
+				&btd_opts.defaults.le.advmon_no_filter_scan_duration))
+			goto done;
+	}
+
 	err = mgmt_send_tlv(adapter->mgmt, MGMT_OP_SET_DEF_SYSTEM_CONFIG,
 			adapter->dev_id, tlv_list, NULL, NULL, NULL);
 

--- a/src/btd.h
+++ b/src/btd.h
@@ -71,6 +71,9 @@ struct btd_le_defaults {
 	uint16_t	conn_latency;
 	uint16_t	conn_lsto;
 	uint16_t	autoconnect_timeout;
+
+	uint16_t	advmon_allowlist_scan_duration;
+	uint16_t	advmon_no_filter_scan_duration;
 };
 
 struct btd_defaults {

--- a/src/btd.h
+++ b/src/btd.h
@@ -74,6 +74,7 @@ struct btd_le_defaults {
 
 	uint16_t	advmon_allowlist_scan_duration;
 	uint16_t	advmon_no_filter_scan_duration;
+	uint8_t		enable_advmon_interleave_scan;
 };
 
 struct btd_defaults {

--- a/src/main.c
+++ b/src/main.c
@@ -114,6 +114,8 @@ static const char *le_options[] = {
 	"ConnectionLatency",
 	"ConnectionSupervisionTimeout",
 	"Autoconnecttimeout",
+	"AdvMonAllowlistScanDuration",
+	"AdvMonNoFilterScanDuration",
 	NULL
 };
 
@@ -497,6 +499,16 @@ static void parse_le_config(GKeyFile *config)
 		  sizeof(btd_opts.defaults.le.autoconnect_timeout),
 		  0x0001,
 		  0x4000},
+		{ "AdvMonAllowlistScanDuration",
+		  &btd_opts.defaults.le.advmon_allowlist_scan_duration,
+		  sizeof(btd_opts.defaults.le.advmon_allowlist_scan_duration),
+		  1,
+		  10000},
+		{ "AdvMonNoFilterScanDuration",
+		  &btd_opts.defaults.le.advmon_no_filter_scan_duration,
+		  sizeof(btd_opts.defaults.le.advmon_no_filter_scan_duration),
+		  1,
+		  10000},
 	};
 
 	if (btd_opts.mode == BT_MODE_BREDR)

--- a/src/main.c
+++ b/src/main.c
@@ -116,6 +116,7 @@ static const char *le_options[] = {
 	"Autoconnecttimeout",
 	"AdvMonAllowlistScanDuration",
 	"AdvMonNoFilterScanDuration",
+	"EnableAdvMonInterleaveScan",
 	NULL
 };
 
@@ -509,6 +510,11 @@ static void parse_le_config(GKeyFile *config)
 		  sizeof(btd_opts.defaults.le.advmon_no_filter_scan_duration),
 		  1,
 		  10000},
+		{ "EnableAdvMonInterleaveScan",
+		  &btd_opts.defaults.le.enable_advmon_interleave_scan,
+		  sizeof(btd_opts.defaults.le.enable_advmon_interleave_scan),
+		  0,
+		  1},
 	};
 
 	if (btd_opts.mode == BT_MODE_BREDR)
@@ -761,6 +767,7 @@ static void init_defaults(void)
 	btd_opts.defaults.num_entries = 0;
 	btd_opts.defaults.br.page_scan_type = 0xFFFF;
 	btd_opts.defaults.br.scan_type = 0xFFFF;
+	btd_opts.defaults.le.enable_advmon_interleave_scan = 0xFF;
 
 	if (sscanf(VERSION, "%hhu.%hhu", &major, &minor) != 2)
 		return;

--- a/src/main.conf
+++ b/src/main.conf
@@ -167,6 +167,12 @@
 # Default: 500
 #AdvMonNoFilterScanDuration=
 
+# Enable/Disable Advertisement Monitor interleave scan for power saving.
+# 0: disable
+# 1: enable
+# Defaults to 1
+#EnableAdvMonInterleaveScan=
+
 [GATT]
 # GATT attribute cache.
 # Possible values:

--- a/src/main.conf
+++ b/src/main.conf
@@ -160,6 +160,13 @@
 #ConnectionSupervisionTimeout=
 #Autoconnecttimeout=
 
+# Scan duration during interleaving scan. Only used when scanning for ADV
+# monitors. The units are msec.
+# Default: 300
+#AdvMonAllowlistScanDuration=
+# Default: 500
+#AdvMonNoFilterScanDuration=
+
 [GATT]
 # GATT attribute cache.
 # Possible values:


### PR DESCRIPTION

This patch adds parameters to control the durations of allowlist scan
and no-filter scan when the kernel is doing interleaving scan.
