### PR TITLE
[PW_SID:377031] [Bluez,v1,1/3] policy: add checks before connecting


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/plugins/policy.c
+++ b/plugins/policy.c
@@ -106,6 +106,7 @@ static void policy_connect(struct policy_data *data,
 {
 	struct btd_profile *profile = btd_service_get_profile(service);
 	struct reconnect_data *reconnect;
+	GSList *l = NULL;
 
 	reconnect = reconnect_find(btd_service_get_device(service));
 	if (reconnect && reconnect->active)
@@ -113,7 +114,9 @@ static void policy_connect(struct policy_data *data,
 
 	DBG("%s profile %s", device_get_path(data->dev), profile->name);
 
-	btd_service_connect(service);
+	l = g_slist_prepend(l, service);
+	btd_device_connect_services(data->dev, l);
+	g_slist_free(l);
 }
 
 static void policy_disconnect(struct policy_data *data,


### PR DESCRIPTION

From: Archie Pusaka <apusaka@chromium.org>

When policy_connect() is called, there might be a case where the
device is not ready, or even the adapter is down. Add some checks
by calling btd_device_connect_services() instead of directly calling
btd_service_connect().

Reviewed-by: Sonny Sasaka <sonnysasaka@chromium.org>
