### PR TITLE
[PW_SID:385377] [bluez,v2] adv_monitor: Fix remove monitor from the kernel


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,39 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Coverity Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "coverity"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+
+  clang-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Clang Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "clang"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}


### PR DESCRIPTION

A monitor is removed in the following scenarios:
- monitor dbus object removed by the app
- monitor removed by the kernel
- client app invokes UnregisterMonitor()
- client app is killed/disconnected
- AdvMonitorManager is destroyed

In the first case, we need to remove the corresponding monitor from the
kernel and free the bluez monitor object.

In the second case, we need to call the Release() method on the
corresponding dbus monitor object and free the bluez monitor object.

Kernel may remove all monitors and send MGMT_EV_ADV_MONITOR_REMOVED
event to bluez. In such case, we need to call Release() method on all
monitors from all registered apps, and free the bluez monitor objects.

In the third case, we need to call the Release() method on the monitor
objects created by the app, remove corresponding monitors from the
kernel and then free the bluez monitor object.

In the fourth case, since the app is not available, all the dbus monitor
objects created by that app are also unavailable. So, we just need to
remove corresponding monitors from the kernel and then free the bluez
monitor objects.

In the fifth case, we need to call Release() method on all monitors from
all registered apps, remove corresponding monitors from the kernel and
then free the bluez monitor objects.

When app exits or gets killed without removing the dbus monitor objects
and without invoking the UnregisterMonitor() method, a race condition
could happen between app_destroy and monitor_proxy_removed since dbus
objects hosted by the app are destroyed on app exit.

This patch fixes the first, second and fourth cases ensuring that
monitors from the kernel are removed correctly, Release() method is
invoked whenever necessary and bluez monitor objects are freed only
once.

Reviewed-by: alainm@chromium.org
Reviewed-by: mcchou@chromium.org
Reviewed-by: howardchung@google.com
Signed-off-by: Manish Mandlik <mmandlik@google.com>
