### PR TITLE
[PW_SID:386271] [BlueZ,1/2] test-runner: Change qemu output


### DIFF
--- a/tools/test-runner.c
+++ b/tools/test-runner.c
@@ -195,8 +195,8 @@ static char *const qemu_argv[] = {
 	"-no-reboot",
 	"-fsdev", "local,id=fsdev-root,path=/,readonly,security_model=none",
 	"-device", "virtio-9p-pci,fsdev=fsdev-root,mount_tag=/dev/root",
-	"-chardev", "stdio,id=chardev-serial0,signal=off",
-	"-device", "pci-serial,chardev=chardev-serial0",
+	"-chardev", "stdio,id=con,mux=on",
+	"-serial", "chardev:con",
 	NULL
 };
 

--- a/tools/test-runner.c
+++ b/tools/test-runner.c
@@ -193,7 +193,8 @@ static char *const qemu_argv[] = {
 	"-no-acpi",
 	"-no-hpet",
 	"-no-reboot",
-	"-fsdev", "local,id=fsdev-root,path=/,readonly,security_model=none",
+	"-fsdev", "local,id=fsdev-root,path=/,readonly,security_model=none,"
+	"multidevs=remap",
 	"-device", "virtio-9p-pci,fsdev=fsdev-root,mount_tag=/dev/root",
 	"-chardev", "stdio,id=con,mux=on",
 	"-serial", "chardev:con",


### PR DESCRIPTION

From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This changes the serial device to include mux=on which enables the
output of early kernel logs.
