### PR TITLE
[PW_SID:390145] test: simple-endpoint: Add support for LDAC


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,39 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Coverity Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "coverity"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+
+  clang-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Clang Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "clang"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/test/simple-endpoint
+++ b/test/simple-endpoint
@@ -29,6 +29,23 @@ SBC_CAPABILITIES = dbus.Array([dbus.Byte(0xff), dbus.Byte(0xff), dbus.Byte(2), d
 # JointStereo 44.1Khz Subbands: Blocks: 16 Bitpool Range: 2-32
 SBC_CONFIGURATION = dbus.Array([dbus.Byte(0x21), dbus.Byte(0x15), dbus.Byte(2), dbus.Byte(32)])
 
+# Should be 0xFF for vendor codecs
+LDAC_CODEC = dbus.Byte(0xff)
+# Frequencies: 44.1 KHZ | 48 KHz | 88.2 KHz | 96 KHz
+# Channels: Mono | Dual | Stereo
+LDAC_CAPABILITIES = dbus.Array([dbus.Byte(0x2d), dbus.Byte(0x01),
+  dbus.Byte(0x00), dbus.Byte(0x00), dbus.Byte(0xaa), dbus.Byte(0x00),
+  dbus.Byte(0x3c), dbus.Byte(0x07)])
+LDAC_CONFIGURATION = dbus.Array([dbus.Byte(0x2d), dbus.Byte(0x01),
+  dbus.Byte(0x00), dbus.Byte(0x00), dbus.Byte(0xaa), dbus.Byte(0x00),
+  # 44.1 KHz, Stereo; 0x20 0x01
+  # 48 KHz,   Stereo; 0x10 0x01
+  # 48 KHz,   Dual  ; 0x10 0x02
+  # 48 KHz,   Mono  ; 0x10 0x04
+  # 88.2 KHz, Stereo; 0x08 0x01
+  # 96 KHz,   Stereo; 0x04 0x01
+  dbus.Byte(0x20), dbus.Byte(0x01)])
+
 MP3_CODEC = dbus.Byte(0x01)
 #Channel Modes: Mono DualChannel Stereo JointStereo
 #Frequencies: 32Khz 44.1Khz 48Khz
@@ -111,6 +128,18 @@ if __name__ == '__main__':
 							"Codec" : SBC_CODEC,
 							"DelayReporting" : True,
 							"Capabilities" : SBC_CAPABILITIES })
+		if sys.argv[2] == "ldacsink":
+			properties = dbus.Dictionary({ "UUID" : A2DP_SINK_UUID,
+							"Codec" : LDAC_CODEC,
+							"DelayReporting" : True,
+							"Capabilities" : LDAC_CAPABILITIES })
+			endpoint.default_configuration(LDAC_CONFIGURATION)
+		if sys.argv[2] == "ldacsource":
+			properties = dbus.Dictionary({ "UUID" : A2DP_SOURCE_UUID,
+							"Codec" : LDAC_CODEC,
+							"DelayReporting" : True,
+							"Capabilities" : LDAC_CAPABILITIES })
+			endpoint.default_configuration(LDAC_CONFIGURATION)
 		if sys.argv[2] == "mp3source":
 			properties = dbus.Dictionary({ "UUID" : A2DP_SOURCE_UUID,
 							"Codec" : MP3_CODEC,


### PR DESCRIPTION

This patch adds support for LDAC to the simple endpoint script.

It has been tested with the LDAC plugins in gstreamer which recently got
merged and can be found in the two merge requests below.
https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/merge_requests/1621
https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/757

For testing this with upstream, gst-build would be required.
https://gitlab.freedesktop.org/gstreamer/gst-build

Sanchayan Maity (1):
test: simple-endpoint: Add support for LDAC

test/simple-endpoint | 29 +++++++++++++++++++++++++++++
1 file changed, 29 insertions(+)
