### PR TITLE
[PW_SID:390539] [BlueZ] main.conf: use correct key for BREDR configuration


### DIFF
--- a/src/main.conf
+++ b/src/main.conf
@@ -86,7 +86,7 @@
 # profile is connected. Defaults to true.
 #RefreshDiscovery = true
 
-[BREDR]
+[BR]
 # The following values are used to load default adapter parameters for BR/EDR.
 # BlueZ loads the values into the kernel before the adapter is powered if the
 # kernel supports the MGMT_LOAD_DEFAULT_PARAMETERS command. If a value isn't


### PR DESCRIPTION

From: Ronan Pigott <rpigott@berkeley.edu>

Signed-off-by: Ronan Pigott <rpigott@berkeley.edu>
