### PR TITLE
[PW_SID:391111] [bluez,v2] adv_monitor: Update log messages


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,39 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Coverity Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "coverity"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+
+  clang-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Clang Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "clang"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/src/adv_monitor.c
+++ b/src/adv_monitor.c
@@ -318,8 +318,9 @@ static void app_disconnect_cb(DBusConnection *conn, void *user_data)
 		return;
 	}
 
-	btd_info(app->manager->adapter_id, "Adv Monitor app %s disconnected "
-			"from D-Bus", app->owner);
+	btd_info(app->manager->adapter_id,
+			"Adv Monitor app %s disconnected from D-Bus",
+			app->owner);
 
 	if (queue_remove(app->manager->apps, app)) {
 		queue_foreach(app->monitors, monitor_state_released, NULL);
@@ -396,8 +397,9 @@ static bool parse_monitor_type(struct adv_monitor *monitor, const char *path)
 	uint16_t adapter_id = monitor->app->manager->adapter_id;
 
 	if (!g_dbus_proxy_get_property(monitor->proxy, "Type", &iter)) {
-		btd_error(adapter_id, "Failed to retrieve property Type from "
-			"the Adv Monitor at path %s", path);
+		btd_error(adapter_id,
+				"Failed to retrieve property Type from the "
+				"Adv Monitor at path %s", path);
 		return false;
 	}
 
@@ -414,8 +416,9 @@ static bool parse_monitor_type(struct adv_monitor *monitor, const char *path)
 	}
 
 failed:
-	btd_error(adapter_id, "Invalid argument of property Type of the Adv "
-			"Monitor at path %s", path);
+	btd_error(adapter_id,
+			"Invalid argument of property Type of the Adv Monitor "
+			"at path %s", path);
 
 	return false;
 }
@@ -515,8 +518,9 @@ failed:
 	monitor->high_rssi_timeout = ADV_MONITOR_UNSET_TIMER;
 	monitor->low_rssi_timeout = ADV_MONITOR_UNSET_TIMER;
 
-	btd_error(adapter_id, "Invalid argument of property "
-			"RSSIThresholdsAndTimers of the Adv Monitor at path %s",
+	btd_error(adapter_id,
+			"Invalid argument of property RSSIThresholdsAndTimers "
+			"of the Adv Monitor at path %s",
 			path);
 
 	return false;
@@ -531,8 +535,9 @@ static bool parse_patterns(struct adv_monitor *monitor, const char *path)
 	uint16_t adapter_id = monitor->app->manager->adapter_id;
 
 	if (!g_dbus_proxy_get_property(monitor->proxy, "Patterns", &array)) {
-		btd_error(adapter_id, "Failed to retrieve property Patterns "
-				"from the Adv Monitor at path %s", path);
+		btd_error(adapter_id,
+				"Failed to retrieve property Patterns from the "
+				"Adv Monitor at path %s", path);
 		return false;
 	}
 
@@ -640,8 +645,9 @@ static void add_adv_patterns_monitor_cb(uint8_t status, uint16_t length,
 	uint16_t adapter_id = monitor->app->manager->adapter_id;
 
 	if (status != MGMT_STATUS_SUCCESS || !param) {
-		btd_error(adapter_id, "Failed to Add Adv Patterns Monitor "
-				"with status 0x%02x", status);
+		btd_error(adapter_id,
+				"Failed to Add Adv Patterns Monitor with status"
+				" 0x%02x", status);
 		monitor->state = MONITOR_STATE_FAILED;
 		monitor_destroy(monitor);
 		return;
@@ -696,15 +702,17 @@ static void monitor_proxy_added_cb(GDBusProxy *proxy, void *user_data)
 	}
 
 	if (queue_find(app->monitors, monitor_match, proxy)) {
-		btd_error(adapter_id, "Adv Monitor proxy already exists with "
-				"path %s", path);
+		btd_error(adapter_id,
+				"Adv Monitor proxy already exists with path %s",
+				path);
 		return;
 	}
 
 	monitor = monitor_new(app, proxy);
 	if (!monitor) {
-		btd_error(adapter_id, "Failed to allocate an Adv Monitor for "
-				"the object at %s", path);
+		btd_error(adapter_id,
+				"Failed to allocate an Adv Monitor for the "
+				"object at %s", path);
 		return;
 	}
 
@@ -882,8 +890,9 @@ static DBusMessage *unregister_monitor(DBusConnection *conn,
 	queue_remove(manager->apps, app);
 	app_destroy(app);
 
-	btd_info(manager->adapter_id, "Path %s removed along with Adv Monitor "
-			"app %s", match.path, match.owner);
+	btd_info(manager->adapter_id,
+			"Path %s removed along with Adv Monitor app %s",
+			match.path, match.owner);
 
 	return dbus_message_new_method_return(msg);
 }
@@ -1021,8 +1030,8 @@ static void adv_monitor_removed_callback(uint16_t index, uint16_t length,
 	const uint16_t adapter_id = manager->adapter_id;
 
 	if (length < sizeof(*ev)) {
-		btd_error(adapter_id, "Wrong size of Adv Monitor Removed "
-				"event");
+		btd_error(adapter_id,
+				"Wrong size of Adv Monitor Removed event");
 		return;
 	}
 
@@ -1093,8 +1102,9 @@ static void read_adv_monitor_features_cb(uint8_t status, uint16_t length,
 	struct btd_adv_monitor_manager *manager = user_data;
 
 	if (status != MGMT_STATUS_SUCCESS || !param) {
-		btd_error(manager->adapter_id, "Failed to Read Adv Monitor "
-				"Features with status 0x%02x", status);
+		btd_error(manager->adapter_id,
+				"Failed to Read Adv Monitor Features with "
+				"status 0x%02x", status);
 		return;
 	}
 
@@ -1436,8 +1446,8 @@ static void adv_monitor_filter_rssi(struct adv_monitor *monitor,
 	if (!dev) {
 		dev = monitor_device_create(monitor, device);
 		if (!dev) {
-			btd_error(adapter_id, "Failed to create Adv Monitor "
-					      "device object.");
+			btd_error(adapter_id,
+				"Failed to create Adv Monitor device object.");
 			return;
 		}
 	}


### PR DESCRIPTION

Update log messages to avoid breaking of user-visible log strings
to make it easy to grep for them.

Reviewed-by: mcchou@chromium.org
Reviewed-by: alainm@chromium.org
Signed-off-by: Manish Mandlik <mmandlik@google.com>
