### PR TITLE
[PW_SID:394297] Emit InterfacesAdded/InterfacesRemoved at correct root path


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,39 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Coverity Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "coverity"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+
+  clang-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Clang Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "clang"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/client/adv_monitor.c
+++ b/client/adv_monitor.c
@@ -602,8 +602,9 @@ void adv_monitor_add_monitor(DBusConnection *conn, char *type,
 	adv_monitor->patterns = patterns;
 	adv_monitor->path = g_strdup_printf("%s/%hhu", ADV_MONITOR_APP_PATH,
 								adv_mon_idx);
-	if (g_dbus_register_interface(conn, adv_monitor->path,
+	if (g_dbus_register_interface_full(conn, adv_monitor->path,
 					ADV_MONITOR_INTERFACE,
+					ADV_MONITOR_APP_PATH,
 					adv_monitor_methods, NULL,
 					adv_monitor_props, adv_monitor,
 					free_adv_monitor) == FALSE) {

--- a/gdbus/gdbus.h
+++ b/gdbus/gdbus.h
@@ -210,8 +210,23 @@ struct GDBusSecurityTable {
 void g_dbus_set_flags(int flags);
 int g_dbus_get_flags(void);
 
+/* Note that, when new interface is registered, InterfacesAdded signal is
+ * emitted. This signal is by default emitted at root path "/" registered
+ * while registering a client using g_dbus_client_new(). If this behavior
+ * is undesired, use g_dbus_register_interface_full() with a desired root
+ * path to ensure InterfacesAdded / InterfacesRemoved signals get emitted
+ * at the correct path.
+ */
 gboolean g_dbus_register_interface(DBusConnection *connection,
 					const char *path, const char *name,
+					const GDBusMethodTable *methods,
+					const GDBusSignalTable *signals,
+					const GDBusPropertyTable *properties,
+					void *user_data,
+					GDBusDestroyFunction destroy);
+gboolean g_dbus_register_interface_full(DBusConnection *connection,
+					const char *path, const char *name,
+					const char *root_path,
 					const GDBusMethodTable *methods,
 					const GDBusSignalTable *signals,
 					const GDBusPropertyTable *properties,

--- a/src/adv_monitor.c
+++ b/src/adv_monitor.c
@@ -775,7 +775,7 @@ static struct adv_monitor_app *app_create(DBusConnection *conn,
 	app->manager = manager;
 	app->reg = NULL;
 
-	app->client = g_dbus_client_new(conn, sender, path);
+	app->client = g_dbus_client_new_full(conn, sender, path, path);
 	if (!app->client) {
 		app_destroy(app);
 		return NULL;


### PR DESCRIPTION

Hello Maintainers,

Existing advertisement monitor implementation registers client app with
bluez-root-path i.e. "/". Because of which client app needs to emit
InterfacesAdded and InterfacesRemoved signals - when monitor objects are
added or removed - at the bluez-root-path.

This may cause confusion for application developers as the app need to
register with bluez with app-root-path for exposing monitor object, but
need to emit InterfacesAdded and InterfacesRemoved signals on the
bluez-root-path.

This patch series fixes advertisement monitor implementation to register
client with client specified app-root-path. Also, adds support in gdbus
library to emit signals at the app-root-path so that bluetoothctl can
emit InterfacesAdded/InterfacesRemoved signals correctly when adv-
monitors are created.

These changes are verified by running the bluetoothctl as well as the
python tester app and verifying that the monitor objects are getting
exposed and DeviceFound/DeviceLost events are getting invoked correctly.

Regards,
Manish.


Manish Mandlik (3):
adv_monitor: Register client app with app-base-path
gdbus: Emit InterfacesAdded/Removed at app root path
client: Fix add advertisement monitor

client/adv_monitor.c |  3 ++-
gdbus/gdbus.h        | 15 +++++++++++++++
