### PR TITLE
[PW_SID:394959] [BlueZ] mesh: Zero out config node struct before initializing


### DIFF
--- a/mesh/node.c
+++ b/mesh/node.c
@@ -856,6 +856,8 @@ static void convert_node_to_storage(struct mesh_node *node,
 {
 	const struct l_queue_entry *entry;
 
+	memset(db_node, 0, sizeof(struct mesh_config_node));
+
 	db_node->cid = node->comp.cid;
 	db_node->pid = node->comp.pid;
 	db_node->vid = node->comp.vid;


### PR DESCRIPTION

This memsets all the fields of mesh_db_node to zero prior to intializing
some fields in mesh_config_node struct and creating a brand new node
configuration. Just a precaution against having uninitialized items.
