### PR TITLE
[PW_SID:395121] [bluez,v2,1/2] adv_monitor: Register client app with app-root-path


### DIFF
--- a/client/adv_monitor.c
+++ b/client/adv_monitor.c
@@ -270,7 +270,7 @@ void adv_monitor_remove_manager(DBusConnection *conn)
 
 static void register_setup(DBusMessageIter *iter, void *user_data)
 {
-	const char *path = ADV_MONITOR_APP_PATH;
+	const char *path = "/";
 
 	dbus_message_iter_append_basic(iter, DBUS_TYPE_OBJECT_PATH, &path);
 }
@@ -293,7 +293,7 @@ static void register_reply(DBusMessage *message, void *user_data)
 
 static void unregister_setup(DBusMessageIter *iter, void *user_data)
 {
-	const char *path = ADV_MONITOR_APP_PATH;
+	const char *path = "/";
 
 	dbus_message_iter_append_basic(iter, DBUS_TYPE_OBJECT_PATH, &path);
 }

--- a/src/adv_monitor.c
+++ b/src/adv_monitor.c
@@ -775,7 +775,7 @@ static struct adv_monitor_app *app_create(DBusConnection *conn,
 	app->manager = manager;
 	app->reg = NULL;
 
-	app->client = g_dbus_client_new(conn, sender, path);
+	app->client = g_dbus_client_new_full(conn, sender, path, path);
 	if (!app->client) {
 		app_destroy(app);
 		return NULL;


### PR DESCRIPTION

When a client app is registered with g_dbus_client_new(), bluez root
path, i.e. "/", is used as the app root path and signal watches are
added at that root path.

Because of this, InterfacesAdded/InterfacesRemoved signals emitted by
app - while creating/removing advertisement monitor objects at the
app root path - are not received by bluetoothd.

Use g_dbus_client_new_full() to register a client app with the correct
app root path.

Signed-off-by: Manish Mandlik <mmandlik@google.com>
Reviewed-by: sonnysasaka@chromium.org
Reviewed-by: howardchung@google.com
Reviewed-by: mcchou@chromium.org
