### PR TITLE
[PW_SID:397867] policy: Fix connection stealing with Airpods


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,39 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Coverity Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "coverity"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+
+  clang-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Clang Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "clang"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/src/main.conf
+++ b/src/main.conf
@@ -220,7 +220,7 @@
 # timeout). The policy plugin should contain a sane set of values by
 # default, but this list can be overridden here. By setting the list to
 # empty the reconnection feature gets disabled.
-#ReconnectUUIDs=00001112-0000-1000-8000-00805f9b34fb,0000111f-0000-1000-8000-00805f9b34fb,0000110a-0000-1000-8000-00805f9b34fb,0000110b-0000-1000-8000-00805f9b34fb
+#ReconnectUUIDs=00001112-0000-1000-8000-00805f9b34fb,0000111f-0000-1000-8000-00805f9b34fb,0000110a-0000-1000-8000-00805f9b34fb
 
 # ReconnectAttempts define the number of attempts to reconnect after a link
 # lost. Setting the value to 0 disables reconnecting feature.
@@ -236,6 +236,13 @@
 # This includes adapters present on start as well as adapters that are plugged
 # in later on. Defaults to 'false'.
 #AutoEnable=false
+
+# The ReconnectResumeUUIDs defines the set of remote services that should try
+# to be reconnected after resume from suspend if they were connected before
+# suspend. If a device is disconnected due to suspend, it will be queued for
+# reconnect on resume first using the ResumeDelay value and then the remaining
+# values in ReconnectIntervals.
+#ReconnectResumeUUIDs=0000110b-0000-1000-8000-00805f9b34fb
 
 # Audio devices that were disconnected due to suspend will be reconnected on
 # resume. ResumeDelay determines the delay between when the controller


### PR DESCRIPTION

Hi Luiz,

When a2dp-sink was added to the reconnection policy, it exposed a bug in
Airpods which were incorrectly emitting Connection Timeout when
connecting to a new device. As a result, Chromebooks started
reconnecting immediately (link loss) and inadvertently "stole"
connections. See hci trace below:

> HCI Event: Disconnect Complete (0x05) plen 4                 #1680 [hci0] 62.656436
Status: Success (0x00)
Handle: 256
Reason: Connection Timeout (0x08)
@ MGMT Event: Device Disconnected (0x000c) plen 8              {0x0004} [hci0] 62.656510
BR/EDR Address: E4:90:FD:7D:E7:5F (OUI E4-90-FD)
Reason: Connection timeout (0x01)
@ MGMT Event: Device Disconnected (0x000c) plen 8              {0x0002} [hci0] 62.656510
BR/EDR Address: E4:90:FD:7D:E7:5F (OUI E4-90-FD)
Reason: Connection timeout (0x01)
@ MGMT Event: Device Disconnected (0x000c) plen 8              {0x0001} [hci0] 62.656510
BR/EDR Address: E4:90:FD:7D:E7:5F (OUI E4-90-FD)
Reason: Connection timeout (0x01)
@ MGMT Event: Device Disconnected (0x000c) plen 8              {0x0003} [hci0] 62.656510
BR/EDR Address: E4:90:FD:7D:E7:5F (OUI E4-90-FD)
Reason: Connection timeout (0x01)
< HCI Command: Write Scan Enable (0x03|0x001a) plen 1          #1681 [hci0] 62.668156
Scan enable: Page Scan (0x02)
> HCI Event: Command Complete (0x0e) plen 4                    #1682 [hci0] 62.670442
Write Scan Enable (0x03|0x001a) ncmd 2
Status: Success (0x00)
< HCI Command: Create Connection (0x01|0x0005) plen 13         #1683 [hci0] 64.090171
Address: E4:90:FD:7D:E7:5F (OUI E4-90-FD)
Packet type: 0xcc18
DM1 may be used
DH1 may be used
DM3 may be used
DH3 may be used
DM5 may be used
DH5 may be used
Page scan repetition mode: R2 (0x02)
Page scan mode: Mandatory (0x00)
Clock offset: 0x0000
Role switch: Allow slave (0x01)
> HCI Event: Command Status (0x0f) plen 4                      #1684 [hci0] 64.090446
Create Connection (0x01|0x0005) ncmd 1

This patch separates the ReconnectUUIDs by adding a ReconnectResumeUUIDs
and distinguishes reconnections that occur on timeout vs. resume.

I've run the following tests:

- Check that Airpods changing to a different device doesn't cause
a reconnection with this change.
- Check that adding a2dp-sink to ReconnectUUIDs will cause the original
issue to be seen.
- Make sure Airpods are reconnected on resume.
- Make sure other headphones are reconnected on resume (tested Anker
Soundcore Life Q20 and ATH-M50xBT)
- Run bluetooth_AdapterSRHealth.sr_reconnect_a2dp (ChromeOS end-to-end
test)

Thanks
Abhishek



Abhishek Pandit-Subedi (1):
policy: Refactor reconnect policy for resume

