### PR TITLE
[PW_SID:402711] [BlueZ,v1] core: Disable advmon manager interface for old kernel


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,39 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Coverity Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "coverity"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+
+  clang-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Clang Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "clang"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -8649,7 +8649,8 @@ static int adapter_register(struct btd_adapter *adapter)
 	adapter->adv_manager = btd_adv_manager_new(adapter, adapter->mgmt);
 
 	if (g_dbus_get_flags() & G_DBUS_FLAG_ENABLE_EXPERIMENTAL) {
-		if (adapter->supported_settings & MGMT_SETTING_LE) {
+		if (adapter->supported_settings & MGMT_SETTING_LE &&
+			btd_has_kernel_features(KERNEL_ADV_MONITOR_CMDS)) {
 			adapter->adv_monitor_manager =
 				btd_adv_monitor_manager_create(adapter,
 								adapter->mgmt);
@@ -8661,7 +8662,7 @@ static int adapter_register(struct btd_adapter *adapter)
 			}
 		} else {
 			btd_info(adapter->dev_id, "Adv Monitor Manager "
-					"skipped, LE unavailable");
+					"skipped, kernel or LE unavailable");
 		}
 	}
 
@@ -9720,6 +9721,10 @@ static void read_commands_complete(uint8_t status, uint16_t length,
 		case MGMT_OP_READ_CONTROLLER_CAP:
 			DBG("kernel supports controller cap command");
 			kernel_features |= KERNEL_HAS_CONTROLLER_CAP_CMD;
+			break;
+		case MGMT_OP_ADD_ADV_PATTERNS_MONITOR:
+			DBG("kernel supports adv monitor commands");
+			kernel_features |= KERNEL_ADV_MONITOR_CMDS;
 			break;
 		default:
 			break;

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -237,6 +237,7 @@ enum kernel_features {
 	KERNEL_HAS_RESUME_EVT		= 1 << 4,
 	KERNEL_HAS_EXT_ADV_ADD_CMDS	= 1 << 5,
 	KERNEL_HAS_CONTROLLER_CAP_CMD	= 1 << 6,
+	KERNEL_ADV_MONITOR_CMDS		= 1 << 7,
 };
 
 bool btd_has_kernel_features(uint32_t feature);


### PR DESCRIPTION

This disables Advertisement monitor manager interface if the underlying
kernel does not support necessary MGMT commands such as add/remove
filters, so clients can know that they are not able to register any
filters before actually register one.
