### PR TITLE
[PW_SID:421289] [BlueZ,v3] input/hog: Fix double registering report value callbacks


### DIFF
--- a/profiles/input/hog-lib.c
+++ b/profiles/input/hog-lib.c
@@ -336,6 +336,9 @@ static void report_ccc_written_cb(guint8 status, const guint8 *pdu,
 		return;
 	}
 
+	if (report->notifyid)
+		return;
+
 	report->notifyid = g_attrib_register(hog->attrib,
 					ATT_OP_HANDLE_NOTIFY,
 					report->value_handle,
@@ -1696,6 +1699,9 @@ bool bt_hog_attach(struct bt_hog *hog, void *gatt)
 	 */
 	for (l = hog->reports; l; l = l->next) {
 		struct report *r = l->data;
+
+		if (r->notifyid)
+			continue;
 
 		r->notifyid = g_attrib_register(hog->attrib,
 					ATT_OP_HANDLE_NOTIFY,


### PR DESCRIPTION

In commit 23b69ab3e484 ("input/hog: Cache the HID report map"), we
optimized HOG reconnection by registering report value callbacks early,
but there was a bug where we also re-register the same report value
callbacks after at CCC write callback. We should handle this case by
avoiding the second callback register if we know we have done it
earlier.
