### PR TITLE
[PW_SID:422227] [BlueZ] input/hog: Fix crashes of UAF of hog->attr


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,39 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Coverity Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "coverity"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+
+  clang-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Clang Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "clang"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/profiles/input/hog-lib.c
+++ b/profiles/input/hog-lib.c
@@ -1651,11 +1651,18 @@ static void primary_cb(uint8_t status, GSList *services, void *user_data)
 bool bt_hog_attach(struct bt_hog *hog, void *gatt)
 {
 	GSList *l;
+	bt_uuid_t uuid;
 
 	if (hog->attrib)
 		return false;
 
 	hog->attrib = g_attrib_ref(gatt);
+
+	if (!hog->attr && hog->gatt_db) {
+		bt_uuid16_create(&uuid, HOG_UUID16);
+		gatt_db_foreach_service(hog->gatt_db, &uuid,
+					foreach_hog_service, hog);
+	}
 
 	if (!hog->attr && !hog->primary) {
 		discover_primary(hog, hog->attrib, NULL, primary_cb, hog);
@@ -1743,6 +1750,14 @@ void bt_hog_detach(struct bt_hog *hog)
 
 		bt_hog_detach(instance);
 	}
+
+	/* hog->attr doesn't own pointer, so it may be invalid when this hog
+	 * object gets re-attached with bt_hog_attach(). So intentionally mark
+	 * it as invalid and remove all instances so that the instances can be
+	 * re-attached at bt_hog_attach().
+	 */
+	hog->attr = NULL;
+	g_slist_free_full(hog->instances, hog_free);
 
 	for (l = hog->reports; l; l = l->next) {
 		struct report *r = l->data;


### PR DESCRIPTION

hog->attr does not own pointer, so it may be invalid when hog object
gets re-attached at bt_hog_attach(). To solve this, this patch
intentionally clears hog->attr at bt_hog_detach() to mark it as invalid
so that it can be repopulated with the valid pointer at bt_hog_attach().
The same applies to all sub-instances.

Sample stack trace:
* thread #1, stop reason = signal SIGSEGV
* frame #0: 0x05ad49f2 bluetoothd`<name omitted> at gatt-db.c:1428
frame #1: 0x05a91922 bluetoothd`bt_hog_attach at hog-lib.c:1694
frame #2: 0x05a9160e bluetoothd`hog_accept at hog.c:212
frame #3: 0x05ab4784 bluetoothd`service_accept at service.c:203
frame #4: 0x05aba1e6 bluetoothd`device_attach_att at device.c:4542
frame #5: 0x05a9c4a2 bluetoothd`connect_cb at gatt-database.c:656
frame #6: 0x05a98e8c bluetoothd`server_cb at btio.c:264
frame #7: 0xec8e6a1a libglib-2.0.so.0`g_main_context_dispatch at gmain.c:3325
frame #8: 0xec8e6c58 libglib-2.0.so.0`g_main_context_iterate at gmain.c:4119
frame #9: 0xec8e6e52 libglib-2.0.so.0`g_main_loop_run at gmain.c:4317
frame #10: 0x05ad582e bluetoothd`mainloop_run at mainloop-glib.c:79
frame #11: 0x05ad5a64 bluetoothd`mainloop_run_with_signal at mainloop-notify.c:201
frame #12: 0x05ac35ac bluetoothd`main at main.c:1103
frame #13: 0xec6ed0a2 libc.so.6`__libc_start_main at libc-start.c:308
