### PR TITLE
[PW_SID:428439] [Bluez,v1] a2dp: set session to NULL when freeing channel


### DIFF
--- a/profiles/audio/a2dp.h
+++ b/profiles/audio/a2dp.h
@@ -42,8 +42,8 @@ struct a2dp_endpoint {
 
 typedef void (*a2dp_discover_cb_t) (struct avdtp *session, GSList *seps,
 						int err, void *user_data);
-typedef void (*a2dp_select_cb_t) (struct avdtp *session,
-					struct a2dp_sep *sep, GSList *caps,
+typedef void (*a2dp_select_cb_t) (struct avdtp *session, struct a2dp_sep *sep,
+					GSList *caps, int err,
 					void *user_data);
 typedef void (*a2dp_config_cb_t) (struct avdtp *session, struct a2dp_sep *sep,
 					struct avdtp_stream *stream, int err,

--- a/profiles/audio/avdtp.c
+++ b/profiles/audio/avdtp.c
@@ -3847,11 +3847,17 @@ uint8_t avdtp_sep_get_seid(struct avdtp_local_sep *sep)
 
 struct btd_adapter *avdtp_get_adapter(struct avdtp *session)
 {
+	if (!session)
+		return NULL;
+
 	return device_get_adapter(session->device);
 }
 
 struct btd_device *avdtp_get_device(struct avdtp *session)
 {
+	if (!session)
+		return NULL;
+
 	return session->device;
 }
 

--- a/profiles/audio/sink.c
+++ b/profiles/audio/sink.c
@@ -183,12 +183,15 @@ static void stream_setup_complete(struct avdtp *session, struct a2dp_sep *sep,
 }
 
 static void select_complete(struct avdtp *session, struct a2dp_sep *sep,
-			GSList *caps, void *user_data)
+			GSList *caps, int err, void *user_data)
 {
 	struct sink *sink = user_data;
 	int id;
 
 	sink->connect_id = 0;
+
+	if (err)
+		goto failed;
 
 	id = a2dp_config(session, sep, stream_setup_complete, caps, sink);
 	if (id == 0)

--- a/profiles/audio/source.c
+++ b/profiles/audio/source.c
@@ -180,12 +180,15 @@ static void stream_setup_complete(struct avdtp *session, struct a2dp_sep *sep,
 }
 
 static void select_complete(struct avdtp *session, struct a2dp_sep *sep,
-			GSList *caps, void *user_data)
+			GSList *caps, int err, void *user_data)
 {
 	struct source *source = user_data;
 	int id;
 
 	source->connect_id = 0;
+
+	if (err)
+		goto failed;
 
 	if (caps == NULL)
 		goto failed;


### PR DESCRIPTION

From: Archie Pusaka <apusaka@chromium.org>

There is a possibility that avdtp_channel is freed when avdtp_setup
is not yet freed. This could cause crashes because setup->chan will
then point to an invalid address.

Reviewed-by: Sonny Sasaka <sonnysasaka@chromium.org>
Reviewed-by: Michael Sun <michaelfsun@google.com>
Reviewed-by: Alain Michaud <alainm@chromium.org>
