### PR TITLE
[PW_SID:432455] Use compliant UUID for mesh


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,39 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Coverity Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "coverity"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+
+  clang-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Clang Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "clang"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/Makefile.am
+++ b/Makefile.am
@@ -134,7 +134,8 @@ ell_headers = ell/util.h \
 			ell/base64.h \
 			ell/asn1-private.h \
 			ell/cert-private.h \
-			ell/pem-private.h
+			ell/pem-private.h \
+			ell/uuid.h
 
 ell_sources = ell/private.h ell/missing.h \
 			ell/util.c \
@@ -169,7 +170,8 @@ ell_sources = ell/private.h ell/missing.h \
 			ell/gvariant-private.h \
 			ell/gvariant-util.c \
 			ell/siphash-private.h \
-			ell/siphash.c
+			ell/siphash.c \
+			ell/uuid.c
 
 ell_libell_internal_la_SOURCES = $(ell_headers) $(ell_sources)
 endif

--- a/doc/mesh-api.txt
+++ b/doc/mesh-api.txt
@@ -27,7 +27,8 @@ Methods:
 		The uuid parameter is a 16-byte array that contains Device UUID.
 		This UUID must be unique (at least from the daemon perspective),
 		therefore attempting to call this function using already
-		registered UUID results in an error.
+		registered UUID results in an error. The composition of the UUID
+		octets must be in compliance with RFC 4122.
 
 		When provisioning finishes, the daemon will call either
 		JoinComplete or JoinFailed method on object implementing
@@ -149,7 +150,8 @@ Methods:
 		The uuid parameter is a 16-byte array that contains Device UUID.
 		This UUID must be unique (at least from the daemon perspective),
 		therefore attempting to call this function using already
-		registered UUID results in an error.
+		registered UUID results in an error. The composition of the UUID
+		octets must be in compliance with RFC 4122.
 
 		The other information the bluetooth-meshd daemon will preserve
 		about the initial node, is to give it the initial primary
@@ -179,7 +181,8 @@ Methods:
 		The uuid parameter is a 16-byte array that contains Device UUID.
 		This UUID must be unique (at least from the daemon perspective),
 		therefore attempting to call this function using already
-		registered UUID results in an error.
+		registered UUID results in an error. The composition of the UUID
+		octets must be in compliance with RFC 4122.
 
 		The dev_key parameter is the 16-byte value of the dev key of
 		the imported mesh node.

--- a/mesh/mesh.c
+++ b/mesh/mesh.c
@@ -533,7 +533,7 @@ static struct l_dbus_message *join_network_call(struct l_dbus *dbus,
 						void *user_data)
 {
 	const char *app_path, *sender;
-	struct l_dbus_message_iter iter_uuid;
+	struct l_dbus_message_iter iter;
 	uint32_t n;
 
 	l_debug("Join network request");
@@ -543,14 +543,13 @@ static struct l_dbus_message *join_network_call(struct l_dbus *dbus,
 						"Provisioning in progress");
 
 	if (!l_dbus_message_get_arguments(msg, "oay", &app_path,
-								&iter_uuid))
+								&iter))
 		return dbus_error(msg, MESH_ERROR_INVALID_ARGS, NULL);
 
 	join_pending = l_new(struct join_data, 1);
 
-	if (!l_dbus_message_iter_get_fixed_array(&iter_uuid,
-						&join_pending->uuid, &n)
-								|| n != 16) {
+	if (!l_dbus_message_iter_get_fixed_array(&iter, &join_pending->uuid, &n)
+			|| n != 16 || !l_uuid_is_valid(join_pending->uuid)) {
 		l_free(join_pending);
 		join_pending = NULL;
 		return dbus_error(msg, MESH_ERROR_INVALID_ARGS,
@@ -785,8 +784,8 @@ static struct l_dbus_message *create_network_call(struct l_dbus *dbus,
 								&iter_uuid))
 		return dbus_error(msg, MESH_ERROR_INVALID_ARGS, NULL);
 
-	if (!l_dbus_message_iter_get_fixed_array(&iter_uuid, &uuid, &n)
-								|| n != 16)
+	if (!l_dbus_message_iter_get_fixed_array(&iter_uuid, &uuid, &n) ||
+					n != 16 || !l_uuid_is_valid(uuid))
 		return dbus_error(msg, MESH_ERROR_INVALID_ARGS,
 							"Bad device UUID");
 
@@ -835,8 +834,9 @@ static struct l_dbus_message *import_call(struct l_dbus *dbus,
 		return dbus_error(msg, MESH_ERROR_INVALID_ARGS, NULL);
 
 	if (!l_dbus_message_iter_get_fixed_array(&iter_uuid, &uuid, &n) ||
-									n != 16)
-		return dbus_error(msg, MESH_ERROR_INVALID_ARGS, "Bad dev UUID");
+					n != 16 || !l_uuid_is_valid(uuid))
+		return dbus_error(msg, MESH_ERROR_INVALID_ARGS,
+							"Bad device UUID");
 
 	if (node_find_by_uuid(uuid))
 		return dbus_error(msg, MESH_ERROR_ALREADY_EXISTS,

--- a/test/test-mesh
+++ b/test/test-mesh
@@ -889,6 +889,11 @@ class MainMenu(Menu):
 
 		uuid = bytearray.fromhex("0a0102030405060708090A0B0C0D0E0F")
 		random.shuffle(uuid)
+		uuid[6] &= 0x0f;
+		uuid[6] |= 4 << 4;
+		uuid[8] &= 0x3f;
+		uuid[8] |= 0x80;
+
 		uuid_str = array_to_string(uuid)
 
 		print(set_yellow('Joining with UUID ') + set_green(uuid_str))

--- a/tools/mesh-cfgclient.c
+++ b/tools/mesh-cfgclient.c
@@ -731,7 +731,7 @@ static void create_net_setup(struct l_dbus_message *msg, void *user_data)
 	struct l_dbus_message_builder *builder;
 
 	/* Generate random UUID */
-	l_getrandom(app.uuid, sizeof(app.uuid));
+	l_uuid_v4(app.uuid);
 
 	builder = l_dbus_message_builder_new(msg);
 
@@ -899,7 +899,7 @@ static void cmd_import_node(int argc, char *argv[])
 
 	/* Device UUID */
 	req->data1 = l_util_from_hexstring(argv[1], &sz);
-	if (!req->data1 || sz != 16) {
+	if (!req->data1 || sz != 16 || !l_uuid_is_valid(req->data1)) {
 		l_error("Failed to generate UUID array from %s", argv[1]);
 		goto fail;
 	}
@@ -1298,7 +1298,7 @@ static void add_node_setup(struct l_dbus_message *msg, void *user_data)
 	struct l_dbus_message_builder *builder;
 
 	uuid = l_util_from_hexstring(str, &sz);
-	if (!uuid || sz != 16) {
+	if (!uuid || sz != 16 || !l_uuid_is_valid(uuid)) {
 		l_error("Failed to generate UUID array from %s", str);
 		return;
 	}

--- a/tools/mesh/mesh-db.c
+++ b/tools/mesh/mesh-db.c
@@ -1407,7 +1407,7 @@ bool mesh_db_create(const char *fname, const uint8_t token[8],
 	if (!add_u8_8(jcfg, "token", token))
 		goto fail;
 
-	l_getrandom(uuid, 16);
+	l_uuid_v4(uuid);
 
 	if (!add_u8_16(jcfg, "uuid", uuid))
 		goto fail;


### PR DESCRIPTION

Mesh profile spec states that the values use for Device UUIDs
folow format and generation procedures outlined in RFC 4122.
This patch set addresses this requirement.

Inga Stotland (4):
doc/mesh-api: Add notion of Device UUID compliance
mesh: Add validation of Device UUID value
test/test-mesh: Generate correct value for Device UUID
tools/mesh-cfg-client:

Makefile.am            |  6 ++++--
