### PR TITLE
[PW_SID:434305] [BlueZ,1/3] avdtp: Fix setting disconnect timer when there is no local endpoints


### DIFF
--- a/btio/btio.c
+++ b/btio/btio.c
@@ -274,7 +274,7 @@ static void server_add(GIOChannel *io, BtIOConnect connect,
 	server->destroy = destroy;
 
 	cond = G_IO_IN | G_IO_ERR | G_IO_HUP | G_IO_NVAL;
-	g_io_add_watch_full(io, G_PRIORITY_DEFAULT, cond, server_cb, server,
+	g_io_add_watch_full(io, G_PRIORITY_HIGH, cond, server_cb, server,
 					(GDestroyNotify) server_remove);
 }
 
@@ -291,7 +291,7 @@ static void connect_add(GIOChannel *io, BtIOConnect connect, bdaddr_t dst,
 	conn->dst = dst;
 
 	cond = G_IO_OUT | G_IO_ERR | G_IO_HUP | G_IO_NVAL;
-	g_io_add_watch_full(io, G_PRIORITY_DEFAULT, cond, connect_cb, conn,
+	g_io_add_watch_full(io, G_PRIORITY_HIGH, cond, connect_cb, conn,
 					(GDestroyNotify) connect_remove);
 }
 
@@ -307,7 +307,7 @@ static void accept_add(GIOChannel *io, BtIOConnect connect, gpointer user_data,
 	accept->destroy = destroy;
 
 	cond = G_IO_OUT | G_IO_ERR | G_IO_HUP | G_IO_NVAL;
-	g_io_add_watch_full(io, G_PRIORITY_DEFAULT, cond, accept_cb, accept,
+	g_io_add_watch_full(io, G_PRIORITY_HIGH, cond, accept_cb, accept,
 					(GDestroyNotify) accept_remove);
 }
 

--- a/profiles/audio/avdtp.c
+++ b/profiles/audio/avdtp.c
@@ -1226,7 +1226,13 @@ void avdtp_unref(struct avdtp *session)
 
 	switch (session->state) {
 	case AVDTP_SESSION_STATE_CONNECTED:
-		set_disconnect_timer(session);
+		/* Only set disconnect timer if there are local endpoints
+		 * otherwise disconnect immediately.
+		 */
+		if (queue_isempty(session->lseps))
+			connection_lost(session, ECONNRESET);
+		else
+			set_disconnect_timer(session);
 		break;
 	case AVDTP_SESSION_STATE_CONNECTING:
 		connection_lost(session, ECONNABORTED);

--- a/profiles/audio/avdtp.c
+++ b/profiles/audio/avdtp.c
@@ -2378,19 +2378,10 @@ static void avdtp_connect_cb(GIOChannel *chan, GError *err, gpointer user_data)
 		if (session->io_id)
 			g_source_remove(session->io_id);
 
-		/* This watch should be low priority since otherwise the
-		 * connect callback might be dispatched before the session
-		 * callback if the kernel wakes us up at the same time for
-		 * them. This could happen if a headset is very quick in
-		 * sending the Start command after connecting the stream
-		 * transport channel.
-		 */
-		session->io_id = g_io_add_watch_full(chan,
-						G_PRIORITY_LOW,
+		session->io_id = g_io_add_watch(chan,
 						G_IO_IN | G_IO_ERR | G_IO_HUP
 						| G_IO_NVAL,
-						(GIOFunc) session_cb, session,
-						NULL);
+						(GIOFunc) session_cb, session);
 
 		if (session->stream_setup)
 			set_disconnect_timer(session);


### PR DESCRIPTION

From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

If there are not local endpoints left there is no point in starting
the disconnect timer as without any endpoint it is not possible to
configure streams anymore so the code should proceed to disconnect
immediately.
