### PR TITLE
[PW_SID:437329] Cleanup: replace symbolic file permissions


### DIFF
--- a/mesh/rpl.c
+++ b/mesh/rpl.c
@@ -62,7 +62,7 @@ bool rpl_put_entry(struct mesh_node *node, uint16_t src, uint32_t iv_index,
 	snprintf(src_file, PATH_MAX, "%s%s/%8.8x/%4.4x", node_path, rpl_dir,
 								iv_index, src);
 
-	fd = open(src_file, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+	fd = open(src_file, O_WRONLY | O_CREAT | O_TRUNC, 0600);
 	if (fd >= 0) {
 		snprintf(seq_txt, 7, "%6.6x", seq);
 		if (write(fd, seq_txt, 6) == 6)

--- a/obexd/plugins/filesystem.c
+++ b/obexd/plugins/filesystem.c
@@ -116,15 +116,15 @@ static char *file_stat_line(char *filename, struct stat *fstat,
 
 	snprintf(perm, 50, "user-perm=\"%s%s%s\" group-perm=\"%s%s%s\" "
 			"other-perm=\"%s%s%s\"",
-			(fstat->st_mode & S_IRUSR ? "R" : ""),
-			(fstat->st_mode & S_IWUSR ? "W" : ""),
-			(dstat->st_mode & S_IWUSR ? "D" : ""),
-			(fstat->st_mode & S_IRGRP ? "R" : ""),
-			(fstat->st_mode & S_IWGRP ? "W" : ""),
-			(dstat->st_mode & S_IWGRP ? "D" : ""),
-			(fstat->st_mode & S_IROTH ? "R" : ""),
-			(fstat->st_mode & S_IWOTH ? "W" : ""),
-			(dstat->st_mode & S_IWOTH ? "D" : ""));
+			(fstat->st_mode & 0400 ? "R" : ""),
+			(fstat->st_mode & 0200 ? "W" : ""),
+			(dstat->st_mode & 0200 ? "D" : ""),
+			(fstat->st_mode & 0040 ? "R" : ""),
+			(fstat->st_mode & 0020 ? "W" : ""),
+			(dstat->st_mode & 0020 ? "D" : ""),
+			(fstat->st_mode & 0004 ? "R" : ""),
+			(fstat->st_mode & 0002 ? "W" : ""),
+			(dstat->st_mode & 0002 ? "D" : ""));
 
 	strftime(atime, 17, "%Y%m%dT%H%M%SZ", gmtime(&fstat->st_atime));
 	strftime(ctime, 17, "%Y%m%dT%H%M%SZ", gmtime(&fstat->st_ctime));

--- a/obexd/plugins/ftp.c
+++ b/obexd/plugins/ftp.c
@@ -284,8 +284,8 @@ int ftp_setpath(struct obex_session *os, void *user_data)
 		goto done;
 	}
 
-	if (S_ISDIR(dstat.st_mode) && (dstat.st_mode & S_IRUSR) &&
-						(dstat.st_mode & S_IXUSR)) {
+	if (S_ISDIR(dstat.st_mode) && (dstat.st_mode & 0400) &&
+						(dstat.st_mode & 0100)) {
 		set_folder(ftp, fullname);
 		goto done;
 	}

--- a/peripheral/efivars.c
+++ b/peripheral/efivars.c
@@ -98,8 +98,7 @@ int efivars_write(const char *name, uint32_t attributes,
 	if (!buf)
 		return -ENOMEM;
 
-	fd = open(pathname, O_CREAT | O_WRONLY | O_TRUNC | O_CLOEXEC,
-				S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+	fd = open(pathname, O_CREAT | O_WRONLY | O_TRUNC | O_CLOEXEC, 0644);
 	if (fd < 0) {
 		free(buf);
 		return -EIO;

--- a/profiles/input/suspend-dummy.c
+++ b/profiles/input/suspend-dummy.c
@@ -121,7 +121,7 @@ int suspend_init(suspend_event suspend, resume_event resume)
 		}
 	}
 
-	if (mkfifo(HOG_SUSPEND_FIFO, S_IRUSR | S_IWUSR) < 0) {
+	if (mkfifo(HOG_SUSPEND_FIFO, 0600) < 0) {
 		int err = -errno;
 
 		error("Can't create FIFO (%s): %s (%d)", HOG_SUSPEND_FIFO,

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -502,7 +502,7 @@ static void store_adapter_info(struct btd_adapter *adapter)
 	snprintf(filename, PATH_MAX, STORAGEDIR "/%s/settings",
 					btd_adapter_get_storage_dir(adapter));
 
-	create_file(filename, S_IRUSR | S_IWUSR);
+	create_file(filename, 0600);
 
 	str = g_key_file_to_data(key_file, &length, NULL);
 	g_file_set_contents(filename, str, length, NULL);
@@ -5427,7 +5427,7 @@ static void convert_names_entry(char *key, char *value, void *user_data)
 		return;
 
 	snprintf(filename, PATH_MAX, STORAGEDIR "/%s/cache/%s", address, str);
-	create_file(filename, S_IRUSR | S_IWUSR);
+	create_file(filename, 0600);
 
 	key_file = g_key_file_new();
 	g_key_file_load_from_file(key_file, filename, 0, NULL);
@@ -5663,7 +5663,7 @@ static void convert_entry(char *key, char *value, void *user_data)
 
 	data = g_key_file_to_data(key_file, &length, NULL);
 	if (length > 0) {
-		create_file(filename, S_IRUSR | S_IWUSR);
+		create_file(filename, 0600);
 		g_file_set_contents(filename, data, length, NULL);
 	}
 
@@ -5759,7 +5759,7 @@ static void store_sdp_record(char *local, char *peer, int handle, char *value)
 
 	data = g_key_file_to_data(key_file, &length, NULL);
 	if (length > 0) {
-		create_file(filename, S_IRUSR | S_IWUSR);
+		create_file(filename, 0600);
 		g_file_set_contents(filename, data, length, NULL);
 	}
 
@@ -5833,7 +5833,7 @@ static void convert_sdp_entry(char *key, char *value, void *user_data)
 
 	data = g_key_file_to_data(key_file, &length, NULL);
 	if (length > 0) {
-		create_file(filename, S_IRUSR | S_IWUSR);
+		create_file(filename, 0600);
 		g_file_set_contents(filename, data, length, NULL);
 	}
 
@@ -5898,7 +5898,7 @@ static void convert_primaries_entry(char *key, char *value, void *user_data)
 	if (length == 0)
 		goto end;
 
-	create_file(filename, S_IRUSR | S_IWUSR);
+	create_file(filename, 0600);
 	g_file_set_contents(filename, data, length, NULL);
 
 	if (device_type < 0)
@@ -5915,7 +5915,7 @@ static void convert_primaries_entry(char *key, char *value, void *user_data)
 
 	data = g_key_file_to_data(key_file, &length, NULL);
 	if (length > 0) {
-		create_file(filename, S_IRUSR | S_IWUSR);
+		create_file(filename, 0600);
 		g_file_set_contents(filename, data, length, NULL);
 	}
 
@@ -5964,7 +5964,7 @@ static void convert_ccc_entry(char *key, char *value, void *user_data)
 
 	data = g_key_file_to_data(key_file, &length, NULL);
 	if (length > 0) {
-		create_file(filename, S_IRUSR | S_IWUSR);
+		create_file(filename, 0600);
 		g_file_set_contents(filename, data, length, NULL);
 	}
 
@@ -6011,7 +6011,7 @@ static void convert_gatt_entry(char *key, char *value, void *user_data)
 
 	data = g_key_file_to_data(key_file, &length, NULL);
 	if (length > 0) {
-		create_file(filename, S_IRUSR | S_IWUSR);
+		create_file(filename, 0600);
 		g_file_set_contents(filename, data, length, NULL);
 	}
 
@@ -6056,7 +6056,7 @@ static void convert_proximity_entry(char *key, char *value, void *user_data)
 
 	data = g_key_file_to_data(key_file, &length, NULL);
 	if (length > 0) {
-		create_file(filename, S_IRUSR | S_IWUSR);
+		create_file(filename, 0600);
 		g_file_set_contents(filename, data, length, NULL);
 	}
 
@@ -6154,7 +6154,7 @@ static void convert_config(struct btd_adapter *adapter, const char *filename,
 	if (read_local_name(&adapter->bdaddr, str) == 0)
 		g_key_file_set_string(key_file, "General", "Alias", str);
 
-	create_file(filename, S_IRUSR | S_IWUSR);
+	create_file(filename, 0600);
 
 	data = g_key_file_to_data(key_file, &length, NULL);
 	g_file_set_contents(filename, data, length, NULL);
@@ -7962,7 +7962,7 @@ static void store_link_key(struct btd_adapter *adapter,
 	g_key_file_set_integer(key_file, "LinkKey", "Type", type);
 	g_key_file_set_integer(key_file, "LinkKey", "PINLength", pin_length);
 
-	create_file(filename, S_IRUSR | S_IWUSR);
+	create_file(filename, 0600);
 
 	str = g_key_file_to_data(key_file, &length, NULL);
 	g_file_set_contents(filename, str, length, NULL);
@@ -8059,7 +8059,7 @@ static void store_longtermkey(struct btd_adapter *adapter, const bdaddr_t *peer,
 	g_key_file_set_integer(key_file, group, "EDiv", ediv);
 	g_key_file_set_uint64(key_file, group, "Rand", rand);
 
-	create_file(filename, S_IRUSR | S_IWUSR);
+	create_file(filename, 0600);
 
 	str = g_key_file_to_data(key_file, &length, NULL);
 	g_file_set_contents(filename, str, length, NULL);
@@ -8183,7 +8183,7 @@ static void store_csrk(struct btd_adapter *adapter, const bdaddr_t *peer,
 	g_key_file_set_integer(key_file, group, "Counter", counter);
 	g_key_file_set_boolean(key_file, group, "Authenticated", auth);
 
-	create_file(filename, S_IRUSR | S_IWUSR);
+	create_file(filename, 0600);
 
 	str = g_key_file_to_data(key_file, &length, NULL);
 	g_file_set_contents(filename, str, length, NULL);
@@ -8251,7 +8251,7 @@ static void store_irk(struct btd_adapter *adapter, const bdaddr_t *peer,
 
 	g_key_file_set_string(key_file, "IdentityResolvingKey", "Key", str);
 
-	create_file(filename, S_IRUSR | S_IWUSR);
+	create_file(filename, 0600);
 
 	store_data = g_key_file_to_data(key_file, &length, NULL);
 	g_file_set_contents(filename, store_data, length, NULL);
@@ -8343,7 +8343,7 @@ static void store_conn_param(struct btd_adapter *adapter, const bdaddr_t *peer,
 	g_key_file_set_integer(key_file, "ConnectionParameters",
 						"Timeout", timeout);
 
-	create_file(filename, S_IRUSR | S_IWUSR);
+	create_file(filename, 0600);
 
 	store_data = g_key_file_to_data(key_file, &length, NULL);
 	g_file_set_contents(filename, store_data, length, NULL);

--- a/src/attrib-server.c
+++ b/src/attrib-server.c
@@ -919,7 +919,7 @@ static uint16_t write_value(struct gatt_channel *channel, uint16_t handle,
 
 		data = g_key_file_to_data(key_file, &length, NULL);
 		if (length > 0) {
-			create_file(filename, S_IRUSR | S_IWUSR);
+			create_file(filename, 0600);
 			g_file_set_contents(filename, data, length, NULL);
 		}
 

--- a/src/device.c
+++ b/src/device.c
@@ -463,7 +463,7 @@ static gboolean store_device_info_cb(gpointer user_data)
 	if (device->remote_csrk)
 		store_csrk(device->remote_csrk, key_file, "RemoteSignatureKey");
 
-	create_file(filename, S_IRUSR | S_IWUSR);
+	create_file(filename, 0600);
 
 	str = g_key_file_to_data(key_file, &length, NULL);
 	g_file_set_contents(filename, str, length, NULL);
@@ -522,7 +522,7 @@ void device_store_cached_name(struct btd_device *dev, const char *name)
 	ba2str(&dev->bdaddr, d_addr);
 	snprintf(filename, PATH_MAX, STORAGEDIR "/%s/cache/%s",
 			btd_adapter_get_storage_dir(dev->adapter), d_addr);
-	create_file(filename, S_IRUSR | S_IWUSR);
+	create_file(filename, 0600);
 
 	key_file = g_key_file_new();
 	g_key_file_load_from_file(key_file, filename, 0, NULL);
@@ -2290,7 +2290,7 @@ static void store_services(struct btd_device *device)
 
 	data = g_key_file_to_data(key_file, &length, NULL);
 	if (length > 0) {
-		create_file(filename, S_IRUSR | S_IWUSR);
+		create_file(filename, 0600);
 		g_file_set_contents(filename, data, length, NULL);
 	}
 
@@ -2478,7 +2478,7 @@ static void store_gatt_db(struct btd_device *device)
 	snprintf(filename, PATH_MAX, STORAGEDIR "/%s/cache/%s",
 				btd_adapter_get_storage_dir(device->adapter),
 				dst_addr);
-	create_file(filename, S_IRUSR | S_IWUSR);
+	create_file(filename, 0600);
 
 	key_file = g_key_file_new();
 	g_key_file_load_from_file(key_file, filename, 0, NULL);
@@ -4439,7 +4439,7 @@ static void device_remove_stored(struct btd_device *device)
 
 	data = g_key_file_to_data(key_file, &length, NULL);
 	if (length > 0) {
-		create_file(filename, S_IRUSR | S_IWUSR);
+		create_file(filename, 0600);
 		g_file_set_contents(filename, data, length, NULL);
 	}
 
@@ -4889,7 +4889,7 @@ next:
 	if (sdp_key_file) {
 		data = g_key_file_to_data(sdp_key_file, &length, NULL);
 		if (length > 0) {
-			create_file(sdp_file, S_IRUSR | S_IWUSR);
+			create_file(sdp_file, 0600);
 			g_file_set_contents(sdp_file, data, length, NULL);
 		}
 
@@ -4900,7 +4900,7 @@ next:
 	if (att_key_file) {
 		data = g_key_file_to_data(att_key_file, &length, NULL);
 		if (length > 0) {
-			create_file(att_file, S_IRUSR | S_IWUSR);
+			create_file(att_file, 0600);
 			g_file_set_contents(att_file, data, length, NULL);
 		}
 
@@ -5807,7 +5807,7 @@ void device_store_svc_chng_ccc(struct btd_device *device, uint8_t bdaddr_type,
 									value);
 	}
 
-	create_file(filename, S_IRUSR | S_IWUSR);
+	create_file(filename, 0600);
 
 	str = g_key_file_to_data(key_file, &length, NULL);
 	g_file_set_contents(filename, str, length, NULL);

--- a/src/sdpd-server.c
+++ b/src/sdpd-server.c
@@ -130,7 +130,7 @@ static int init_server(uint16_t mtu, int master, int compat)
 		return -1;
 	}
 
-	chmod(SDP_UNIX_PATH, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+	chmod(SDP_UNIX_PATH, 0660);
 
 	return 0;
 }

--- a/src/shared/btsnoop.c
+++ b/src/shared/btsnoop.c
@@ -151,7 +151,7 @@ struct btsnoop *btsnoop_create(const char *path, size_t max_size,
 	}
 
 	btsnoop->fd = open(real_path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC,
-					S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+									0644);
 	if (btsnoop->fd < 0) {
 		free(btsnoop);
 		return NULL;
@@ -230,7 +230,7 @@ static bool btsnoop_rotate(struct btsnoop *btsnoop)
 	btsnoop->cur_count++;
 
 	btsnoop->fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC,
-					S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+									0644);
 	if (btsnoop->fd < 0)
 		return false;
 

--- a/src/textfile.c
+++ b/src/textfile.c
@@ -65,7 +65,7 @@ int create_file(const char *filename, const mode_t mode)
 {
 	int fd;
 
-	create_dirs(filename, S_IRUSR | S_IWUSR | S_IXUSR);
+	create_dirs(filename, 0700);
 
 	fd = open(filename, O_RDWR | O_CREAT, mode);
 	if (fd < 0)

--- a/tools/btsnoop.c
+++ b/tools/btsnoop.c
@@ -57,8 +57,7 @@ static int create_btsnoop(const char *path)
 	ssize_t written;
 	int fd;
 
-	fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC,
-				S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+	fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
 	if (fd < 0) {
 		perror("failed to output file");
 		return -1;

--- a/tools/create-image.c
+++ b/tools/create-image.c
@@ -53,8 +53,7 @@
 
 static unsigned int ino_cnt = 721;
 
-#define REG_EXE	S_IFREG | \
-		S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH
+#define REG_EXE	S_IFREG | 0555
 
 static const struct {
 	const char *source;

--- a/tools/hcidump.c
+++ b/tools/hcidump.c
@@ -434,7 +434,7 @@ static int open_file(char *file, int mode, unsigned long flags)
 	else
 		open_flags = O_RDONLY;
 
-	fd = open(file, open_flags, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+	fd = open(file, open_flags, 0644);
 	if (fd < 0) {
 		perror("Can't open dump file");
 		exit(1);

--- a/tools/rctest.c
+++ b/tools/rctest.c
@@ -631,8 +631,7 @@ static void automated_send_recv()
 			do_listen(recv_mode);
 		}
 
-		save_fd = open(savefile, O_CREAT | O_WRONLY,
-						S_IRUSR | S_IWUSR);
+		save_fd = open(savefile, O_CREAT | O_WRONLY, 0600);
 		if (save_fd < 0)
 			syslog(LOG_ERR, "Failed to open file to save data");
 


### PR DESCRIPTION

The kernel has moved away from using Symbolic File Permission macros,
and this is reflected in our checkpatch usage which flags lines which
still use them.  The preferred method is to use the well known octal
notation, for instance 0755 meaning:

User has read/write/execute permissions
Group has read/execute permissions
Other has read/execute permissions

Brian Gix (6):
mesh: Cleanup deprecated symbolic file permissions
obexd: Cleanup deprecated symbolic file permissions
peripheral: Cleanup deprecated symbolic file permissions
profiles: Cleanup deprecated symbolic file permissions
src: Cleanup deprecated symbolic file permissions
tools: Cleanup deprecated symbolic file permissions

mesh/rpl.c                     |  2 +-
