### PR TITLE
[PW_SID:439193] [BlueZ,v2] monitor: Add option to set fallback width


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,39 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Coverity Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "coverity"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+
+  clang-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Clang Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "clang"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/monitor/control.c
+++ b/monitor/control.c
@@ -1474,7 +1474,7 @@ bool control_writer(const char *path)
 	return !!btsnoop_file;
 }
 
-void control_reader(const char *path, bool pager)
+void control_reader(const char *path, bool pager, int num_columns)
 {
 	unsigned char buf[BTSNOOP_MAX_PACKET_SIZE];
 	uint16_t pktlen;
@@ -1500,7 +1500,7 @@ void control_reader(const char *path, bool pager)
 	}
 
 	if (pager)
-		open_pager();
+		open_pager(num_columns);
 
 	switch (format) {
 	case BTSNOOP_FORMAT_HCI:

--- a/monitor/control.h
+++ b/monitor/control.h
@@ -12,7 +12,7 @@
 #include <stdint.h>
 
 bool control_writer(const char *path);
-void control_reader(const char *path, bool pager);
+void control_reader(const char *path, bool pager, int num_columns);
 void control_server(const char *path);
 int control_tty(const char *path, unsigned int speed);
 int control_rtt(char *jlink, char *rtt);

--- a/monitor/display.c
+++ b/monitor/display.c
@@ -28,6 +28,7 @@
 #include "display.h"
 
 static pid_t pager_pid = 0;
+static int n_columns = FALLBACK_TERMINAL_WIDTH;
 
 bool use_color(void)
 {
@@ -48,7 +49,8 @@ int num_columns(void)
 
 		if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) < 0 ||
 								ws.ws_col == 0)
-			cached_num_columns = FALLBACK_TERMINAL_WIDTH;
+			cached_num_columns = n_columns > 0 ?
+				n_columns : FALLBACK_TERMINAL_WIDTH;
 		else
 			cached_num_columns = ws.ws_col;
 	}
@@ -81,11 +83,13 @@ static void wait_for_terminate(pid_t pid)
 	}
 }
 
-void open_pager(void)
+void open_pager(int columns)
 {
 	const char *pager;
 	pid_t parent_pid;
 	int fd[2];
+
+	n_columns = columns;
 
 	if (pager_pid > 0)
 		return;

--- a/monitor/display.h
+++ b/monitor/display.h
@@ -75,5 +75,5 @@ static inline uint64_t print_bitfield(int indent, uint64_t val,
 
 int num_columns(void);
 
-void open_pager(void);
+void open_pager(int);
 void close_pager(void);

--- a/monitor/main.c
+++ b/monitor/main.c
@@ -67,6 +67,7 @@ static void usage(void)
 		"\t                       Read data from RTT\n"
 		"\t-R  --rtt [<address>],[<area>],[<name>]\n"
 		"\t                       RTT control block parameters\n"
+		"\t-C, --column [width]   Output width if not a terminal\n"
 		"\t-h, --help             Show help options\n");
 }
 
@@ -90,6 +91,7 @@ static const struct option main_options[] = {
 	{ "no-pager",  no_argument,       NULL, 'P' },
 	{ "jlink",     required_argument, NULL, 'J' },
 	{ "rtt",       required_argument, NULL, 'R' },
+	{ "column",    required_argument, NULL, 'C' },
 	{ "todo",      no_argument,       NULL, '#' },
 	{ "version",   no_argument,       NULL, 'v' },
 	{ "help",      no_argument,       NULL, 'h' },
@@ -110,6 +112,7 @@ int main(int argc, char *argv[])
 	const char *str;
 	char *jlink = NULL;
 	char *rtt = NULL;
+	int num_columns = 0;
 	int exit_status;
 
 	mainloop_init();
@@ -121,7 +124,7 @@ int main(int argc, char *argv[])
 		struct sockaddr_un addr;
 
 		opt = getopt_long(argc, argv,
-					"r:w:a:s:p:i:d:B:V:MNtTSAE:PJ:R:vh",
+					"r:w:a:s:p:i:d:B:V:MNtTSAE:PJ:R:vhC:",
 					main_options, NULL);
 		if (opt < 0)
 			break;
@@ -205,6 +208,9 @@ int main(int argc, char *argv[])
 		case 'R':
 			rtt = optarg;
 			break;
+		case 'C':
+			num_columns = atoi(optarg);
+			break;
 		case '#':
 			packet_todo();
 			lmp_todo();
@@ -245,7 +251,7 @@ int main(int argc, char *argv[])
 		if (ellisys_server)
 			ellisys_enable(ellisys_server, ellisys_port);
 
-		control_reader(reader_path, use_pager);
+		control_reader(reader_path, use_pager, num_columns);
 		return EXIT_SUCCESS;
 	}
 


### PR DESCRIPTION

Sometimes we want to be able to pipe the output of btmon to a
non-terminal device. The current fallback width is usually not long
enough so this patch adds an option to specify the column width. This is
especially needed for text logs from bluetoothd.

Reviewed-by: Daniel Winkler <danielwinkler@google.com>
