### PR TITLE
[PW_SID:440755] [BlueZ,v4] monitor: Add option to set fallback width


### DIFF
--- a/monitor/display.c
+++ b/monitor/display.c
@@ -28,6 +28,7 @@
 #include "display.h"
 
 static pid_t pager_pid = 0;
+int default_pager_num_columns = FALLBACK_TERMINAL_WIDTH;
 
 bool use_color(void)
 {
@@ -39,6 +40,11 @@ bool use_color(void)
 	return cached_use_color;
 }
 
+void set_default_pager_num_columns(int num_columns)
+{
+	default_pager_num_columns = num_columns;
+}
+
 int num_columns(void)
 {
 	static int cached_num_columns = -1;
@@ -48,7 +54,7 @@ int num_columns(void)
 
 		if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) < 0 ||
 								ws.ws_col == 0)
-			cached_num_columns = FALLBACK_TERMINAL_WIDTH;
+			cached_num_columns = default_pager_num_columns;
 		else
 			cached_num_columns = ws.ws_col;
 	}

--- a/monitor/display.h
+++ b/monitor/display.h
@@ -73,6 +73,7 @@ static inline uint64_t print_bitfield(int indent, uint64_t val,
 	return mask;
 }
 
+void set_default_pager_num_columns(int num_columns);
 int num_columns(void);
 
 void open_pager(void);

--- a/monitor/main.c
+++ b/monitor/main.c
@@ -30,6 +30,7 @@
 #include "analyze.h"
 #include "ellisys.h"
 #include "control.h"
+#include "display.h"
 
 static void signal_callback(int signum, void *user_data)
 {
@@ -67,6 +68,7 @@ static void usage(void)
 		"\t                       Read data from RTT\n"
 		"\t-R  --rtt [<address>],[<area>],[<name>]\n"
 		"\t                       RTT control block parameters\n"
+		"\t-C, --columns [width]  Output width if not a terminal\n"
 		"\t-h, --help             Show help options\n");
 }
 
@@ -90,6 +92,7 @@ static const struct option main_options[] = {
 	{ "no-pager",  no_argument,       NULL, 'P' },
 	{ "jlink",     required_argument, NULL, 'J' },
 	{ "rtt",       required_argument, NULL, 'R' },
+	{ "columns",   required_argument, NULL, 'C' },
 	{ "todo",      no_argument,       NULL, '#' },
 	{ "version",   no_argument,       NULL, 'v' },
 	{ "help",      no_argument,       NULL, 'h' },
@@ -121,7 +124,7 @@ int main(int argc, char *argv[])
 		struct sockaddr_un addr;
 
 		opt = getopt_long(argc, argv,
-					"r:w:a:s:p:i:d:B:V:MNtTSAE:PJ:R:vh",
+					"r:w:a:s:p:i:d:B:V:MNtTSAE:PJ:R:C:vh",
 					main_options, NULL);
 		if (opt < 0)
 			break;
@@ -204,6 +207,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'R':
 			rtt = optarg;
+			break;
+		case 'C':
+			set_default_pager_num_columns(atoi(optarg));
 			break;
 		case '#':
 			packet_todo();


### PR DESCRIPTION

Sometimes we want to be able to pipe the output of btmon to a
non-terminal device. The current fallback width is usually not long
enough so this patch adds an option to specify the column width. This is
especially needed for text logs from bluetoothd.

Reviewed-by: Daniel Winkler <danielwinkler@google.com>
