### PR TITLE
[PW_SID:449327] adapter: Fix discovery trigger for 0 second delay


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,39 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Coverity Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "coverity"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+
+  clang-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Clang Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "clang"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/plugins/policy.c
+++ b/plugins/policy.c
@@ -31,6 +31,7 @@
 #include "src/service.h"
 #include "src/profile.h"
 #include "src/btd.h"
+#include "src/shared/timeout.h"
 
 #define CONTROL_CONNECT_TIMEOUT 2
 #define SOURCE_RETRY_TIMEOUT 2
@@ -46,7 +47,7 @@ struct reconnect_data {
 	struct btd_device *dev;
 	bool reconnect;
 	GSList *services;
-	guint timer;
+	unsigned int timer;
 	bool active;
 	unsigned int attempt;
 	bool on_resume;
@@ -77,13 +78,13 @@ static bool auto_enable = false;
 struct policy_data {
 	struct btd_device *dev;
 
-	guint source_timer;
+	unsigned int source_timer;
 	uint8_t source_retries;
-	guint sink_timer;
+	unsigned int sink_timer;
 	uint8_t sink_retries;
-	guint ct_timer;
+	unsigned int ct_timer;
 	uint8_t ct_retries;
-	guint tg_timer;
+	unsigned int tg_timer;
 	uint8_t tg_retries;
 };
 
@@ -126,7 +127,7 @@ static void policy_disconnect(struct policy_data *data,
 	btd_service_disconnect(service);
 }
 
-static gboolean policy_connect_ct(gpointer user_data)
+static bool policy_connect_ct(gpointer user_data)
 {
 	struct policy_data *data = user_data;
 	struct btd_service *service;
@@ -144,10 +145,10 @@ static gboolean policy_connect_ct(gpointer user_data)
 static void policy_set_ct_timer(struct policy_data *data, int timeout)
 {
 	if (data->ct_timer > 0)
-		g_source_remove(data->ct_timer);
+		timeout_remove(data->ct_timer);
 
-	data->ct_timer = g_timeout_add_seconds(timeout, policy_connect_ct,
-									data);
+	data->ct_timer = timeout_add_seconds(timeout, policy_connect_ct,
+						data, NULL);
 }
 
 static struct policy_data *find_data(struct btd_device *dev)
@@ -169,16 +170,16 @@ static void policy_remove(void *user_data)
 	struct policy_data *data = user_data;
 
 	if (data->source_timer > 0)
-		g_source_remove(data->source_timer);
+		timeout_remove(data->source_timer);
 
 	if (data->sink_timer > 0)
-		g_source_remove(data->sink_timer);
+		timeout_remove(data->sink_timer);
 
 	if (data->ct_timer > 0)
-		g_source_remove(data->ct_timer);
+		timeout_remove(data->ct_timer);
 
 	if (data->tg_timer > 0)
-		g_source_remove(data->tg_timer);
+		timeout_remove(data->tg_timer);
 
 	g_free(data);
 }
@@ -199,7 +200,7 @@ static struct policy_data *policy_get_data(struct btd_device *dev)
 	return data;
 }
 
-static gboolean policy_connect_sink(gpointer user_data)
+static bool policy_connect_sink(gpointer user_data)
 {
 	struct policy_data *data = user_data;
 	struct btd_service *service;
@@ -217,11 +218,11 @@ static gboolean policy_connect_sink(gpointer user_data)
 static void policy_set_sink_timer(struct policy_data *data)
 {
 	if (data->sink_timer > 0)
-		g_source_remove(data->sink_timer);
+		timeout_remove(data->sink_timer);
 
-	data->sink_timer = g_timeout_add_seconds(SINK_RETRY_TIMEOUT,
+	data->sink_timer = timeout_add_seconds(SINK_RETRY_TIMEOUT,
 							policy_connect_sink,
-							data);
+							data, NULL);
 }
 
 static void sink_cb(struct btd_service *service, btd_service_state_t old_state,
@@ -240,7 +241,7 @@ static void sink_cb(struct btd_service *service, btd_service_state_t old_state,
 	switch (new_state) {
 	case BTD_SERVICE_STATE_UNAVAILABLE:
 		if (data->sink_timer > 0) {
-			g_source_remove(data->sink_timer);
+			timeout_remove(data->sink_timer);
 			data->sink_timer = 0;
 		}
 		break;
@@ -255,13 +256,13 @@ static void sink_cb(struct btd_service *service, btd_service_state_t old_state,
 					data->sink_retries = 0;
 				break;
 			} else if (data->sink_timer > 0) {
-				g_source_remove(data->sink_timer);
+				timeout_remove(data->sink_timer);
 				data->sink_timer = 0;
 			}
 		}
 
 		if (data->ct_timer > 0) {
-			g_source_remove(data->ct_timer);
+			timeout_remove(data->ct_timer);
 			data->ct_timer = 0;
 		} else if (btd_service_get_state(controller) !=
 						BTD_SERVICE_STATE_DISCONNECTED)
@@ -271,7 +272,7 @@ static void sink_cb(struct btd_service *service, btd_service_state_t old_state,
 		break;
 	case BTD_SERVICE_STATE_CONNECTED:
 		if (data->sink_timer > 0) {
-			g_source_remove(data->sink_timer);
+			timeout_remove(data->sink_timer);
 			data->sink_timer = 0;
 		}
 
@@ -325,7 +326,7 @@ static void hs_cb(struct btd_service *service, btd_service_state_t old_state,
 	}
 }
 
-static gboolean policy_connect_tg(gpointer user_data)
+static bool policy_connect_tg(gpointer user_data)
 {
 	struct policy_data *data = user_data;
 	struct btd_service *service;
@@ -343,13 +344,13 @@ static gboolean policy_connect_tg(gpointer user_data)
 static void policy_set_tg_timer(struct policy_data *data, int timeout)
 {
 	if (data->tg_timer > 0)
-		g_source_remove(data->tg_timer);
+		timeout_remove(data->tg_timer);
 
-	data->tg_timer = g_timeout_add_seconds(timeout, policy_connect_tg,
-							data);
+	data->tg_timer = timeout_add_seconds(timeout, policy_connect_tg,
+							data, NULL);
 }
 
-static gboolean policy_connect_source(gpointer user_data)
+static bool policy_connect_source(gpointer user_data)
 {
 	struct policy_data *data = user_data;
 	struct btd_service *service;
@@ -367,11 +368,11 @@ static gboolean policy_connect_source(gpointer user_data)
 static void policy_set_source_timer(struct policy_data *data)
 {
 	if (data->source_timer > 0)
-		g_source_remove(data->source_timer);
+		timeout_remove(data->source_timer);
 
-	data->source_timer = g_timeout_add_seconds(SOURCE_RETRY_TIMEOUT,
+	data->source_timer = timeout_add_seconds(SOURCE_RETRY_TIMEOUT,
 							policy_connect_source,
-							data);
+							data, NULL);
 }
 
 static void source_cb(struct btd_service *service,
@@ -391,7 +392,7 @@ static void source_cb(struct btd_service *service,
 	switch (new_state) {
 	case BTD_SERVICE_STATE_UNAVAILABLE:
 		if (data->source_timer > 0) {
-			g_source_remove(data->source_timer);
+			timeout_remove(data->source_timer);
 			data->source_timer = 0;
 		}
 		break;
@@ -406,13 +407,13 @@ static void source_cb(struct btd_service *service,
 					data->source_retries = 0;
 				break;
 			} else if (data->source_timer > 0) {
-				g_source_remove(data->source_timer);
+				timeout_remove(data->source_timer);
 				data->source_timer = 0;
 			}
 		}
 
 		if (data->tg_timer > 0) {
-			g_source_remove(data->tg_timer);
+			timeout_remove(data->tg_timer);
 			data->tg_timer = 0;
 		} else if (btd_service_get_state(target) !=
 						BTD_SERVICE_STATE_DISCONNECTED)
@@ -422,7 +423,7 @@ static void source_cb(struct btd_service *service,
 		break;
 	case BTD_SERVICE_STATE_CONNECTED:
 		if (data->source_timer > 0) {
-			g_source_remove(data->source_timer);
+			timeout_remove(data->source_timer);
 			data->source_timer = 0;
 		}
 
@@ -454,7 +455,7 @@ static void controller_cb(struct btd_service *service,
 	switch (new_state) {
 	case BTD_SERVICE_STATE_UNAVAILABLE:
 		if (data->ct_timer > 0) {
-			g_source_remove(data->ct_timer);
+			timeout_remove(data->ct_timer);
 			data->ct_timer = 0;
 		}
 		break;
@@ -470,7 +471,7 @@ static void controller_cb(struct btd_service *service,
 					data->ct_retries = 0;
 				break;
 			} else if (data->ct_timer > 0) {
-				g_source_remove(data->ct_timer);
+				timeout_remove(data->ct_timer);
 				data->ct_timer = 0;
 			}
 		} else if (old_state == BTD_SERVICE_STATE_CONNECTED) {
@@ -481,7 +482,7 @@ static void controller_cb(struct btd_service *service,
 		break;
 	case BTD_SERVICE_STATE_CONNECTED:
 		if (data->ct_timer > 0) {
-			g_source_remove(data->ct_timer);
+			timeout_remove(data->ct_timer);
 			data->ct_timer = 0;
 		}
 		break;
@@ -504,7 +505,7 @@ static void target_cb(struct btd_service *service,
 	switch (new_state) {
 	case BTD_SERVICE_STATE_UNAVAILABLE:
 		if (data->tg_timer > 0) {
-			g_source_remove(data->tg_timer);
+			timeout_remove(data->tg_timer);
 			data->tg_timer = 0;
 		}
 		break;
@@ -520,7 +521,7 @@ static void target_cb(struct btd_service *service,
 					data->tg_retries = 0;
 				break;
 			} else if (data->tg_timer > 0) {
-				g_source_remove(data->tg_timer);
+				timeout_remove(data->tg_timer);
 				data->tg_timer = 0;
 			}
 		} else if (old_state == BTD_SERVICE_STATE_CONNECTED) {
@@ -531,7 +532,7 @@ static void target_cb(struct btd_service *service,
 		break;
 	case BTD_SERVICE_STATE_CONNECTED:
 		if (data->tg_timer > 0) {
-			g_source_remove(data->tg_timer);
+			timeout_remove(data->tg_timer);
 			data->tg_timer = 0;
 		}
 		break;
@@ -546,7 +547,7 @@ static void reconnect_reset(struct reconnect_data *reconnect)
 	reconnect->active = false;
 
 	if (reconnect->timer > 0) {
-		g_source_remove(reconnect->timer);
+		timeout_remove(reconnect->timer);
 		reconnect->timer = 0;
 	}
 }
@@ -592,7 +593,7 @@ static void reconnect_destroy(gpointer data)
 	struct reconnect_data *reconnect = data;
 
 	if (reconnect->timer > 0)
-		g_source_remove(reconnect->timer);
+		timeout_remove(reconnect->timer);
 
 	g_slist_free_full(reconnect->services,
 					(GDestroyNotify) btd_service_unref);
@@ -622,7 +623,7 @@ static void reconnect_remove(struct btd_service *service)
 	reconnects = g_slist_remove(reconnects, reconnect);
 
 	if (reconnect->timer > 0)
-		g_source_remove(reconnect->timer);
+		timeout_remove(reconnect->timer);
 
 	g_free(reconnect);
 }
@@ -693,7 +694,7 @@ static void service_cb(struct btd_service *service,
 	DBG("Added %s reconnect %u", profile->name, reconnect->reconnect);
 }
 
-static gboolean reconnect_timeout(gpointer data)
+static bool reconnect_timeout(gpointer data)
 {
 	struct reconnect_data *reconnect = data;
 	int err;
@@ -734,8 +735,8 @@ static void reconnect_set_timer(struct reconnect_data *reconnect, int timeout)
 	DBG("attempt %u/%zu %d seconds", reconnect->attempt + 1,
 						reconnect_attempts, timeout);
 
-	reconnect->timer = g_timeout_add_seconds(timeout, reconnect_timeout,
-								reconnect);
+	reconnect->timer = timeout_add_seconds(timeout, reconnect_timeout,
+						reconnect, NULL);
 }
 
 static void disconnect_cb(struct btd_device *dev, uint8_t reason)

--- a/profiles/health/hdp.c
+++ b/profiles/health/hdp.c
@@ -31,6 +31,7 @@
 #include "src/adapter.h"
 #include "src/device.h"
 #include "src/sdpd.h"
+#include "src/shared/timeout.h"
 #include "btio/btio.h"
 
 #include "hdp_types.h"
@@ -70,7 +71,7 @@ struct hdp_tmp_dc_data {
 struct hdp_echo_data {
 	gboolean		echo_done;	/* Is a echo was already done */
 	gpointer		buf;		/* echo packet sent */
-	guint			tid;		/* echo timeout */
+	unsigned int		tid;		/* echo timeout */
 };
 
 static struct hdp_channel *hdp_channel_ref(struct hdp_channel *chan)
@@ -683,7 +684,7 @@ static void free_echo_data(struct hdp_echo_data *edata)
 		return;
 
 	if (edata->tid > 0)
-		g_source_remove(edata->tid);
+		timeout_remove(edata->tid);
 
 	if (edata->buf != NULL)
 		g_free(edata->buf);
@@ -1524,7 +1525,7 @@ end:
 	reply = g_dbus_create_reply(hdp_conn->msg, DBUS_TYPE_BOOLEAN, &value,
 							DBUS_TYPE_INVALID);
 	g_dbus_send_message(btd_get_dbus_connection(), reply);
-	g_source_remove(edata->tid);
+	timeout_remove(edata->tid);
 	edata->tid = 0;
 	g_free(edata->buf);
 	edata->buf = NULL;
@@ -1538,7 +1539,7 @@ end:
 	return FALSE;
 }
 
-static gboolean echo_timeout(gpointer data)
+static bool echo_timeout(gpointer data)
 {
 	struct hdp_channel *chan = data;
 	GIOChannel *io;
@@ -1606,10 +1607,9 @@ static void hdp_echo_connect_cb(struct mcap_mdl *mdl, GError *err,
 	g_io_add_watch(io, G_IO_ERR | G_IO_HUP | G_IO_NVAL | G_IO_IN,
 			check_echo, hdp_tmp_dc_data_ref(hdp_conn));
 
-	edata->tid = g_timeout_add_seconds_full(G_PRIORITY_DEFAULT,
-					ECHO_TIMEOUT, echo_timeout,
-					hdp_channel_ref(hdp_conn->hdp_chann),
-					(GDestroyNotify) hdp_channel_unref);
+	edata->tid = timeout_add_seconds(ECHO_TIMEOUT, echo_timeout,
+				hdp_channel_ref(hdp_conn->hdp_chann),
+				(timeout_destroy_func_t) hdp_channel_unref);
 
 	g_io_channel_unref(io);
 }

--- a/profiles/health/mcap.c
+++ b/profiles/health/mcap.c
@@ -26,6 +26,7 @@
 #include "bluetooth/l2cap.h"
 #include "btio/btio.h"
 #include "src/log.h"
+#include "src/shared/timeout.h"
 
 #include "mcap.h"
 
@@ -43,7 +44,7 @@
 
 #define RELEASE_TIMER(__mcl) do {		\
 	if (__mcl->tid) {			\
-		g_source_remove(__mcl->tid);	\
+		timeout_remove(__mcl->tid);	\
 		__mcl->tid = 0;			\
 	}					\
 } while(0)
@@ -483,7 +484,7 @@ static int compare_mdl(gconstpointer a, gconstpointer b)
 		return 1;
 }
 
-static gboolean wait_response_timer(gpointer data)
+static bool wait_response_timer(gpointer data)
 {
 	struct mcap_mcl *mcl = data;
 
@@ -549,8 +550,8 @@ gboolean mcap_create_mdl(struct mcap_mcl *mcl,
 
 	mcl->mdls = g_slist_insert_sorted(mcl->mdls, mcap_mdl_ref(mdl),
 								compare_mdl);
-	mcl->tid = g_timeout_add_seconds(RESPONSE_TIMER, wait_response_timer,
-									mcl);
+	mcl->tid = timeout_add_seconds(RESPONSE_TIMER, wait_response_timer,
+					mcl, NULL);
 	return TRUE;
 }
 
@@ -587,8 +588,8 @@ gboolean mcap_reconnect_mdl(struct mcap_mdl *mdl,
 	mcl->state = MCL_ACTIVE;
 	mcl->priv_data = con;
 
-	mcl->tid = g_timeout_add_seconds(RESPONSE_TIMER, wait_response_timer,
-									mcl);
+	mcl->tid = timeout_add_seconds(RESPONSE_TIMER, wait_response_timer,
+					mcl, NULL);
 	return TRUE;
 }
 
@@ -607,8 +608,8 @@ static gboolean send_delete_req(struct mcap_mcl *mcl,
 
 	mcl->priv_data = con;
 
-	mcl->tid = g_timeout_add_seconds(RESPONSE_TIMER, wait_response_timer,
-									mcl);
+	mcl->tid = timeout_add_seconds(RESPONSE_TIMER, wait_response_timer,
+					mcl, NULL);
 	return TRUE;
 }
 
@@ -718,8 +719,8 @@ gboolean mcap_mdl_abort(struct mcap_mdl *mdl, mcap_mdl_notify_cb abort_cb,
 	con->user_data = user_data;
 
 	mcl->priv_data = con;
-	mcl->tid = g_timeout_add_seconds(RESPONSE_TIMER, wait_response_timer,
-									mcl);
+	mcl->tid = timeout_add_seconds(RESPONSE_TIMER, wait_response_timer,
+					mcl, NULL);
 	return TRUE;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -41,6 +41,7 @@
 
 #include "shared/att-types.h"
 #include "shared/mainloop.h"
+#include "shared/timeout.h"
 #include "lib/uuid.h"
 #include "shared/util.h"
 #include "btd.h"
@@ -853,7 +854,7 @@ void btd_exit(void)
 	mainloop_quit();
 }
 
-static gboolean quit_eventloop(gpointer user_data)
+static bool quit_eventloop(gpointer user_data)
 {
 	btd_exit();
 	return FALSE;
@@ -868,8 +869,8 @@ static void signal_callback(int signum, void *user_data)
 	case SIGTERM:
 		if (!terminated) {
 			info("Terminating");
-			g_timeout_add_seconds(SHUTDOWN_GRACE_SECONDS,
-							quit_eventloop, NULL);
+			timeout_add_seconds(SHUTDOWN_GRACE_SECONDS,
+						quit_eventloop, NULL, NULL);
 
 			mainloop_sd_notify("STATUS=Powering down");
 			adapter_shutdown();

--- a/src/shared/timeout-ell.c
+++ b/src/shared/timeout-ell.c
@@ -101,3 +101,9 @@ void timeout_remove(unsigned int id)
 	if (to)
 		l_timeout_remove(to);
 }
+
+unsigned int timeout_add_seconds(unsigned int timeout, timeout_func_t func,
+			void *user_data, timeout_destroy_func_t destroy)
+{
+	return timeout_add(timeout * 1000, func, user_data, destroy);
+}

--- a/src/shared/timeout-glib.c
+++ b/src/shared/timeout-glib.c
@@ -71,3 +71,30 @@ void timeout_remove(unsigned int id)
 	if (source)
 		g_source_destroy(source);
 }
+
+unsigned int timeout_add_seconds(unsigned int timeout, timeout_func_t func,
+			void *user_data, timeout_destroy_func_t destroy)
+{
+	struct timeout_data *data;
+	guint id;
+
+	data = g_try_new0(struct timeout_data, 1);
+	if (!data)
+		return 0;
+
+	data->func = func;
+	data->destroy = destroy;
+	data->user_data = user_data;
+
+	if (!timeout)
+		id = g_idle_add_full(G_PRIORITY_DEFAULT_IDLE, timeout_callback,
+							data, timeout_destroy);
+	else
+		id = g_timeout_add_seconds_full(G_PRIORITY_DEFAULT, timeout,
+							timeout_callback, data,
+							timeout_destroy);
+	if (!id)
+		g_free(data);
+
+	return id;
+}

--- a/src/shared/timeout-mainloop.c
+++ b/src/shared/timeout-mainloop.c
@@ -71,3 +71,9 @@ void timeout_remove(unsigned int id)
 
 	mainloop_remove_timeout((int) id);
 }
+
+unsigned int timeout_add_seconds(unsigned int timeout, timeout_func_t func,
+			void *user_data, timeout_destroy_func_t destroy)
+{
+	return timeout_add(timeout * 1000, func, user_data, destroy);
+}

--- a/src/shared/timeout.h
+++ b/src/shared/timeout.h
@@ -16,3 +16,6 @@ typedef void (*timeout_destroy_func_t)(void *user_data);
 unsigned int timeout_add(unsigned int timeout, timeout_func_t func,
 			void *user_data, timeout_destroy_func_t destroy);
 void timeout_remove(unsigned int id);
+
+unsigned int timeout_add_seconds(unsigned int timeout, timeout_func_t func,
+			void *user_data, timeout_destroy_func_t destroy);


### PR DESCRIPTION

When calling `StartDiscovery` the effective start can take around 10 ms or
up to 700 ms.
g_timeout_add_seconds() call doesn't ensure the time for the first call of
the timer if the delay is less or equal to 1 second.

v2: Fix issue found by CI
v3: Add a wrapper function for g_timeout_add_seconds and replace calls to it in
src/*, profiles/* and plugins/*
v4: Fix issue found by CI
v5: Fix issue found by CI

Frédéric Danis (4):
shared/timeout: Add timeout_add_seconds abstraction
src: Replace calls to g_timeout_add_seconds by timeout_add_seconds
plugins: Replace calls to g_timeout_add_seconds by timeout_add_seconds
profiles: Replace calls to g_timeout_add_seconds by
timeout_add_seconds

