### PR TITLE
[PW_SID:449559] [BlueZ] monitor: Add option to force output color


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,39 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Coverity Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "coverity"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+
+  clang-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Clang Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_repo: "tedd-an/bluez"
+        scan_tool: "clang"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/monitor/display.c
+++ b/monitor/display.c
@@ -29,12 +29,22 @@
 
 static pid_t pager_pid = 0;
 int default_pager_num_columns = FALLBACK_TERMINAL_WIDTH;
+enum monitor_color setting_monitor_color = COLOR_AUTO;
+
+void set_monitor_color(enum monitor_color color)
+{
+	setting_monitor_color = color;
+}
 
 bool use_color(void)
 {
 	static int cached_use_color = -1;
 
-	if (__builtin_expect(!!(cached_use_color < 0), 0))
+	if (setting_monitor_color == COLOR_ALWAYS)
+		cached_use_color = 1;
+	else if (setting_monitor_color == COLOR_NEVER)
+		cached_use_color = 0;
+	else if (__builtin_expect(!!(cached_use_color < 0), 0))
 		cached_use_color = isatty(STDOUT_FILENO) > 0 || pager_pid > 0;
 
 	return cached_use_color;

--- a/monitor/display.h
+++ b/monitor/display.h
@@ -14,6 +14,9 @@
 
 bool use_color(void);
 
+enum monitor_color { COLOR_AUTO, COLOR_ALWAYS, COLOR_NEVER };
+void set_monitor_color(enum monitor_color);
+
 #define COLOR_OFF	"\x1B[0m"
 #define COLOR_BLACK	"\x1B[0;30m"
 #define COLOR_RED	"\x1B[0;31m"

--- a/monitor/main.c
+++ b/monitor/main.c
@@ -69,6 +69,7 @@ static void usage(void)
 		"\t-R  --rtt [<address>],[<area>],[<name>]\n"
 		"\t                       RTT control block parameters\n"
 		"\t-C, --columns [width]  Output width if not a terminal\n"
+		"\t-c, --color [mode]     Output color: auto/always/never\n"
 		"\t-h, --help             Show help options\n");
 }
 
@@ -93,6 +94,7 @@ static const struct option main_options[] = {
 	{ "jlink",     required_argument, NULL, 'J' },
 	{ "rtt",       required_argument, NULL, 'R' },
 	{ "columns",   required_argument, NULL, 'C' },
+	{ "color",     required_argument, NULL, 'c' },
 	{ "todo",      no_argument,       NULL, '#' },
 	{ "version",   no_argument,       NULL, 'v' },
 	{ "help",      no_argument,       NULL, 'h' },
@@ -124,7 +126,7 @@ int main(int argc, char *argv[])
 		struct sockaddr_un addr;
 
 		opt = getopt_long(argc, argv,
-					"r:w:a:s:p:i:d:B:V:MNtTSAE:PJ:R:C:vh",
+					"r:w:a:s:p:i:d:B:V:MNtTSAE:PJ:R:C:c:vh",
 					main_options, NULL);
 		if (opt < 0)
 			break;
@@ -210,6 +212,19 @@ int main(int argc, char *argv[])
 			break;
 		case 'C':
 			set_default_pager_num_columns(atoi(optarg));
+			break;
+		case 'c':
+			if (strcmp("always", optarg) == 0)
+				set_monitor_color(COLOR_ALWAYS);
+			else if (strcmp("never", optarg) == 0)
+				set_monitor_color(COLOR_NEVER);
+			else if (strcmp("auto", optarg) == 0)
+				set_monitor_color(COLOR_AUTO);
+			else {
+				fprintf(stderr, "Color option must be one of "
+						"auto/always/never\n");
+				return EXIT_FAILURE;
+			}
 			break;
 		case '#':
 			packet_todo();


### PR DESCRIPTION

Sometimes we want to force output color even when stdout is not a
terminal, for example when piping the output to a filter script and then
piping it further to a pager which can display colors.

This patch provides a general option to force whether color is on or off
(always and never), or leave btmon to decide (auto).

Reviewed-by: Daniel Winkler <danielwinkler@google.com>
