### PR TITLE
[PW_SID:451087] [BlueZ,v2] tools/mgmt-tester: Fix for scan response in read adv feature command


### DIFF
--- a/tools/mgmt-tester.c
+++ b/tools/mgmt-tester.c
@@ -4162,7 +4162,7 @@ static const struct generic_data read_adv_features_invalid_index_test = {
 };
 
 static const uint8_t read_adv_features_rsp_1[] =  {
-	0x7f, 0xf0, 0x00, 0x00,	/* supported flags */
+	0x7f, 0xf0, 0x01, 0x00,	/* supported flags */
 	0x1f,			/* max_adv_data_len */
 	0x1f,			/* max_scan_rsp_len */
 	0x05,			/* max_instances */
@@ -4177,7 +4177,7 @@ static const struct generic_data read_adv_features_success_1 = {
 };
 
 static const uint8_t read_adv_features_rsp_2[] =  {
-	0x7f, 0xf0, 0x00, 0x00,	/* supported flags */
+	0x7f, 0xf0, 0x01, 0x00,	/* supported flags */
 	0x1f,			/* max_adv_data_len */
 	0x1f,			/* max_scan_rsp_len */
 	0x05,			/* max_instances */
@@ -7137,7 +7137,7 @@ static const struct generic_data set_appearance_success = {
 };
 
 static const uint8_t read_adv_features_rsp_3[] =  {
-	0xff, 0xff, 0x00, 0x00,	/* supported flags */
+	0xff, 0xff, 0x01, 0x00,	/* supported flags */
 	0x1f,			/* max_adv_data_len */
 	0x1f,			/* max_scan_rsp_len */
 	0x01,			/* max_instances */


### PR DESCRIPTION

From: Tedd Ho-Jeong An <tedd.an@intel.com>

This patch fixes the test failure with the read advertising feature
API which is changed to include the scan response flag.

Read Advertising Features - Success 1 (No instance) 	Failed
Read Advertising Features - Success 2 (One instance)	Failed
Read Ext Advertising Features - Success 3 (PHY flags)	Failed
