### PR TITLE
[PW_SID:458277] [BlueZ] profiles/battery: Reset battery value cache on disconnect


### DIFF
--- a/profiles/battery/battery.c
+++ b/profiles/battery/battery.c
@@ -75,6 +75,7 @@ static void batt_free(struct batt *batt)
 static void batt_reset(struct batt *batt)
 {
 	batt->attr = NULL;
+	batt->percentage = -1;
 	gatt_db_unref(batt->db);
 	batt->db = NULL;
 	bt_gatt_client_unref(batt->client);


### PR DESCRIPTION

Due to cache in batt object, bluetoothd fails to update publish the
battery value after reconnection when the battery value does not change
compared to before reconnection. We should reset the battery percentage
cache on disconnect.

Reviewed-by: Alain Michaud <alainm@chromium.org>
