### PR TITLE
[PW_SID:462829] [BlueZ] input/hog-lib: do not silently ignore missing connection in read_char()


### DIFF
--- a/profiles/input/hog-lib.c
+++ b/profiles/input/hog-lib.c
@@ -181,10 +181,6 @@ static void read_char(struct bt_hog *hog, GAttrib *attrib, uint16_t handle,
 	struct gatt_request *req;
 	unsigned int id;
 
-	/* Ignore if not connected */
-	if (!attrib)
-		return;
-
 	req = create_request(hog, user_data);
 	if (!req)
 		return;


### PR DESCRIPTION

From: Dmitry Torokhov <dtor@chromium.org>

Currently we silently ignore missing connection (attrib) in read_char(),
but not in the other GATT interfaces (such as write_char, discover_desc,
etc). The code should avoid calling read_char() when there is no active
connection instead, and logging errors will help us trace the offenders.
