### PR TITLE
[PW_SID:462831] [BlueZ] input/hog-lib: avoid scanning characteristics too early


### DIFF
--- a/profiles/input/hog-lib.c
+++ b/profiles/input/hog-lib.c
@@ -1439,7 +1439,6 @@ static void hog_attach_instance(struct bt_hog *hog,
 
 	if (!hog->attr) {
 		hog->attr = attr;
-		gatt_db_service_foreach_char(hog->attr, foreach_hog_chrc, hog);
 		return;
 	}
 


### PR DESCRIPTION

From: Dmitry Torokhov <dtor@chromium.org>

We need to have active connection to fully discover a HOG instance,
and in the chain

bt_hog_new()->
gatt_db_foreach_service()->
foreach_hog_service()->
hog_attach_instance()

we have not set up hog->attrib yet. So let's skip calling
foreach_hog_chrc() from hog_attach_instance(), especially since
we will be calling bt_hog_attach() pretty much immediately after
bt_hog_new(), and we will be discovering characteristics there anyway.
