### PR TITLE
[PW_SID:462833] [BlueZ] input/hog-lib: add error handling when calling into gatt


### DIFF
--- a/profiles/input/hog-lib.c
+++ b/profiles/input/hog-lib.c
@@ -166,13 +166,16 @@ static void write_char(struct bt_hog *hog, GAttrib *attrib, uint16_t handle,
 		return;
 
 	id = gatt_write_char(attrib, handle, value, vlen, func, req);
-
-	if (set_and_store_gatt_req(hog, req, id))
+	if (!id) {
+		error("hog: Could not write char");
 		return;
+	}
 
-	error("hog: Could not read char");
-	g_attrib_cancel(attrib, id);
-	free(req);
+	if (!set_and_store_gatt_req(hog, req, id)) {
+		error("hog: Failed to queue write char req");
+		g_attrib_cancel(attrib, id);
+		free(req);
+	}
 }
 
 static void read_char(struct bt_hog *hog, GAttrib *attrib, uint16_t handle,
@@ -190,13 +193,16 @@ static void read_char(struct bt_hog *hog, GAttrib *attrib, uint16_t handle,
 		return;
 
 	id = gatt_read_char(attrib, handle, func, req);
-
-	if (set_and_store_gatt_req(hog, req, id))
+	if (!id) {
+		error("hog: Could not read char");
 		return;
+	}
 
-	error("hog: Could not read char");
-	g_attrib_cancel(attrib, id);
-	free(req);
+	if (!set_and_store_gatt_req(hog, req, id)) {
+		error("hog: Failed to queue read char req");
+		g_attrib_cancel(attrib, id);
+		free(req);
+	}
 }
 
 static void discover_desc(struct bt_hog *hog, GAttrib *attrib,
@@ -211,12 +217,16 @@ static void discover_desc(struct bt_hog *hog, GAttrib *attrib,
 		return;
 
 	id = gatt_discover_desc(attrib, start, end, NULL, func, req);
-	if (set_and_store_gatt_req(hog, req, id))
+	if (!id) {
+		error("hog: Could not discover descriptors");
 		return;
+	}
 
-	error("hog: Could not discover descriptors");
-	g_attrib_cancel(attrib, id);
-	free(req);
+	if (!set_and_store_gatt_req(hog, req, id)) {
+		error("hog: Failed to queue discover descriptors req");
+		g_attrib_cancel(attrib, id);
+		free(req);
+	}
 }
 
 static void discover_char(struct bt_hog *hog, GAttrib *attrib,
@@ -232,13 +242,16 @@ static void discover_char(struct bt_hog *hog, GAttrib *attrib,
 		return;
 
 	id = gatt_discover_char(attrib, start, end, uuid, func, req);
-
-	if (set_and_store_gatt_req(hog, req, id))
+	if (!id) {
+		error("hog: Could not discover characteristic");
 		return;
+	}
 
-	error("hog: Could not discover characteristic");
-	g_attrib_cancel(attrib, id);
-	free(req);
+	if (!set_and_store_gatt_req(hog, req, id)) {
+		error("hog: Failed to queue discover characteristic req");
+		g_attrib_cancel(attrib, id);
+		free(req);
+	}
 }
 
 static void discover_primary(struct bt_hog *hog, GAttrib *attrib,
@@ -253,13 +266,16 @@ static void discover_primary(struct bt_hog *hog, GAttrib *attrib,
 		return;
 
 	id = gatt_discover_primary(attrib, uuid, func, req);
-
-	if (set_and_store_gatt_req(hog, req, id))
+	if (!id) {
+		error("hog: Could not send discover primary");
 		return;
+	}
 
-	error("hog: Could not send discover primary");
-	g_attrib_cancel(attrib, id);
-	free(req);
+	if (!set_and_store_gatt_req(hog, req, id)) {
+		error("hog: Failed to queue discover primary req");
+		g_attrib_cancel(attrib, id);
+		free(req);
+	}
 }
 
 static void find_included(struct bt_hog *hog, GAttrib *attrib,
@@ -274,13 +290,16 @@ static void find_included(struct bt_hog *hog, GAttrib *attrib,
 		return;
 
 	id = gatt_find_included(attrib, start, end, func, req);
-
-	if (set_and_store_gatt_req(hog, req, id))
+	if (!id) {
+		error("hog: Could not find included");
 		return;
+	}
 
-	error("Could not find included");
-	g_attrib_cancel(attrib, id);
-	free(req);
+	if (!set_and_store_gatt_req(hog, req, id)) {
+		error("hog: Failed to queue find included req");
+		g_attrib_cancel(attrib, id);
+		free(req);
+	}
 }
 
 static void report_value_cb(const guint8 *pdu, guint16 len, gpointer user_data)


### PR DESCRIPTION

From: Dmitry Torokhov <dtor@chromium.org>

When calling gatt_write_char(), gatt_read_char(), etc, id == 0 indicates
error. Let's recognize this fact and log it instead of queueing request
that will never be completed.
