### PR TITLE
[PW_SID:462833] [BlueZ] input/hog-lib: add error handling when calling into gatt


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,26 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  code-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        path: src
+    - name: Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/profiles/input/hog-lib.c
+++ b/profiles/input/hog-lib.c
@@ -166,13 +166,16 @@ static void write_char(struct bt_hog *hog, GAttrib *attrib, uint16_t handle,
 		return;
 
 	id = gatt_write_char(attrib, handle, value, vlen, func, req);
-
-	if (set_and_store_gatt_req(hog, req, id))
+	if (!id) {
+		error("hog: Could not write char");
 		return;
+	}
 
-	error("hog: Could not read char");
-	g_attrib_cancel(attrib, id);
-	free(req);
+	if (!set_and_store_gatt_req(hog, req, id)) {
+		error("hog: Failed to queue write char req");
+		g_attrib_cancel(attrib, id);
+		free(req);
+	}
 }
 
 static void read_char(struct bt_hog *hog, GAttrib *attrib, uint16_t handle,
@@ -190,13 +193,16 @@ static void read_char(struct bt_hog *hog, GAttrib *attrib, uint16_t handle,
 		return;
 
 	id = gatt_read_char(attrib, handle, func, req);
-
-	if (set_and_store_gatt_req(hog, req, id))
+	if (!id) {
+		error("hog: Could not read char");
 		return;
+	}
 
-	error("hog: Could not read char");
-	g_attrib_cancel(attrib, id);
-	free(req);
+	if (!set_and_store_gatt_req(hog, req, id)) {
+		error("hog: Failed to queue read char req");
+		g_attrib_cancel(attrib, id);
+		free(req);
+	}
 }
 
 static void discover_desc(struct bt_hog *hog, GAttrib *attrib,
@@ -211,12 +217,16 @@ static void discover_desc(struct bt_hog *hog, GAttrib *attrib,
 		return;
 
 	id = gatt_discover_desc(attrib, start, end, NULL, func, req);
-	if (set_and_store_gatt_req(hog, req, id))
+	if (!id) {
+		error("hog: Could not discover descriptors");
 		return;
+	}
 
-	error("hog: Could not discover descriptors");
-	g_attrib_cancel(attrib, id);
-	free(req);
+	if (!set_and_store_gatt_req(hog, req, id)) {
+		error("hog: Failed to queue discover descriptors req");
+		g_attrib_cancel(attrib, id);
+		free(req);
+	}
 }
 
 static void discover_char(struct bt_hog *hog, GAttrib *attrib,
@@ -232,13 +242,16 @@ static void discover_char(struct bt_hog *hog, GAttrib *attrib,
 		return;
 
 	id = gatt_discover_char(attrib, start, end, uuid, func, req);
-
-	if (set_and_store_gatt_req(hog, req, id))
+	if (!id) {
+		error("hog: Could not discover characteristic");
 		return;
+	}
 
-	error("hog: Could not discover characteristic");
-	g_attrib_cancel(attrib, id);
-	free(req);
+	if (!set_and_store_gatt_req(hog, req, id)) {
+		error("hog: Failed to queue discover characteristic req");
+		g_attrib_cancel(attrib, id);
+		free(req);
+	}
 }
 
 static void discover_primary(struct bt_hog *hog, GAttrib *attrib,
@@ -253,13 +266,16 @@ static void discover_primary(struct bt_hog *hog, GAttrib *attrib,
 		return;
 
 	id = gatt_discover_primary(attrib, uuid, func, req);
-
-	if (set_and_store_gatt_req(hog, req, id))
+	if (!id) {
+		error("hog: Could not send discover primary");
 		return;
+	}
 
-	error("hog: Could not send discover primary");
-	g_attrib_cancel(attrib, id);
-	free(req);
+	if (!set_and_store_gatt_req(hog, req, id)) {
+		error("hog: Failed to queue discover primary req");
+		g_attrib_cancel(attrib, id);
+		free(req);
+	}
 }
 
 static void find_included(struct bt_hog *hog, GAttrib *attrib,
@@ -274,13 +290,16 @@ static void find_included(struct bt_hog *hog, GAttrib *attrib,
 		return;
 
 	id = gatt_find_included(attrib, start, end, func, req);
-
-	if (set_and_store_gatt_req(hog, req, id))
+	if (!id) {
+		error("hog: Could not find included");
 		return;
+	}
 
-	error("Could not find included");
-	g_attrib_cancel(attrib, id);
-	free(req);
+	if (!set_and_store_gatt_req(hog, req, id)) {
+		error("hog: Failed to queue find included req");
+		g_attrib_cancel(attrib, id);
+		free(req);
+	}
 }
 
 static void report_value_cb(const guint8 *pdu, guint16 len, gpointer user_data)


### PR DESCRIPTION

From: Dmitry Torokhov <dtor@chromium.org>

When calling gatt_write_char(), gatt_read_char(), etc, id == 0 indicates
error. Let's recognize this fact and log it instead of queueing request
that will never be completed.
