### PR TITLE
[PW_SID:464847] [BlueZ,1/2] tools/mgmt-tester: Add callback routine for validating the parameter


### DIFF
--- a/tools/mgmt-tester.c
+++ b/tools/mgmt-tester.c
@@ -910,6 +910,20 @@ static uint8_t set_connectable_off_scan_adv_param[] = {
 		0x00,					/* filter_policy */
 };
 
+static int set_connectable_off_scan_adv_check_func(const void *param,
+								uint16_t length)
+{
+	const uint8_t *received = param;
+	uint8_t *expected = set_connectable_off_scan_adv_param;
+
+	/* Compare the received param with expected param, but ignore the
+	 * min_internal and max_interval since these values are turned often
+	 * in the kernel and we don't want to update the expected value every
+	 * time.
+	 */
+	return memcmp(&received[4], &expected[4], length - 4);
+}
+
 static const struct generic_data set_connectable_off_le_test_2 = {
 	.setup_settings = settings_powered_le_connectable_advertising,
 	.send_opcode = MGMT_OP_SET_CONNECTABLE,
@@ -922,6 +936,7 @@ static const struct generic_data set_connectable_off_le_test_2 = {
 	.expect_hci_command = BT_HCI_CMD_LE_SET_ADV_PARAMETERS,
 	.expect_hci_param = set_connectable_off_scan_adv_param,
 	.expect_hci_len = sizeof(set_connectable_off_scan_adv_param),
+	.expect_hci_param_check_func = set_connectable_off_scan_adv_check_func
 };
 
 static uint16_t settings_powered_le_discoverable[] = {
@@ -949,6 +964,7 @@ static const struct generic_data set_connectable_off_le_test_3 = {
 	.expect_hci_command = BT_HCI_CMD_LE_SET_ADV_PARAMETERS,
 	.expect_hci_param = set_connectable_off_scan_adv_param,
 	.expect_hci_len = sizeof(set_connectable_off_scan_adv_param),
+	.expect_hci_param_check_func = set_connectable_off_scan_adv_check_func
 };
 
 static const struct generic_data set_connectable_off_le_test_4 = {
@@ -964,6 +980,7 @@ static const struct generic_data set_connectable_off_le_test_4 = {
 	.expect_hci_command = BT_HCI_CMD_LE_SET_ADV_PARAMETERS,
 	.expect_hci_param = set_connectable_off_scan_adv_param,
 	.expect_hci_len = sizeof(set_connectable_off_scan_adv_param),
+	.expect_hci_param_check_func = set_connectable_off_scan_adv_check_func
 };
 
 static const char set_fast_conn_on_param[] = { 0x01 };
@@ -4750,6 +4767,7 @@ static const struct generic_data add_advertising_success_13 = {
 	.expect_hci_command = BT_HCI_CMD_LE_SET_ADV_PARAMETERS,
 	.expect_hci_param = set_connectable_off_scan_adv_param,
 	.expect_hci_len = sizeof(set_connectable_off_scan_adv_param),
+	.expect_hci_param_check_func = set_connectable_off_scan_adv_check_func
 };
 
 static uint8_t set_connectable_off_adv_param[] = {
@@ -4763,6 +4781,20 @@ static uint8_t set_connectable_off_adv_param[] = {
 		0x00,					/* filter_policy */
 };
 
+static int set_connectable_off_adv_check_func(const void *param,
+								uint16_t length)
+{
+	const uint8_t *received = param;
+	uint8_t *expected = set_connectable_off_adv_param;
+
+	/* Compare the received param with expected param, but ignore the
+	 * min_internal and max_interval since these values are turned often
+	 * in the kernel and we don't want to update the expected value every
+	 * time.
+	 */
+	return memcmp(&received[4], &expected[4], length - 4);
+}
+
 static const struct generic_data add_advertising_success_14 = {
 	.setup_settings = settings_powered_le,
 	.send_opcode = MGMT_OP_ADD_ADVERTISING,
@@ -4774,6 +4806,7 @@ static const struct generic_data add_advertising_success_14 = {
 	.expect_hci_command = BT_HCI_CMD_LE_SET_ADV_PARAMETERS,
 	.expect_hci_param = set_connectable_off_adv_param,
 	.expect_hci_len = sizeof(set_connectable_off_adv_param),
+	.expect_hci_param_check_func = set_connectable_off_adv_check_func
 };
 
 static const struct generic_data add_advertising_success_15 = {
@@ -4814,6 +4847,7 @@ static const struct generic_data add_advertising_success_17 = {
 	.expect_hci_command = BT_HCI_CMD_LE_SET_ADV_PARAMETERS,
 	.expect_hci_param = set_connectable_off_adv_param,
 	.expect_hci_len = sizeof(set_connectable_off_adv_param),
+	.expect_hci_param_check_func = set_connectable_off_adv_check_func
 };
 
 static const char set_powered_off_le_settings_param[] = {


### PR DESCRIPTION

From: Tedd Ho-Jeong An <tedd.an@intel.com>

This patch adds a callback routine for validating the received HCI
parameter, so it can customize to compare the parameters instead of
memcmp the full length.
