### PR TITLE
[PW_SID:466569] [1/2] monitor: Add control packet count to analyze command


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,26 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  code-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        path: src
+    - name: Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/monitor/analyze.c
+++ b/monitor/analyze.c
@@ -34,6 +34,7 @@ struct hci_dev {
 	unsigned long num_evt;
 	unsigned long num_acl;
 	unsigned long num_sco;
+	unsigned long num_iso;
 	unsigned long vendor_diag;
 	unsigned long system_note;
 	unsigned long user_log;
@@ -77,6 +78,7 @@ static void dev_destroy(void *data)
 	printf("  %lu events\n", dev->num_evt);
 	printf("  %lu ACL packets\n", dev->num_acl);
 	printf("  %lu SCO packets\n", dev->num_sco);
+	printf("  %lu ISO packets\n", dev->num_iso);
 	printf("  %lu vendor diagnostics\n", dev->vendor_diag);
 	printf("  %lu system notes\n", dev->system_note);
 	printf("  %lu user logs\n", dev->user_log);
@@ -253,6 +255,22 @@ static void sco_pkt(struct timeval *tv, uint16_t index,
 		return;
 
 	dev->num_sco++;
+}
+
+static void iso_pkt(struct timeval *tv, uint16_t index,
+					const void *data, uint16_t size)
+{
+	const struct bt_hci_iso_hdr *hdr = data;
+	struct hci_dev *dev;
+
+	data += sizeof(*hdr);
+	size -= sizeof(*hdr);
+
+	dev = dev_lookup(index);
+	if (!dev)
+		return;
+
+	dev->num_iso++;
 }
 
 static void info_index(struct timeval *tv, uint16_t index,
@@ -447,6 +465,10 @@ void analyze_trace(const char *path)
 			break;
 		case BTSNOOP_OPCODE_CTRL_EVENT:
 			ctrl_evt(&tv, index, buf, pktlen);
+			break;
+		case BTSNOOP_OPCODE_ISO_TX_PKT:
+		case BTSNOOP_OPCODE_ISO_RX_PKT:
+			iso_pkt(&tv, index, buf, pktlen);
 			break;
 		default:
 			fprintf(stderr, "Unknown opcode %u\n", opcode);

--- a/monitor/analyze.c
+++ b/monitor/analyze.c
@@ -37,6 +37,10 @@ struct hci_dev {
 	unsigned long vendor_diag;
 	unsigned long system_note;
 	unsigned long user_log;
+	unsigned long ctrl_open;
+	unsigned long ctrl_close;
+	unsigned long ctrl_cmd;
+	unsigned long ctrl_evt;
 	unsigned long unknown;
 	uint16_t manufacturer;
 };
@@ -76,6 +80,10 @@ static void dev_destroy(void *data)
 	printf("  %lu vendor diagnostics\n", dev->vendor_diag);
 	printf("  %lu system notes\n", dev->system_note);
 	printf("  %lu user logs\n", dev->user_log);
+	printf("  %lu control open\n", dev->ctrl_open);
+	printf("  %lu control close\n", dev->ctrl_close);
+	printf("  %lu control commands\n", dev->ctrl_cmd);
+	printf("  %lu control events\n", dev->ctrl_evt);
 	printf("  %lu unknown opcodes\n", dev->unknown);
 	printf("\n");
 
@@ -299,6 +307,54 @@ static void user_log(struct timeval *tv, uint16_t index,
 	dev->user_log++;
 }
 
+static void ctrl_open(struct timeval *tv, uint16_t index,
+					const void *data, uint16_t size)
+{
+	struct hci_dev *dev;
+
+	dev = dev_lookup(index);
+	if (!dev)
+		return;
+
+	dev->ctrl_open++;
+}
+
+static void ctrl_close(struct timeval *tv, uint16_t index,
+					const void *data, uint16_t size)
+{
+	struct hci_dev *dev;
+
+	dev = dev_lookup(index);
+	if (!dev)
+		return;
+
+	dev->ctrl_close++;
+}
+
+static void ctrl_cmd(struct timeval *tv, uint16_t index,
+					const void *data, uint16_t size)
+{
+	struct hci_dev *dev;
+
+	dev = dev_lookup(index);
+	if (!dev)
+		return;
+
+	dev->ctrl_cmd++;
+}
+
+static void ctrl_evt(struct timeval *tv, uint16_t index,
+					const void *data, uint16_t size)
+{
+	struct hci_dev *dev;
+
+	dev = dev_lookup(index);
+	if (!dev)
+		return;
+
+	dev->ctrl_evt++;
+}
+
 static void unknown_opcode(struct timeval *tv, uint16_t index,
 					const void *data, uint16_t size)
 {
@@ -379,6 +435,18 @@ void analyze_trace(const char *path)
 			break;
 		case BTSNOOP_OPCODE_USER_LOGGING:
 			user_log(&tv, index, buf, pktlen);
+			break;
+		case BTSNOOP_OPCODE_CTRL_OPEN:
+			ctrl_open(&tv, index, buf, pktlen);
+			break;
+		case BTSNOOP_OPCODE_CTRL_CLOSE:
+			ctrl_close(&tv, index, buf, pktlen);
+			break;
+		case BTSNOOP_OPCODE_CTRL_COMMAND:
+			ctrl_cmd(&tv, index, buf, pktlen);
+			break;
+		case BTSNOOP_OPCODE_CTRL_EVENT:
+			ctrl_evt(&tv, index, buf, pktlen);
 			break;
 		default:
 			fprintf(stderr, "Unknown opcode %u\n", opcode);


### PR DESCRIPTION

From: Tedd Ho-Jeong An <tedd.an@intel.com>

This patch adds control packets(open, close, command, event) count to
analyze command.
