### PR TITLE
[PW_SID:474765] [BlueZ] Build: Add missing ELL headers and sources


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,26 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  code-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        path: src
+    - name: Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/Makefile.am
+++ b/Makefile.am
@@ -140,7 +140,12 @@ ell_headers = ell/util.h \
 			ell/uuid.h \
 			ell/useful.h \
 			ell/main-private.h \
-			ell/tester.h
+			ell/tester.h \
+			ell/tls.h \
+			ell/tls-private.h \
+			ell/ecc.h \
+			ell/ecc-private.h \
+			ell/ecdh.h
 
 ell_sources = ell/private.h ell/missing.h \
 			ell/util.c \
@@ -178,7 +183,14 @@ ell_sources = ell/private.h ell/missing.h \
 			ell/siphash-private.h \
 			ell/siphash.c \
 			ell/uuid.c \
-			ell/tester.c
+			ell/tester.c \
+			ell/tls.c \
+			ell/tls-extensions.c \
+			ell/tls-suites.c \
+			ell/tls-record.c \
+			ell/ecc.c \
+			ell/ecc-external.c \
+			ell/ecdh.c
 
 ell_shared = ell/useful.h
 


### PR DESCRIPTION

From: Tedd Ho-Jeong An <tedd.an@intel.com>

The recent change in ELL included the header file tls.h which didn't
included in the BlueZ. This patch adds a series of missing ELL headers
and sources to align with the change in ELL.
