### PR TITLE
[PW_SID:475329] [Bluez,v1] doc/mgmt-api - Add a new error code for HCI status 0x3e


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,26 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  code-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        path: src
+    - name: Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/doc/mgmt-api.txt
+++ b/doc/mgmt-api.txt
@@ -200,6 +200,7 @@ and Command Complete events:
 0x12	RFKilled
 0x13	Already Paired
 0x14	Permission Denied
+0x15	Connection Not Established
 
 As a general rule all commands generate the events as specified below,
 however invalid lengths or unknown commands will always generate a
@@ -1112,6 +1113,7 @@ Pair Device Command
 				Not Powered
 				Invalid Index
 				Already Paired
+				Connection Not Established
 
 
 Cancel Pair Device Command


### PR DESCRIPTION

We want to retry the pairing when HCI status 0x3e (Connection failed to
established/Synchronization timeout) is returned from the controller.
This is to add a new MGMT error code so that we can catch this 0x3e
failure and issue a retry in the user space.

Reviewed-by: Abhishek Pandit-Subedi <abhishekpandit@chromium.org>
