### PR TITLE
[PW_SID:476307] [Bluez,1/2] unit/gobex: remove timer only when it's not removed yet


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,26 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  code-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        path: src
+    - name: Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/Makefile.am
+++ b/Makefile.am
@@ -492,6 +492,7 @@ unit_test_gdbus_client_SOURCES = unit/test-gdbus-client.c
 unit_test_gdbus_client_LDADD = gdbus/libgdbus-internal.la \
 				src/libshared-glib.la $(GLIB_LIBS) $(DBUS_LIBS)
 
+if OBEX
 unit_tests += unit/test-gobex-header unit/test-gobex-packet unit/test-gobex \
 			unit/test-gobex-transfer unit/test-gobex-apparam
 
@@ -514,6 +515,7 @@ unit_test_gobex_transfer_LDADD = $(GLIB_LIBS)
 unit_test_gobex_apparam_SOURCES = $(gobex_sources) unit/util.c unit/util.h \
 						unit/test-gobex-apparam.c
 unit_test_gobex_apparam_LDADD = $(GLIB_LIBS)
+endif
 
 unit_tests += unit/test-lib
 

--- a/unit/test-gobex.c
+++ b/unit/test-gobex.c
@@ -266,7 +266,8 @@ static void send_req(GObexPacket *req, GObexResponseFunc rsp_func,
 	g_main_loop_unref(mainloop);
 	mainloop = NULL;
 
-	g_source_remove(timer_id);
+	if (!g_error_matches(gerr, TEST_ERROR, TEST_ERROR_TIMEOUT))
+		g_source_remove(timer_id);
 	g_io_channel_unref(io);
 	g_obex_unref(obex);
 
@@ -450,7 +451,8 @@ static void test_cancel_req_delay(int transport_type)
 
 	g_assert_no_error(r.err);
 
-	g_source_remove(timer_id);
+	if (!g_error_matches(r.err, TEST_ERROR, TEST_ERROR_TIMEOUT))
+		g_source_remove(timer_id);
 	g_io_channel_unref(io);
 	g_source_remove(io_id);
 	g_obex_unref(r.obex);
@@ -551,7 +553,8 @@ static void test_send_connect(int transport_type)
 	g_main_loop_unref(mainloop);
 	mainloop = NULL;
 
-	g_source_remove(timer_id);
+	if (!g_error_matches(r.err, TEST_ERROR, TEST_ERROR_TIMEOUT))
+		g_source_remove(timer_id);
 	g_io_channel_unref(io);
 	if (!r.completed)
 		g_source_remove(io_id);
@@ -612,7 +615,8 @@ static void test_recv_unexpected(void)
 	g_main_loop_unref(mainloop);
 	mainloop = NULL;
 
-	g_source_remove(timer_id);
+	if (!g_error_matches(err, TEST_ERROR, TEST_ERROR_TIMEOUT))
+		g_source_remove(timer_id);
 	g_io_channel_unref(io);
 	g_obex_unref(obex);
 
@@ -667,7 +671,8 @@ static void test_send_on_demand(int transport_type, GObexDataProducer func)
 	g_main_loop_unref(mainloop);
 	mainloop = NULL;
 
-	g_source_remove(timer_id);
+	if (!g_error_matches(r.err, TEST_ERROR, TEST_ERROR_TIMEOUT))
+		g_source_remove(timer_id);
 	g_io_channel_unref(io);
 	if (!r.completed)
 		g_source_remove(io_id);
@@ -748,7 +753,8 @@ static void recv_connect(int transport_type)
 
 	g_main_loop_run(mainloop);
 
-	g_source_remove(timer_id);
+	if (!g_error_matches(gerr, TEST_ERROR, TEST_ERROR_TIMEOUT))
+		g_source_remove(timer_id);
 	g_obex_unref(obex);
 	g_io_channel_unref(io);
 
@@ -800,7 +806,8 @@ static void test_disconnect(void)
 
 	g_assert_no_error(gerr);
 
-	g_source_remove(timer_id);
+	if (!g_error_matches(gerr, TEST_ERROR, TEST_ERROR_TIMEOUT))
+		g_source_remove(timer_id);
 	g_io_channel_unref(io);
 	g_obex_unref(obex);
 


### PR DESCRIPTION

From: Archie Pusaka <apusaka@chromium.org>

There are instances where timer is removed because timeout has
occurred, yet we still remove it again by the end of the test. This
causes double removal and prints ugly messages which obscures the
real culprit.

Reviewed-by: Sonny Sasaka <sonnysasaka@chromium.org>
Reviewed-by: Yun-Hao Chung <howardchung@chromium.org>
