### PR TITLE
[PW_SID:477013] [BlueZ] checkpatch: ignore SPDX license header check


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -12,3 +12,4 @@
 --ignore PREFER_PACKED
 --ignore COMMIT_MESSAGE
 --ignore SSCANF_TO_KSTRTO
+--ignore SPDX_LICENSE_TAG


### PR DESCRIPTION

From: Tedd Ho-Jeong An <tedd.an@intel.com>

This patch adds the rule to ignore the SPDX license header check.
