### PR TITLE
[PW_SID:477477] [BlueZ,1/2] gitignore: Add generated files to the ignore list


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,26 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  code-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        path: src
+    - name: Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -47,23 +47,33 @@ tools/avinfo
 tools/bccmd
 tools/hwdb
 tools/ciptool
+tools/ciptool.1
 tools/hciattach
+tools/hciattach.1
 tools/hciconfig
+tools/hciconfig.1
 tools/hcieventmask
 tools/hcisecfilter
 tools/hcitool
+tools/hcitool.1
 tools/hcidump
+tools/hcidump.1
 tools/hid2hci
+tools/hid2hci.1
 tools/rfcomm
+tools/rfcomm.1
 tools/l2ping
+tools/l2ping.1
 tools/l2test
 tools/cltest
 tools/rctest
+tools/rctest.1
 tools/scotest
 tools/amptest
 tools/oobtest
 tools/advtest
 tools/sdptool
+tools/sdptool.1
 tools/avtest
 tools/bdaddr
 tools/bluemoon
@@ -116,6 +126,7 @@ tools/rfcomm-tester
 tools/bnep-tester
 tools/userchan-tester
 tools/btattach
+tools/btattach.1
 tools/btconfig
 tools/btmgmt
 tools/btsnoop
@@ -125,15 +136,18 @@ tools/btmon-logger
 tools/bluetooth-logger.service
 peripheral/btsensor
 monitor/btmon
+monitor/btmon.1
 emulator/btvirt
 emulator/b1ee
 emulator/hfp
 client/bluetoothctl
 tools/meshctl
 tools/mesh-cfgclient
+tools/mesh-cfgtest
 mesh/bluetooth-meshd
 
 src/bluetoothd.8
+src/bluetoothd.rst
 src/bluetooth.service
 mesh/bluetooth-mesh.service
 
@@ -156,8 +170,6 @@ unit/test-gattrib
 unit/test-mesh-crypto
 unit/test-*.log
 unit/test-*.trs
-
-doc/btmon.1
 
 android/system-emulator
 android/bluetoothd

--- a/Makefile.am
+++ b/Makefile.am
@@ -594,7 +594,8 @@ if LIBRARY
 pkgconfig_DATA = lib/bluez.pc
 endif
 
-EXTRA_DIST += $(manual_pages:.1=.rst)
+EXTRA_DIST += $(manual_pages) $(patsubst %.1,%.rst, \
+				$(patsubst %.8,%.rst,$(manual_pages)))
 
 DISTCHECK_CONFIGURE_FLAGS = --disable-datafiles --enable-library \
 						--enable-health \


### PR DESCRIPTION

From: Tedd Ho-Jeong An <tedd.an@intel.com>

This patch adds generated files like manpages and binaries to the
ignore list so it won't show with 'git status'.
