### PR TITLE
[PW_SID:478179] [BlueZ] monitor: Remove Pygments dependency from manpage


### DIFF
--- a/monitor/btmon.rst
+++ b/monitor/btmon.rst
@@ -148,14 +148,14 @@ EXAMPLES
 Capture the traces from hci0 to hcidump.log file
 ------------------------------------------------
 
-.. code-block:: bash
+.. code-block::
 
    $ btmon -i hci0 -w hcidump.log
 
 Open the trace file
 -------------------
 
-.. code-block:: bash
+.. code-block::
 
    $ btmon -r hcidump.log
 


### PR DESCRIPTION

From: Tedd Ho-Jeong An <tedd.an@intel.com>

This patch removes the Pygments dependency from btmon .rst file.
When the code-block type is specified, the rst2man throws a warning
asking for Pygments package.
