### PR TITLE
[PW_SID:478219] Convert tester tools to use ELL


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,26 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  code-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        path: src
+    - name: Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/Makefile.am
+++ b/Makefile.am
@@ -253,8 +253,8 @@ if LIBSHARED_ELL
 src_libshared_ell_la_SOURCES = $(shared_sources) \
 				src/shared/io-ell.c \
 				src/shared/timeout-ell.c \
-				src/shared/mainloop.h \
-				src/shared/mainloop-ell.c
+				src/shared/mainloop-ell.c \
+				src/shared/bttester.h src/shared/bttester.c
 endif
 
 attrib_sources = attrib/att.h attrib/att-database.h attrib/att.c \

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -128,12 +128,12 @@ tools_l2cap_tester_LDADD = lib/libbluetooth-internal.la \
 				src/libshared-ell.la $(ell_ldadd)
 
 tools_rfcomm_tester_SOURCES = tools/rfcomm-tester.c monitor/bt.h \
-				emulator/hciemu.h emulator/hciemu.c \
+				emulator/hciemu.h emulator/hciemu-ell.c \
 				emulator/btdev.h emulator/btdev.c \
 				emulator/bthost.h emulator/bthost.c \
 				emulator/smp.c
 tools_rfcomm_tester_LDADD = lib/libbluetooth-internal.la \
-				src/libshared-glib.la $(GLIB_LIBS)
+				src/libshared-ell.la $(ell_ldadd)
 
 tools_bnep_tester_SOURCES = tools/bnep-tester.c monitor/bt.h \
 				emulator/hciemu.h emulator/hciemu-ell.c \

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -152,14 +152,12 @@ tools_smp_tester_LDADD = lib/libbluetooth-internal.la \
 				src/libshared-glib.la $(GLIB_LIBS)
 
 tools_gap_tester_SOURCES = tools/gap-tester.c monitor/bt.h \
-				emulator/hciemu.h emulator/hciemu.c \
+				emulator/hciemu.h emulator/hciemu-ell.c \
 				emulator/btdev.h emulator/btdev.c \
 				emulator/bthost.h emulator/bthost.c \
 				emulator/smp.c
 tools_gap_tester_LDADD =  lib/libbluetooth-internal.la \
-				gdbus/libgdbus-internal.la \
-				src/libshared-glib.la \
-				$(GLIB_LIBS) $(DBUS_LIBS)
+				src/libshared-ell.la $(ell_ldadd)
 
 tools_sco_tester_SOURCES = tools/sco-tester.c monitor/bt.h \
 				emulator/hciemu.h emulator/hciemu.c \

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -136,12 +136,12 @@ tools_rfcomm_tester_LDADD = lib/libbluetooth-internal.la \
 				src/libshared-glib.la $(GLIB_LIBS)
 
 tools_bnep_tester_SOURCES = tools/bnep-tester.c monitor/bt.h \
-				emulator/hciemu.h emulator/hciemu.c \
+				emulator/hciemu.h emulator/hciemu-ell.c \
 				emulator/btdev.h emulator/btdev.c \
 				emulator/bthost.h emulator/bthost.c \
 				emulator/smp.c
 tools_bnep_tester_LDADD = lib/libbluetooth-internal.la \
-				src/libshared-glib.la $(GLIB_LIBS)
+				src/libshared-ell.la $(ell_ldadd)
 
 tools_smp_tester_SOURCES = tools/smp-tester.c monitor/bt.h \
 				emulator/hciemu.h emulator/hciemu-ell.c \

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -168,7 +168,7 @@ tools_sco_tester_LDADD = lib/libbluetooth-internal.la \
 				src/libshared-ell.la $(ell_ldadd)
 
 tools_hci_tester_SOURCES = tools/hci-tester.c monitor/bt.h
-tools_hci_tester_LDADD = src/libshared-glib.la $(GLIB_LIBS)
+tools_hci_tester_LDADD = src/libshared-ell.la $(ell_ldadd)
 
 tools_userchan_tester_SOURCES = tools/userchan-tester.c monitor/bt.h \
 				emulator/hciemu.h emulator/hciemu-ell.c \

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -160,12 +160,12 @@ tools_gap_tester_LDADD =  lib/libbluetooth-internal.la \
 				src/libshared-ell.la $(ell_ldadd)
 
 tools_sco_tester_SOURCES = tools/sco-tester.c monitor/bt.h \
-				emulator/hciemu.h emulator/hciemu.c \
+				emulator/hciemu.h emulator/hciemu-ell.c \
 				emulator/btdev.h emulator/btdev.c \
 				emulator/bthost.h emulator/bthost.c \
 				emulator/smp.c
 tools_sco_tester_LDADD = lib/libbluetooth-internal.la \
-				src/libshared-glib.la $(GLIB_LIBS)
+				src/libshared-ell.la $(ell_ldadd)
 
 tools_hci_tester_SOURCES = tools/hci-tester.c monitor/bt.h
 tools_hci_tester_LDADD = src/libshared-glib.la $(GLIB_LIBS)

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -144,12 +144,12 @@ tools_bnep_tester_LDADD = lib/libbluetooth-internal.la \
 				src/libshared-glib.la $(GLIB_LIBS)
 
 tools_smp_tester_SOURCES = tools/smp-tester.c monitor/bt.h \
-				emulator/hciemu.h emulator/hciemu.c \
+				emulator/hciemu.h emulator/hciemu-ell.c \
 				emulator/btdev.h emulator/btdev.c \
 				emulator/bthost.h emulator/bthost.c \
 				emulator/smp.c
 tools_smp_tester_LDADD = lib/libbluetooth-internal.la \
-				src/libshared-glib.la $(GLIB_LIBS)
+				src/libshared-ell.la $(ell_ldadd)
 
 tools_gap_tester_SOURCES = tools/gap-tester.c monitor/bt.h \
 				emulator/hciemu.h emulator/hciemu-ell.c \

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -171,12 +171,12 @@ tools_hci_tester_SOURCES = tools/hci-tester.c monitor/bt.h
 tools_hci_tester_LDADD = src/libshared-glib.la $(GLIB_LIBS)
 
 tools_userchan_tester_SOURCES = tools/userchan-tester.c monitor/bt.h \
-				emulator/hciemu.h emulator/hciemu.c \
+				emulator/hciemu.h emulator/hciemu-ell.c \
 				emulator/btdev.h emulator/btdev.c \
 				emulator/bthost.h emulator/bthost.c \
 				emulator/smp.c
 tools_userchan_tester_LDADD = lib/libbluetooth-internal.la \
-				src/libshared-glib.la $(GLIB_LIBS)
+				src/libshared-ell.la $(ell_ldadd)
 endif
 
 if TOOLS

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -120,12 +120,12 @@ tools_mgmt_tester_LDADD = lib/libbluetooth-internal.la \
 				src/libshared-glib.la $(GLIB_LIBS)
 
 tools_l2cap_tester_SOURCES = tools/l2cap-tester.c monitor/bt.h \
-				emulator/hciemu.h emulator/hciemu.c \
+				emulator/hciemu.h emulator/hciemu-ell.c \
 				emulator/btdev.h emulator/btdev.c \
 				emulator/bthost.h emulator/bthost.c \
 				emulator/smp.c
 tools_l2cap_tester_LDADD = lib/libbluetooth-internal.la \
-				src/libshared-glib.la $(GLIB_LIBS)
+				src/libshared-ell.la $(ell_ldadd)
 
 tools_rfcomm_tester_SOURCES = tools/rfcomm-tester.c monitor/bt.h \
 				emulator/hciemu.h emulator/hciemu.c \

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -112,12 +112,12 @@ tools_3dsp_SOURCES = tools/3dsp.c monitor/bt.h
 tools_3dsp_LDADD = src/libshared-mainloop.la
 
 tools_mgmt_tester_SOURCES = tools/mgmt-tester.c monitor/bt.h \
-				emulator/hciemu.h emulator/hciemu.c \
+				emulator/hciemu.h emulator/hciemu-ell.c \
 				emulator/btdev.h emulator/btdev.c \
 				emulator/bthost.h emulator/bthost.c \
 				emulator/smp.c
 tools_mgmt_tester_LDADD = lib/libbluetooth-internal.la \
-				src/libshared-glib.la $(GLIB_LIBS)
+				src/libshared-ell.la $(ell_ldadd)
 
 tools_l2cap_tester_SOURCES = tools/l2cap-tester.c monitor/bt.h \
 				emulator/hciemu.h emulator/hciemu-ell.c \

--- a/emulator/hciemu-ell.c
+++ b/emulator/hciemu-ell.c
@@ -1,0 +1,645 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2012-2014, 2021  Intel Corporation. All rights reserved.
+ *
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <sys/socket.h>
+
+#include <ell/ell.h>
+
+#include "lib/bluetooth.h"
+#include "lib/hci.h"
+
+#include "monitor/bt.h"
+#include "emulator/btdev.h"
+#include "emulator/bthost.h"
+#include "src/shared/util.h"
+#include "src/shared/queue.h"
+#include "emulator/hciemu.h"
+
+struct hciemu_client {
+	struct bthost *host;
+	struct btdev *dev;
+	struct l_idle *start_idle;
+	struct l_io *host_io;
+	struct l_io *io;
+};
+
+struct hciemu {
+	int ref_count;
+	enum btdev_type btdev_type;
+	struct btdev *dev;
+	struct l_queue *clients;
+	struct l_io *io;
+	struct l_queue *post_command_hooks;
+	char bdaddr_str[18];
+
+	hciemu_debug_func_t debug_callback;
+	hciemu_destroy_func_t debug_destroy;
+	void *debug_data;
+};
+
+struct hciemu_command_hook {
+	hciemu_command_func_t function;
+	void *user_data;
+};
+
+static void destroy_command_hook(void *data)
+{
+	struct hciemu_command_hook *hook = data;
+
+	l_free(hook);
+}
+
+struct run_data {
+	uint16_t opcode;
+	const void *data;
+	uint8_t len;
+};
+
+static void run_command_hook(void *data, void *user_data)
+{
+	struct hciemu_command_hook *hook = data;
+	struct run_data *run_data = user_data;
+
+	if (hook->function)
+		hook->function(run_data->opcode, run_data->data,
+					run_data->len, hook->user_data);
+}
+
+static void master_command_callback(uint16_t opcode,
+				const void *data, uint8_t len,
+				btdev_callback callback, void *user_data)
+{
+	struct hciemu *hciemu = user_data;
+	struct run_data run_data = { .opcode = opcode,
+						.data = data, .len = len };
+
+	btdev_command_default(callback);
+
+	l_queue_foreach(hciemu->post_command_hooks, run_command_hook,
+								&run_data);
+}
+
+static void client_command_callback(uint16_t opcode,
+				const void *data, uint8_t len,
+				btdev_callback callback, void *user_data)
+{
+	btdev_command_default(callback);
+}
+
+static void writev_callback(const struct iovec *iov, int iovlen,
+								void *user_data)
+{
+	struct l_io *io = user_data;
+	ssize_t written;
+	int fd;
+
+	fd = l_io_get_fd(io);
+
+	written = writev(fd, iov, iovlen);
+	if (written < 0)
+		return;
+}
+
+static bool receive_bthost(struct l_io *io, void *user_data)
+{
+	struct bthost *bthost = user_data;
+	unsigned char buf[4096];
+	ssize_t len;
+	int fd;
+
+	fd = l_io_get_fd(io);
+
+	len = read(fd, buf, sizeof(buf));
+	if (len < 0)
+		return false;
+
+	bthost_receive_h4(bthost, buf, len);
+
+	return true;
+}
+
+static struct l_io *create_io_bthost(int fd, struct bthost *bthost)
+{
+	struct l_io *io;
+
+	io = l_io_new(fd);
+
+	l_io_set_close_on_destroy(io, true);
+
+	bthost_set_send_handler(bthost, writev_callback, io);
+
+	l_io_set_read_handler(io, receive_bthost, bthost, NULL);
+
+	return io;
+}
+
+static bool receive_btdev(struct l_io *io, void *user_data)
+{
+	struct btdev *btdev = user_data;
+	unsigned char buf[4096];
+	ssize_t len;
+	int fd;
+
+	fd = l_io_get_fd(io);
+
+	len = read(fd, buf, sizeof(buf));
+	if (len < 0) {
+		if (errno == EAGAIN || errno == EINTR)
+			return true;
+
+		return false;
+	}
+
+	if (len < 1)
+		return false;
+
+	switch (buf[0]) {
+	case BT_H4_CMD_PKT:
+	case BT_H4_ACL_PKT:
+	case BT_H4_SCO_PKT:
+		btdev_receive_h4(btdev, buf, len);
+		break;
+	}
+
+	return true;
+}
+
+static struct l_io *create_io_btdev(int fd, struct btdev *btdev)
+{
+	struct l_io *io;
+
+	io = l_io_new(fd);
+
+	l_io_set_close_on_destroy(io, true);
+
+	btdev_set_send_handler(btdev, writev_callback, io);
+
+	l_io_set_read_handler(io, receive_btdev, btdev, NULL);
+
+	return io;
+}
+
+static bool create_vhci(struct hciemu *hciemu)
+{
+	struct btdev *btdev;
+	uint8_t create_req[2];
+	ssize_t written;
+	int fd;
+
+	btdev = btdev_create(hciemu->btdev_type, 0x00);
+	if (!btdev)
+		return false;
+
+	btdev_set_command_handler(btdev, master_command_callback, hciemu);
+
+	fd = open("/dev/vhci", O_RDWR | O_NONBLOCK | O_CLOEXEC);
+	if (fd < 0) {
+		perror("Opening /dev/vhci failed");
+		btdev_destroy(btdev);
+		return false;
+	}
+
+	create_req[0] = HCI_VENDOR_PKT;
+	create_req[1] = HCI_PRIMARY;
+
+	written = write(fd, create_req, sizeof(create_req));
+	if (written < 0) {
+		close(fd);
+		btdev_destroy(btdev);
+		return false;
+	}
+
+	hciemu->dev = btdev;
+
+	hciemu->io = create_io_btdev(fd, btdev);
+
+	return true;
+}
+
+struct hciemu_client *hciemu_get_client(struct hciemu *hciemu, int num)
+{
+	const struct l_queue_entry *entry;
+
+	if (!hciemu)
+		return NULL;
+
+	for (entry = l_queue_get_entries(hciemu->clients); entry;
+					entry = entry->next, num--) {
+		if (!num)
+			return entry->data;
+	}
+
+	return NULL;
+}
+
+struct bthost *hciemu_client_host(struct hciemu_client *client)
+{
+	if (!client)
+		return NULL;
+
+	return client->host;
+}
+
+struct bthost *hciemu_client_get_host(struct hciemu *hciemu)
+{
+	struct hciemu_client *client;
+
+	if (!hciemu)
+		return NULL;
+
+	client = hciemu_get_client(hciemu, 0);
+
+	return hciemu_client_host(client);
+}
+
+static void start_host(struct l_idle *idle, void *user_data)
+{
+	struct hciemu_client *client = user_data;
+
+	l_idle_remove(client->start_idle);
+
+	client->start_idle = NULL;
+
+	bthost_start(client->host);
+}
+
+static void hciemu_client_destroy(void *data)
+{
+	struct hciemu_client *client = data;
+
+	if (client->start_idle)
+		l_idle_remove(client->start_idle);
+
+	l_io_destroy(client->host_io);
+	l_io_destroy(client->io);
+
+	bthost_destroy(client->host);
+	btdev_destroy(client->dev);
+
+	l_free(client);
+}
+
+static struct hciemu_client *hciemu_client_new(struct hciemu *hciemu,
+							uint8_t id)
+{
+	struct hciemu_client *client;
+	int sv[2];
+
+	client = l_new(struct hciemu_client, 1);
+
+	client->dev = btdev_create(hciemu->btdev_type, id++);
+	if (!client->dev) {
+		l_free(client);
+		return NULL;
+	}
+
+	client->host = bthost_create();
+	if (!client->host) {
+		btdev_destroy(client->dev);
+		l_free(client);
+		return NULL;
+	}
+
+	btdev_set_command_handler(client->dev, client_command_callback, client);
+
+	if (socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK | SOCK_CLOEXEC,
+								0, sv) < 0) {
+		bthost_destroy(client->host);
+		btdev_destroy(client->dev);
+		return NULL;
+	}
+
+	client->io = create_io_btdev(sv[0], client->dev);
+	client->host_io = create_io_bthost(sv[1], client->host);
+	client->start_idle = l_idle_create(start_host, client, NULL);
+
+	return client;
+}
+
+struct hciemu *hciemu_new_num(enum hciemu_type type, uint8_t num)
+{
+
+	struct hciemu *hciemu;
+	int i;
+
+	if (!num)
+		return NULL;
+
+	hciemu = l_new(struct hciemu, 1);
+
+	switch (type) {
+	case HCIEMU_TYPE_BREDRLE:
+		hciemu->btdev_type = BTDEV_TYPE_BREDRLE;
+		break;
+	case HCIEMU_TYPE_BREDR:
+		hciemu->btdev_type = BTDEV_TYPE_BREDR;
+		break;
+	case HCIEMU_TYPE_LE:
+		hciemu->btdev_type = BTDEV_TYPE_LE;
+		break;
+	case HCIEMU_TYPE_LEGACY:
+		hciemu->btdev_type = BTDEV_TYPE_BREDR20;
+		break;
+	case HCIEMU_TYPE_BREDRLE50:
+		hciemu->btdev_type = BTDEV_TYPE_BREDRLE50;
+		break;
+	case HCIEMU_TYPE_BREDRLE52:
+		hciemu->btdev_type = BTDEV_TYPE_BREDRLE52;
+		break;
+	default:
+		return NULL;
+	}
+
+	hciemu->post_command_hooks = l_queue_new();
+	if (!hciemu->post_command_hooks) {
+		l_free(hciemu);
+		return NULL;
+	}
+
+	if (!create_vhci(hciemu)) {
+		l_queue_destroy(hciemu->post_command_hooks, NULL);
+		l_free(hciemu);
+		return NULL;
+	}
+
+	hciemu->clients = l_queue_new();
+
+	for (i = 0; i < num; i++) {
+		struct hciemu_client *client = hciemu_client_new(hciemu, i);
+
+		if (!client) {
+			l_queue_destroy(hciemu->clients, hciemu_client_destroy);
+			break;
+		}
+
+		l_queue_push_tail(hciemu->clients, client);
+	}
+
+	return hciemu_ref(hciemu);
+}
+
+struct hciemu *hciemu_new(enum hciemu_type type)
+{
+	return hciemu_new_num(type, 1);
+}
+
+struct hciemu *hciemu_ref(struct hciemu *hciemu)
+{
+	if (!hciemu)
+		return NULL;
+
+	__sync_fetch_and_add(&hciemu->ref_count, 1);
+
+	return hciemu;
+}
+
+void hciemu_unref(struct hciemu *hciemu)
+{
+	if (!hciemu)
+		return;
+
+	if (__sync_sub_and_fetch(&hciemu->ref_count, 1))
+		return;
+
+	l_queue_destroy(hciemu->post_command_hooks, destroy_command_hook);
+	l_queue_destroy(hciemu->clients, hciemu_client_destroy);
+
+	l_io_destroy(hciemu->io);
+	btdev_destroy(hciemu->dev);
+
+	l_free(hciemu);
+}
+
+static void bthost_debug(const char *str, void *user_data)
+{
+	struct hciemu *hciemu = user_data;
+
+	util_debug(hciemu->debug_callback, hciemu->debug_data,
+					"bthost: %s", str);
+}
+
+static void btdev_master_debug(const char *str, void *user_data)
+{
+	struct hciemu *hciemu = user_data;
+
+	util_debug(hciemu->debug_callback, hciemu->debug_data,
+					"btdev: %s", str);
+}
+
+static void btdev_client_debug(const char *str, void *user_data)
+{
+	struct hciemu *hciemu = user_data;
+
+	util_debug(hciemu->debug_callback, hciemu->debug_data,
+					"btdev[bthost]: %s", str);
+}
+
+static void hciemu_client_set_debug(void *data, void *user_data)
+{
+	struct hciemu_client *client = data;
+	struct hciemu *hciemu = user_data;
+
+	btdev_set_debug(client->dev, btdev_client_debug, hciemu, NULL);
+	bthost_set_debug(client->host, bthost_debug, hciemu, NULL);
+}
+
+bool hciemu_set_debug(struct hciemu *hciemu, hciemu_debug_func_t callback,
+			void *user_data, hciemu_destroy_func_t destroy)
+{
+	if (!hciemu)
+		return false;
+
+	if (hciemu->debug_destroy)
+		hciemu->debug_destroy(hciemu->debug_data);
+
+	hciemu->debug_callback = callback;
+	hciemu->debug_destroy = destroy;
+	hciemu->debug_data = user_data;
+
+	btdev_set_debug(hciemu->dev, btdev_master_debug, hciemu, NULL);
+
+	l_queue_foreach(hciemu->clients, hciemu_client_set_debug, hciemu);
+
+	return true;
+}
+
+const char *hciemu_get_address(struct hciemu *hciemu)
+{
+	const uint8_t *addr;
+
+	if (!hciemu || !hciemu->dev)
+		return NULL;
+
+	addr = btdev_get_bdaddr(hciemu->dev);
+	sprintf(hciemu->bdaddr_str, "%2.2X:%2.2X:%2.2X:%2.2X:%2.2X:%2.2X",
+			addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]);
+	return hciemu->bdaddr_str;
+}
+
+uint8_t *hciemu_get_features(struct hciemu *hciemu)
+{
+	if (!hciemu || !hciemu->dev)
+		return NULL;
+
+	return btdev_get_features(hciemu->dev);
+}
+
+const uint8_t *hciemu_get_master_bdaddr(struct hciemu *hciemu)
+{
+	if (!hciemu || !hciemu->dev)
+		return NULL;
+
+	return btdev_get_bdaddr(hciemu->dev);
+}
+
+const uint8_t *hciemu_client_bdaddr(struct hciemu_client *client)
+{
+	if (!client)
+		return NULL;
+
+	return btdev_get_bdaddr(client->dev);
+}
+
+const uint8_t *hciemu_get_client_bdaddr(struct hciemu *hciemu)
+{
+	struct hciemu_client *client;
+
+	if (!hciemu)
+		return NULL;
+
+	client = hciemu_get_client(hciemu, 0);
+
+	return hciemu_client_bdaddr(client);
+}
+
+uint8_t hciemu_get_master_scan_enable(struct hciemu *hciemu)
+{
+	if (!hciemu || !hciemu->dev)
+		return 0;
+
+	return btdev_get_scan_enable(hciemu->dev);
+}
+
+uint8_t hciemu_get_master_le_scan_enable(struct hciemu *hciemu)
+{
+	if (!hciemu || !hciemu->dev)
+		return 0;
+
+	return btdev_get_le_scan_enable(hciemu->dev);
+}
+
+void hciemu_set_master_le_states(struct hciemu *hciemu,
+						const uint8_t *le_states)
+{
+	if (!hciemu || !hciemu->dev)
+		return;
+
+	btdev_set_le_states(hciemu->dev, le_states);
+}
+
+bool hciemu_add_master_post_command_hook(struct hciemu *hciemu,
+			hciemu_command_func_t function, void *user_data)
+{
+	struct hciemu_command_hook *hook;
+
+	if (!hciemu)
+		return false;
+
+	hook = l_new(struct hciemu_command_hook, 1);
+
+	hook->function = function;
+	hook->user_data = user_data;
+
+	if (!l_queue_push_tail(hciemu->post_command_hooks, hook)) {
+		l_free(hook);
+		return false;
+	}
+
+	return true;
+}
+
+bool hciemu_clear_master_post_command_hooks(struct hciemu *hciemu)
+{
+	if (!hciemu)
+		return false;
+
+	l_queue_clear(hciemu->post_command_hooks, destroy_command_hook);
+	return true;
+}
+
+int hciemu_add_hook(struct hciemu *hciemu, enum hciemu_hook_type type,
+				uint16_t opcode, hciemu_hook_func_t function,
+				void *user_data)
+{
+	enum btdev_hook_type hook_type;
+
+	if (!hciemu)
+		return -1;
+
+	switch (type) {
+	case HCIEMU_HOOK_PRE_CMD:
+		hook_type = BTDEV_HOOK_PRE_CMD;
+		break;
+	case HCIEMU_HOOK_POST_CMD:
+		hook_type = BTDEV_HOOK_POST_CMD;
+		break;
+	case HCIEMU_HOOK_PRE_EVT:
+		hook_type = BTDEV_HOOK_PRE_EVT;
+		break;
+	case HCIEMU_HOOK_POST_EVT:
+		hook_type = BTDEV_HOOK_POST_EVT;
+		break;
+	default:
+		return -1;
+	}
+
+	return btdev_add_hook(hciemu->dev, hook_type, opcode, function,
+								user_data);
+}
+
+bool hciemu_del_hook(struct hciemu *hciemu, enum hciemu_hook_type type,
+								uint16_t opcode)
+{
+	enum btdev_hook_type hook_type;
+
+	if (!hciemu)
+		return false;
+
+	switch (type) {
+	case HCIEMU_HOOK_PRE_CMD:
+		hook_type = BTDEV_HOOK_PRE_CMD;
+		break;
+	case HCIEMU_HOOK_POST_CMD:
+		hook_type = BTDEV_HOOK_POST_CMD;
+		break;
+	case HCIEMU_HOOK_PRE_EVT:
+		hook_type = BTDEV_HOOK_PRE_EVT;
+		break;
+	case HCIEMU_HOOK_POST_EVT:
+		hook_type = BTDEV_HOOK_POST_EVT;
+		break;
+	default:
+		return false;
+	}
+
+	return btdev_del_hook(hciemu->dev, hook_type, opcode);
+}

--- a/src/shared/bttester.c
+++ b/src/shared/bttester.c
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2012-2014  Intel Corporation. All rights reserved.
+ *
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <getopt.h>
+#include <syslog.h>
+
+#include <ell/ell.h>
+
+#include "lib/bluetooth.h"
+#include "lib/hci.h"
+
+#include "src/shared/util.h"
+#include "src/shared/bttester.h"
+#include "src/shared/log.h"
+
+#define COLOR_WHITE    "\x1B[0;37m"
+#define COLOR_OFF      "\x1B[0m"
+
+static char *tester_name;
+
+static bool option_quiet;
+static bool option_debug;
+static bool option_monitor;
+static bool option_list;
+static const char *option_prefix;
+static const char *option_string;
+
+struct l_tester *tester;
+
+struct monitor_hdr {
+	uint16_t opcode;
+	uint16_t index;
+	uint16_t len;
+	uint8_t  priority;
+	uint8_t  ident_len;
+} __attribute__((packed));
+
+struct monitor_l2cap_hdr {
+	uint16_t cid;
+	uint16_t psm;
+} __attribute__((packed));
+
+static void tester_vprintf(const char *format, va_list ap)
+{
+	if (bttester_use_quiet())
+		return;
+
+	printf("  %s", COLOR_WHITE);
+	vprintf(format, ap);
+	printf("%s\n", COLOR_OFF);
+}
+
+void bttester_print(const char *format, ...)
+{
+	va_list ap;
+
+	va_start(ap, format);
+	tester_vprintf(format, ap);
+	va_end(ap);
+
+	va_start(ap, format);
+	bt_log_vprintf(HCI_DEV_NONE, tester_name, LOG_INFO, format, ap);
+	va_end(ap);
+}
+
+void bttester_debug(const char *format, ...)
+{
+	va_list ap;
+
+	va_start(ap, format);
+	tester_vprintf(format, ap);
+	va_end(ap);
+
+	va_start(ap, format);
+	bt_log_vprintf(HCI_DEV_NONE, tester_name, LOG_DEBUG, format, ap);
+	va_end(ap);
+}
+
+void bttester_warn(const char *format, ...)
+{
+	va_list ap;
+
+	va_start(ap, format);
+	tester_vprintf(format, ap);
+	va_end(ap);
+
+	va_start(ap, format);
+	bt_log_vprintf(HCI_DEV_NONE, tester_name, LOG_WARNING, format, ap);
+	va_end(ap);
+}
+
+static void monitor_debug(const char *str, void *user_data)
+{
+	const char *label = user_data;
+
+	bttester_debug("%s: %s", label, str);
+}
+
+static void monitor_log(char dir, uint16_t cid, uint16_t psm, const void *data,
+								size_t len)
+{
+	struct iovec iov[3];
+	struct monitor_l2cap_hdr hdr;
+	uint8_t term = 0x00;
+	char label[16];
+
+	if (snprintf(label, sizeof(label), "%c %s", dir, tester_name) < 0)
+		return;
+
+	hdr.cid = cpu_to_le16(cid);
+	hdr.psm = cpu_to_le16(psm);
+
+	iov[0].iov_base = &hdr;
+	iov[0].iov_len = sizeof(hdr);
+
+	iov[1].iov_base = (void *) data;
+	iov[1].iov_len = len;
+
+	/* Kernel won't forward if data is no NULL terminated */
+	iov[2].iov_base = &term;
+	iov[2].iov_len = sizeof(term);
+
+	bt_log_sendmsg(HCI_DEV_NONE, label, LOG_INFO, iov, 3);
+}
+
+void bttester_monitor(char dir, uint16_t cid, uint16_t psm, const void *data,
+								size_t len)
+{
+	monitor_log(dir, cid, psm, data, len);
+
+	if (!bttester_use_debug())
+		return;
+
+	util_hexdump(dir, data, len, monitor_debug, (void *) tester_name);
+}
+
+bool bttester_use_quiet(void)
+{
+	return option_quiet;
+}
+
+bool bttester_use_debug(void)
+{
+	return option_debug;
+}
+
+static const struct option options[] = {
+	{ "version",	no_argument,		NULL, 'v' },
+	{ "quiet",	no_argument,		NULL, 'q' },
+	{ "monitor",	no_argument,		NULL, 'm' },
+	{ "debug",	no_argument,		NULL, 'd' },
+	{ "list",	no_argument,		NULL, 'l' },
+	{ "prefix",	required_argument,	NULL, 'p' },
+	{ "string",	required_argument,	NULL, 's' },
+	{ }
+};
+
+static void usage(void)
+{
+	fprintf(stderr,
+		"Usage:\n"
+		"\%s [options]\n", tester_name);
+	fprintf(stderr,
+		"Options:\n"
+		"\t-v, --version Show version information and exit\n"
+		"\t-q, --quiet   Run tests without logging\n"
+		"\t-d, --debug   Run tests with debug output\n"
+		"\t-d, --monitor Enable monitor output\n"
+		"\t-l, --list	 Only list the tests to be run\n"
+		"\t-p, --prefix	 Run tests matching the provided prefix\n"
+		"\t-s, --string	 Run tests matching the provided string\n");
+}
+
+static void parse_options(int *argc, char ***argv)
+{
+	tester_name = strrchr(*argv[0], '/');
+
+	for (;;) {
+		int opt;
+
+		opt = getopt_long(*argc, *argv, "s:p:dvlm", options, NULL);
+		if (opt < 0)
+			break;
+
+		switch (opt) {
+		case 'v':
+			printf("%s\n", VERSION);
+			exit(EXIT_SUCCESS);
+		case 'd':
+			option_debug = true;
+			break;
+		case 'l':
+			option_list = true;
+			break;
+		case 'm':
+			option_monitor = true;
+			break;
+		case 'p':
+			option_prefix = optarg;
+			break;
+		case 's':
+			option_string = optarg;
+			break;
+		default:
+			usage();
+			exit(0);
+		}
+	}
+}
+
+static bool terminated;
+
+static void signal_callback(unsigned int signum, void *user_data)
+{
+	switch (signum) {
+	case SIGINT:
+	case SIGTERM:
+		if (!terminated)
+			l_main_quit();
+
+		terminated = true;
+		break;
+	}
+}
+
+static void done_callback(struct l_tester *tester)
+{
+	if (terminated)
+		return;
+
+	l_main_quit();
+	terminated = true;
+}
+
+struct l_tester *bttester_init(int *argc, char ***argv)
+{
+	l_log_set_stderr();
+
+	l_main_init();
+
+	tester_name = strrchr(*argv[0], '/');
+	parse_options(argc, argv);
+
+	tester = l_tester_new(option_prefix, option_string, option_list);
+
+	return tester;
+}
+
+int bttester_run(void)
+{
+	int status = EXIT_SUCCESS;
+
+	l_tester_start(tester, done_callback);
+
+	if (!option_list && !terminated)
+		l_main_run_with_signal(signal_callback, NULL);
+
+	if (!option_list && !l_tester_summarize(tester))
+		status = EXIT_FAILURE;
+
+	l_tester_destroy(tester);
+
+	return status;
+}

--- a/src/shared/bttester.h
+++ b/src/shared/bttester.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2012-2014, 2021  Intel Corporation. All rights reserved.
+ *
+ *
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct l_tester *bttester_init(int *argc, char ***argv);
+int bttester_run(void);
+
+bool bttester_use_quiet(void);
+bool bttester_use_debug(void);
+
+void bttester_print(const char *format, ...)
+				__attribute__((format(printf, 1, 2)));
+void bttester_warn(const char *format, ...)
+				__attribute__((format(printf, 1, 2)));
+void bttester_debug(const char *format, ...)
+				__attribute__((format(printf, 1, 2)));
+void bttester_monitor(char dir, uint16_t cid,
+				uint16_t psm, const void *data, size_t len);

--- a/tools/bnep-tester.c
+++ b/tools/bnep-tester.c
@@ -18,7 +18,7 @@
 #include <errno.h>
 #include <stdbool.h>
 
-#include <glib.h>
+#include <ell/ell.h>
 
 #include "lib/bluetooth.h"
 #include "lib/bnep.h"
@@ -28,7 +28,7 @@
 #include "emulator/bthost.h"
 #include "emulator/hciemu.h"
 
-#include "src/shared/tester.h"
+#include "src/shared/bttester.h"
 #include "src/shared/mgmt.h"
 
 struct test_data {
@@ -37,7 +37,6 @@ struct test_data {
 	struct hciemu *hciemu;
 	enum hciemu_type hciemu_type;
 	const void *test_data;
-	unsigned int io_id;
 	uint16_t conn_handle;
 };
 
@@ -59,27 +58,29 @@ struct rfcomm_server_data {
 	uint16_t data_len;
 };
 
+static struct l_tester *tester;
+
 static void print_debug(const char *str, void *user_data)
 {
 	const char *prefix = user_data;
 
-	tester_print("%s%s", prefix, str);
+	bttester_print("%s%s", prefix, str);
 }
 
 static void read_info_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct mgmt_rp_read_info *rp = param;
 	char addr[18];
 	uint16_t manufacturer;
 	uint32_t supported_settings, current_settings;
 
-	tester_print("Read Info callback");
-	tester_print("  Status: 0x%02x", status);
+	bttester_print("Read Info callback");
+	bttester_print("  Status: 0x%02x", status);
 
 	if (status || !param) {
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
@@ -88,31 +89,31 @@ static void read_info_callback(uint8_t status, uint16_t length,
 	supported_settings = btohl(rp->supported_settings);
 	current_settings = btohl(rp->current_settings);
 
-	tester_print("  Address: %s", addr);
-	tester_print("  Version: 0x%02x", rp->version);
-	tester_print("  Manufacturer: 0x%04x", manufacturer);
-	tester_print("  Supported settings: 0x%08x", supported_settings);
-	tester_print("  Current settings: 0x%08x", current_settings);
-	tester_print("  Class: 0x%02x%02x%02x",
+	bttester_print("  Address: %s", addr);
+	bttester_print("  Version: 0x%02x", rp->version);
+	bttester_print("  Manufacturer: 0x%04x", manufacturer);
+	bttester_print("  Supported settings: 0x%08x", supported_settings);
+	bttester_print("  Current settings: 0x%08x", current_settings);
+	bttester_print("  Class: 0x%02x%02x%02x",
 			rp->dev_class[2], rp->dev_class[1], rp->dev_class[0]);
-	tester_print("  Name: %s", rp->name);
-	tester_print("  Short name: %s", rp->short_name);
+	bttester_print("  Name: %s", rp->name);
+	bttester_print("  Short name: %s", rp->short_name);
 
 	if (strcmp(hciemu_get_address(data->hciemu), addr)) {
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
-	tester_pre_setup_complete();
+	l_tester_pre_setup_complete(tester);
 }
 
 static void index_added_callback(uint16_t index, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Index Added callback");
-	tester_print("  Index: 0x%04x", index);
+	bttester_print("Index Added callback");
+	bttester_print("  Index: 0x%04x", index);
 
 	data->mgmt_index = index;
 
@@ -123,10 +124,10 @@ static void index_added_callback(uint16_t index, uint16_t length,
 static void index_removed_callback(uint16_t index, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Index Removed callback");
-	tester_print("  Index: 0x%04x", index);
+	bttester_print("Index Removed callback");
+	bttester_print("  Index: 0x%04x", index);
 
 	if (index != data->mgmt_index)
 		return;
@@ -136,19 +137,19 @@ static void index_removed_callback(uint16_t index, uint16_t length,
 	mgmt_unref(data->mgmt);
 	data->mgmt = NULL;
 
-	tester_post_teardown_complete();
+	l_tester_post_teardown_complete(tester);
 }
 
 static void read_index_list_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Read Index List callback");
-	tester_print("  Status: 0x%02x", status);
+	bttester_print("Read Index List callback");
+	bttester_print("  Status: 0x%02x", status);
 
 	if (status || !param) {
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
@@ -160,28 +161,28 @@ static void read_index_list_callback(uint8_t status, uint16_t length,
 
 	data->hciemu = hciemu_new(data->hciemu_type);
 	if (!data->hciemu) {
-		tester_warn("Failed to setup HCI emulation");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to setup HCI emulation");
+		l_tester_pre_setup_failed(tester);
 	}
 
-	if (tester_use_debug())
+	if (bttester_use_debug())
 		hciemu_set_debug(data->hciemu, print_debug, "hciemu: ", NULL);
 
-	tester_print("New hciemu instance created");
+	bttester_print("New hciemu instance created");
 }
 
 static void test_pre_setup(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
 	data->mgmt = mgmt_new_default();
 	if (!data->mgmt) {
-		tester_warn("Failed to setup management interface");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to setup management interface");
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
-	if (tester_use_debug())
+	if (bttester_use_debug())
 		mgmt_set_debug(data->mgmt, print_debug, "mgmt: ", NULL);
 
 	mgmt_send(data->mgmt, MGMT_OP_READ_INDEX_LIST, MGMT_INDEX_NONE, 0, NULL,
@@ -190,12 +191,7 @@ static void test_pre_setup(const void *test_data)
 
 static void test_post_teardown(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
-
-	if (data->io_id > 0) {
-		g_source_remove(data->io_id);
-		data->io_id = 0;
-	}
+	struct test_data *data = l_tester_get_data(tester);
 
 	hciemu_unref(data->hciemu);
 	data->hciemu = NULL;
@@ -205,7 +201,7 @@ static void test_data_free(void *test_data)
 {
 	struct test_data *data = test_data;
 
-	free(data);
+	l_free(data);
 }
 
 static void client_connectable_complete(uint16_t opcode, uint8_t status,
@@ -219,26 +215,26 @@ static void client_connectable_complete(uint16_t opcode, uint8_t status,
 		return;
 	}
 
-	tester_print("Client set connectable status 0x%02x", status);
+	bttester_print("Client set connectable status 0x%02x", status);
 
 	if (status)
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 	else
-		tester_setup_complete();
+		l_tester_setup_complete(tester);
 }
 
 static void setup_powered_client_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct bthost *bthost;
 
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_print("Controller powered on");
+	bttester_print("Controller powered on");
 
 	bthost = hciemu_client_get_host(data->hciemu);
 	bthost_set_cmd_complete_cb(bthost, client_connectable_complete, data);
@@ -247,10 +243,10 @@ static void setup_powered_client_callback(uint8_t status, uint16_t length,
 
 static void setup_powered_client(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Powering on controller");
+	bttester_print("Powering on controller");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_POWERED, data->mgmt_index,
 			sizeof(param), param, setup_powered_client_callback,
@@ -263,37 +259,36 @@ static void test_basic(const void *test_data)
 
 	sk = socket(PF_BLUETOOTH, SOCK_RAW, BTPROTO_BNEP);
 	if (sk < 0) {
-		tester_warn("Can't create socket: %s (%d)", strerror(errno),
+		bttester_warn("Can't create socket: %s (%d)", strerror(errno),
 									errno);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	close(sk);
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 }
 
 #define test_bnep(name, data, setup, func) \
 	do { \
 		struct test_data *user; \
-		user = malloc(sizeof(struct test_data)); \
+		user = l_new(struct test_data, 1);	\
 		if (!user) \
 			break; \
 		user->hciemu_type = HCIEMU_TYPE_BREDR; \
 		user->test_data = data; \
-		user->io_id = 0; \
-		tester_add_full(name, data, \
+		l_tester_add_full(tester, name, data,		   \
 				test_pre_setup, setup, func, NULL, \
 				test_post_teardown, 2, user, test_data_free); \
 	} while (0)
 
 int main(int argc, char *argv[])
 {
-	tester_init(&argc, &argv);
+	tester = bttester_init(&argc, &argv);
 
 	test_bnep("Basic BNEP Socket - Success", NULL,
 					setup_powered_client, test_basic);
 
-	return tester_run();
+	return bttester_run();
 }

--- a/tools/hci-tester.c
+++ b/tools/hci-tester.c
@@ -15,11 +15,13 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <ell/ell.h>
+
 #include "monitor/bt.h"
 #include "src/shared/hci.h"
 #include "src/shared/util.h"
 #include "src/shared/ecc.h"
-#include "src/shared/tester.h"
+#include "src/shared/bttester.h"
 
 struct user_data {
 	const void *test_data;
@@ -38,6 +40,8 @@ struct le_keys {
 	uint8_t local_pk[64];
 } key_test_data;
 
+static struct l_tester *tester;
+
 static void swap_buf(const uint8_t *src, uint8_t *dst, uint16_t len)
 {
 	int i;
@@ -48,43 +52,43 @@ static void swap_buf(const uint8_t *src, uint8_t *dst, uint16_t len)
 
 static void test_debug(const char *str, void *user_data)
 {
-	tester_debug("%s", str);
+	bttester_debug("%s", str);
 }
 
 static void test_pre_setup_lt_address(const void *data, uint8_t size,
 							void *user_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	const struct bt_hci_rsp_read_bd_addr *rsp = data;
 
 	if (rsp->status) {
-		tester_warn("Read lower tester address failed (0x%02x)",
+		bttester_warn("Read lower tester address failed (0x%02x)",
 								rsp->status);
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
 	memcpy(user->bdaddr_lt, rsp->bdaddr, 6);
 
-	tester_pre_setup_complete();
+	l_tester_pre_setup_complete(tester);
 }
 
 static void test_pre_setup_lt_complete(const void *data, uint8_t size,
 							void *user_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	uint8_t status = *((uint8_t *) data);
 
 	if (status) {
-		tester_warn("Reset lower tester failed (0x%02x)", status);
-		tester_pre_setup_failed();
+		bttester_warn("Reset lower tester failed (0x%02x)", status);
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
 	if (!bt_hci_send(user->hci_lt, BT_HCI_CMD_READ_BD_ADDR, NULL, 0,
 				test_pre_setup_lt_address, NULL, NULL)) {
-		tester_warn("Failed to read lower tester address");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to read lower tester address");
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 }
@@ -92,13 +96,13 @@ static void test_pre_setup_lt_complete(const void *data, uint8_t size,
 static void test_pre_setup_ut_address(const void *data, uint8_t size,
 							void *user_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	const struct bt_hci_rsp_read_bd_addr *rsp = data;
 
 	if (rsp->status) {
-		tester_warn("Read upper tester address failed (0x%02x)",
+		bttester_warn("Read upper tester address failed (0x%02x)",
 								rsp->status);
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
@@ -106,15 +110,15 @@ static void test_pre_setup_ut_address(const void *data, uint8_t size,
 
 	user->hci_lt = bt_hci_new_user_channel(user->index_lt);
 	if (!user->hci_lt) {
-		tester_warn("Failed to setup lower tester user channel");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to setup lower tester user channel");
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
 	if (!bt_hci_send(user->hci_lt, BT_HCI_CMD_RESET, NULL, 0,
 				test_pre_setup_lt_complete, NULL, NULL)) {
-		tester_warn("Failed to reset lower tester");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to reset lower tester");
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 }
@@ -122,50 +126,50 @@ static void test_pre_setup_ut_address(const void *data, uint8_t size,
 static void test_pre_setup_ut_complete(const void *data, uint8_t size,
 							void *user_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	uint8_t status = *((uint8_t *) data);
 
 	if (status) {
-		tester_warn("Reset upper tester failed (0x%02x)", status);
-		tester_pre_setup_failed();
+		bttester_warn("Reset upper tester failed (0x%02x)", status);
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
 	if (user->index_lt == 0xffff) {
-		tester_pre_setup_complete();
+		l_tester_pre_setup_complete(tester);
 		return;
 	}
 
 	if (!bt_hci_send(user->hci_ut, BT_HCI_CMD_READ_BD_ADDR, NULL, 0,
 				test_pre_setup_ut_address, NULL, NULL)) {
-		tester_warn("Failed to read upper tester address");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to read upper tester address");
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 }
 
 static void test_pre_setup(const void *test_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 
 	user->hci_ut = bt_hci_new_user_channel(user->index_ut);
 	if (!user->hci_ut) {
-		tester_warn("Failed to setup upper tester user channel");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to setup upper tester user channel");
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
 	if (!bt_hci_send(user->hci_ut, BT_HCI_CMD_RESET, NULL, 0,
 				test_pre_setup_ut_complete, NULL, NULL)) {
-		tester_warn("Failed to reset upper tester");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to reset upper tester");
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 }
 
 static void test_post_teardown(const void *test_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 
 	bt_hci_unref(user->hci_lt);
 	user->hci_lt = NULL;
@@ -173,42 +177,31 @@ static void test_post_teardown(const void *test_data)
 	bt_hci_unref(user->hci_ut);
 	user->hci_ut = NULL;
 
-	tester_post_teardown_complete();
-}
-
-static void user_data_free(void *data)
-{
-	struct user_data *user = data;
-
-	free(user);
+	l_tester_post_teardown_complete(tester);
 }
 
 #define test_hci(name, data, setup, func, teardown) \
 	do { \
 		struct user_data *user; \
-		user = calloc(1, sizeof(struct user_data)); \
-		if (!user) \
-			break; \
+		user = l_new(struct user_data, 1);	\
 		user->test_data = data; \
 		user->index_ut = 0; \
 		user->index_lt = 1; \
-		tester_add_full(name, data, \
+		l_tester_add_full(tester, name, data,		       \
 				test_pre_setup, setup, func, teardown, \
-				test_post_teardown, 30, user, user_data_free); \
+				test_post_teardown, 30, user, l_free); \
 	} while (0)
 
 #define test_hci_local(name, data, setup, func) \
 	do { \
 		struct user_data *user; \
-		user = calloc(1, sizeof(struct user_data)); \
-		if (!user) \
-			break; \
+		user = l_new(struct user_data, 1);	\
 		user->test_data = data; \
 		user->index_ut = 0; \
 		user->index_lt = 0xffff; \
-		tester_add_full(name, data, \
+		l_tester_add_full(tester, name, data,		   \
 				test_pre_setup, setup, func, NULL, \
-				test_post_teardown, 30, user, user_data_free); \
+				test_post_teardown, 30, user, l_free); \
 	} while (0)
 
 static void setup_features_complete(const void *data, uint8_t size,
@@ -217,29 +210,30 @@ static void setup_features_complete(const void *data, uint8_t size,
 	const struct bt_hci_rsp_read_local_features *rsp = data;
 
 	if (rsp->status) {
-		tester_warn("Failed to get HCI features (0x%02x)", rsp->status);
-		tester_setup_failed();
+		bttester_warn("Failed to get HCI features (0x%02x)",
+								rsp->status);
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_setup_complete();
+	l_tester_setup_complete(tester);
 }
 
 static void setup_features(const void *test_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 
 	if (!bt_hci_send(user->hci_ut, BT_HCI_CMD_READ_LOCAL_FEATURES, NULL, 0,
 					setup_features_complete, NULL, NULL)) {
-		tester_warn("Failed to send HCI features command");
-		tester_setup_failed();
+		bttester_warn("Failed to send HCI features command");
+		l_tester_setup_failed(tester);
 		return;
 	}
 }
 
 static void test_reset(const void *test_data)
 {
-	tester_test_passed();
+	l_tester_test_passed(tester);
 }
 
 static void test_command_complete(const void *data, uint8_t size,
@@ -248,22 +242,22 @@ static void test_command_complete(const void *data, uint8_t size,
 	uint8_t status = *((uint8_t *) data);
 
 	if (status) {
-		tester_warn("HCI command failed (0x%02x)", status);
-		tester_test_failed();
+		bttester_warn("HCI command failed (0x%02x)", status);
+		l_tester_test_failed(tester);
 		return;
 	}
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 }
 
 static void test_command(uint16_t opcode)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 
 	if (!bt_hci_send(user->hci_ut, opcode, NULL, 0,
 					test_command_complete, NULL, NULL)) {
-		tester_warn("Failed to send HCI command 0x%04x", opcode);
-		tester_test_failed();
+		bttester_warn("Failed to send HCI command 0x%04x", opcode);
+		l_tester_test_failed(tester);
 		return;
 	}
 }
@@ -289,18 +283,18 @@ static void test_local_extended_features_complete(const void *data,
 	const struct bt_hci_rsp_read_local_ext_features *rsp = data;
 
 	if (rsp->status) {
-		tester_warn("Failed to get HCI extended features (0x%02x)",
+		bttester_warn("Failed to get HCI extended features (0x%02x)",
 								rsp->status);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 }
 
 static void test_read_local_extended_features(const void *test_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	struct bt_hci_cmd_read_local_ext_features cmd;
 
 	cmd.page = 0x00;
@@ -309,8 +303,8 @@ static void test_read_local_extended_features(const void *test_data)
 					&cmd, sizeof(cmd),
 					test_local_extended_features_complete,
 								NULL, NULL)) {
-		tester_warn("Failed to send HCI extended features command");
-		tester_test_failed();
+		bttester_warn("Failed to send HCI extended features command");
+		l_tester_test_failed(tester);
 		return;
 	}
 }
@@ -356,8 +350,8 @@ static void test_le_encrypt_complete(const void *data, uint8_t size,
 	uint8_t enc_data[16];
 
 	if (rsp->status) {
-		tester_warn("Failed HCI LE Encrypt (0x%02x)", rsp->status);
-		tester_test_failed();
+		bttester_warn("Failed HCI LE Encrypt (0x%02x)", rsp->status);
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -365,15 +359,15 @@ static void test_le_encrypt_complete(const void *data, uint8_t size,
 	util_hexdump('>', enc_data, 16, test_debug, NULL);
 
 	if (!memcmp(sample, enc_data, 16))
-		tester_test_passed();
+		l_tester_test_passed(tester);
 	else
-		tester_test_failed();
+		l_tester_test_failed(tester);
 }
 
 /* Data are taken from RFC 4493 Test Vectors */
 static void test_le_encrypt(const void *test_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	struct bt_hci_cmd_le_encrypt cmd;
 	uint8_t key[16] = {
 		0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
@@ -392,8 +386,8 @@ static void test_le_encrypt(const void *test_data)
 
 	if (!bt_hci_send(user->hci_ut, BT_HCI_CMD_LE_ENCRYPT, &cmd, sizeof(cmd),
 					test_le_encrypt_complete, NULL, NULL)) {
-		tester_warn("Failed to send HCI LE Encrypt command");
-		tester_test_failed();
+		bttester_warn("Failed to send HCI LE Encrypt command");
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -412,16 +406,16 @@ static void test_le_read_local_pk_complete(const void *data, uint8_t size,
 	struct le_keys *keys = user_data;
 
 	if (*event != BT_HCI_EVT_LE_READ_LOCAL_PK256_COMPLETE) {
-		tester_warn("Failed Read Local PK256 command");
-		tester_test_failed();
+		bttester_warn("Failed Read Local PK256 command");
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	evt = (void *)(event + 1);
 	if (evt->status) {
-		tester_warn("HCI Read Local PK complete failed (0x%02x)",
+		bttester_warn("HCI Read Local PK complete failed (0x%02x)",
 								evt->status);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -429,7 +423,7 @@ static void test_le_read_local_pk_complete(const void *data, uint8_t size,
 
 	util_hexdump('>', evt->local_pk256, 64, test_debug, NULL);
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 }
 
 static void test_le_read_local_pk_status(const void *data, uint8_t size,
@@ -438,15 +432,16 @@ static void test_le_read_local_pk_status(const void *data, uint8_t size,
 	uint8_t status = *((uint8_t *) data);
 
 	if (status) {
-		tester_warn("Failed to send Read Local PK256 cmd (0x%02x)", status);
-		tester_test_failed();
+		bttester_warn("Failed to send Read Local PK256 cmd (0x%02x)",
+									status);
+		l_tester_test_failed(tester);
 		return;
 	}
 }
 
 static void test_le_read_local_pk(const void *test_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	struct bt_hci_cmd_set_event_mask sem;
 	struct bt_hci_cmd_le_set_event_mask lsem;
 
@@ -471,8 +466,8 @@ static void test_le_read_local_pk(const void *test_data)
 	if (!bt_hci_send(user->hci_ut, BT_HCI_CMD_LE_READ_LOCAL_PK256, NULL,
 				0, test_le_read_local_pk_status,
 				NULL, NULL)) {
-		tester_warn("Failed to send HCI LE Read Local PK256 command");
-		tester_test_failed();
+		bttester_warn("Failed to send HCI LE Read Local PK256 command");
+		l_tester_test_failed(tester);
 		return;
 	}
 }
@@ -485,16 +480,16 @@ static void setup_le_read_local_pk_complete(const void *data, uint8_t size,
 	struct le_keys *keys = user_data;
 
 	if (*event != BT_HCI_EVT_LE_READ_LOCAL_PK256_COMPLETE) {
-		tester_warn("Failed Read Local PK256 command");
-		tester_setup_failed();
+		bttester_warn("Failed Read Local PK256 command");
+		l_tester_setup_failed(tester);
 		return;
 	}
 
 	evt = (void *)(event + 1);
 	if (evt->status) {
-		tester_warn("HCI Read Local PK complete failed (0x%02x)",
+		bttester_warn("HCI Read Local PK complete failed (0x%02x)",
 								evt->status);
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
@@ -502,7 +497,7 @@ static void setup_le_read_local_pk_complete(const void *data, uint8_t size,
 
 	util_hexdump('>', evt->local_pk256, 64, test_debug, NULL);
 
-	tester_setup_complete();
+	l_tester_setup_complete(tester);
 }
 
 static void setup_le_read_local_pk_status(const void *data, uint8_t size,
@@ -511,15 +506,15 @@ static void setup_le_read_local_pk_status(const void *data, uint8_t size,
 	uint8_t status = *((uint8_t *) data);
 
 	if (status) {
-		tester_warn("Failed to send DHKey gen cmd (0x%02x)", status);
-		tester_setup_failed();
+		bttester_warn("Failed to send DHKey gen cmd (0x%02x)", status);
+		l_tester_setup_failed(tester);
 		return;
 	}
 }
 
 static void setup_le_generate_dhkey(const void *test_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	struct bt_hci_cmd_set_event_mask sem;
 	struct bt_hci_cmd_le_set_event_mask lsem;
 
@@ -545,8 +540,8 @@ static void setup_le_generate_dhkey(const void *test_data)
 	if (!bt_hci_send(user->hci_ut, BT_HCI_CMD_LE_READ_LOCAL_PK256, NULL,
 				0, setup_le_read_local_pk_status,
 				NULL, NULL)) {
-		tester_warn("Failed to send HCI LE Read Local PK256 command");
-		tester_setup_failed();
+		bttester_warn("Failed to send HCI LE Read Local PK256 command");
+		l_tester_setup_failed(tester);
 		return;
 	}
 }
@@ -560,16 +555,16 @@ static void test_le_generate_dhkey_complete(const void *data, uint8_t size,
 	uint8_t dhkey[32];
 
 	if (*event != BT_HCI_EVT_LE_GENERATE_DHKEY_COMPLETE) {
-		tester_warn("Failed DHKey generation command");
-		tester_test_failed();
+		bttester_warn("Failed DHKey generation command");
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	evt = (void *)(event + 1);
 	if (evt->status) {
-		tester_warn("HCI Generate DHKey complete failed (0x%02x)",
+		bttester_warn("HCI Generate DHKey complete failed (0x%02x)",
 								evt->status);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -588,9 +583,9 @@ static void test_le_generate_dhkey_complete(const void *data, uint8_t size,
 	util_hexdump('D', dhkey, 32, test_debug, NULL);
 
 	if (!memcmp(dhkey, evt->dhkey, 32))
-		tester_test_passed();
+		l_tester_test_passed(tester);
 	else
-		tester_test_failed();
+		l_tester_test_failed(tester);
 }
 
 static void test_le_generate_dhkey_status(const void *data, uint8_t size,
@@ -599,15 +594,15 @@ static void test_le_generate_dhkey_status(const void *data, uint8_t size,
 	uint8_t status = *((uint8_t *) data);
 
 	if (status) {
-		tester_warn("Failed to send DHKey gen cmd (0x%02x)", status);
-		tester_test_failed();
+		bttester_warn("Failed to send DHKey gen cmd (0x%02x)", status);
+		l_tester_test_failed(tester);
 		return;
 	}
 }
 
 static void test_le_generate_dhkey(const void *test_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	struct bt_hci_cmd_le_generate_dhkey cmd;
 	struct le_keys *keys = (void *)test_data;
 
@@ -623,8 +618,8 @@ static void test_le_generate_dhkey(const void *test_data)
 	if (!bt_hci_send(user->hci_ut, BT_HCI_CMD_LE_GENERATE_DHKEY, &cmd,
 				sizeof(cmd), test_le_generate_dhkey_status,
 				NULL, NULL)) {
-		tester_warn("Failed to send HCI LE Encrypt command");
-		tester_test_failed();
+		bttester_warn("Failed to send HCI LE Encrypt command");
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -636,13 +631,13 @@ static void test_inquiry_complete(const void *data, uint8_t size,
 	const struct bt_hci_evt_inquiry_complete *evt = data;
 
 	if (evt->status) {
-		tester_warn("HCI inquiry complete failed (0x%02x)",
+		bttester_warn("HCI inquiry complete failed (0x%02x)",
 							evt->status);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 }
 
 static void test_inquiry_status(const void *data, uint8_t size,
@@ -651,15 +646,15 @@ static void test_inquiry_status(const void *data, uint8_t size,
 	uint8_t status = *((uint8_t *) data);
 
 	if (status) {
-		tester_warn("HCI inquiry command failed (0x%02x)", status);
-		tester_test_failed();
+		bttester_warn("HCI inquiry command failed (0x%02x)", status);
+		l_tester_test_failed(tester);
 		return;
 	}
 }
 
 static void test_inquiry_liac(const void *test_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	struct bt_hci_cmd_inquiry cmd;
 
 	bt_hci_register(user->hci_ut, BT_HCI_EVT_INQUIRY_COMPLETE,
@@ -673,8 +668,8 @@ static void test_inquiry_liac(const void *test_data)
 
 	if (!bt_hci_send(user->hci_ut, BT_HCI_CMD_INQUIRY, &cmd, sizeof(cmd),
 					test_inquiry_status, NULL, NULL)) {
-		tester_warn("Failed to send HCI inquiry command");
-		tester_test_failed();
+		bttester_warn("Failed to send HCI inquiry command");
+		l_tester_test_failed(tester);
 		return;
 	}
 }
@@ -685,18 +680,18 @@ static void setup_lt_connectable_complete(const void *data, uint8_t size,
 	uint8_t status = *((uint8_t *) data);
 
 	if (status) {
-		tester_warn("Failed to set HCI scan enable (0x%02x)", status);
-		tester_setup_failed();
+		bttester_warn("Failed to set HCI scan enable (0x%02x)", status);
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_setup_complete();
+	l_tester_setup_complete(tester);
 }
 
 static void setup_lt_connect_request_accept(const void *data, uint8_t size,
 							void *user_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	const struct bt_hci_evt_conn_request *evt = data;
 	struct bt_hci_cmd_accept_conn_request cmd;
 
@@ -705,14 +700,14 @@ static void setup_lt_connect_request_accept(const void *data, uint8_t size,
 
 	if (!bt_hci_send(user->hci_lt, BT_HCI_CMD_ACCEPT_CONN_REQUEST,
 					&cmd, sizeof(cmd), NULL, NULL, NULL)) {
-		tester_warn("Failed to send HCI accept connection command");
+		bttester_warn("Failed to send HCI accept connection command");
 		return;
 	}
 }
 
 static void setup_lt_connectable(const void *test_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	struct bt_hci_cmd_write_scan_enable cmd;
 
 	bt_hci_register(user->hci_lt, BT_HCI_EVT_CONN_REQUEST,
@@ -723,33 +718,33 @@ static void setup_lt_connectable(const void *test_data)
 	if (!bt_hci_send(user->hci_lt, BT_HCI_CMD_WRITE_SCAN_ENABLE,
 				&cmd, sizeof(cmd),
 				setup_lt_connectable_complete, NULL, NULL)) {
-		tester_warn("Failed to send HCI scan enable command");
-		tester_setup_failed();
+		bttester_warn("Failed to send HCI scan enable command");
+		l_tester_setup_failed(tester);
 		return;
 	}
 }
 
 static void test_create_connection_disconnect(void *user_data)
 {
-	tester_test_passed();
+	l_tester_test_passed(tester);
 }
 
 static void test_create_connection_complete(const void *data, uint8_t size,
 							void *user_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	const struct bt_hci_evt_conn_complete *evt = data;
 
 	if (evt->status) {
-		tester_warn("HCI create connection complete failed (0x%02x)",
+		bttester_warn("HCI create connection complete failed (0x%02x)",
 								evt->status);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	user->handle_ut = le16_to_cpu(evt->handle);
 
-	tester_wait(2, test_create_connection_disconnect, NULL);
+	l_tester_wait(tester, 2, test_create_connection_disconnect, NULL);
 }
 
 static void test_create_connection_status(const void *data, uint8_t size,
@@ -758,16 +753,16 @@ static void test_create_connection_status(const void *data, uint8_t size,
 	uint8_t status = *((uint8_t *) data);
 
 	if (status) {
-		tester_warn("HCI create connection command failed (0x%02x)",
+		bttester_warn("HCI create connection command failed (0x%02x)",
 								status);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 }
 
 static void test_create_connection(const void *test_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	struct bt_hci_cmd_create_conn cmd;
 
 	bt_hci_register(user->hci_ut, BT_HCI_EVT_CONN_COMPLETE,
@@ -784,15 +779,15 @@ static void test_create_connection(const void *test_data)
 						&cmd, sizeof(cmd),
 						test_create_connection_status,
 								NULL, NULL)) {
-		tester_warn("Failed to send HCI create connection command");
-		tester_test_failed();
+		bttester_warn("Failed to send HCI create connection command");
+		l_tester_test_failed(tester);
 		return;
 	}
 }
 
 static void teardown_timeout(void *user_data)
 {
-	tester_teardown_complete();
+	l_tester_teardown_complete(tester);
 }
 
 static void teardown_disconnect_status(const void *data, uint8_t size,
@@ -801,17 +796,17 @@ static void teardown_disconnect_status(const void *data, uint8_t size,
 	uint8_t status = *((uint8_t *) data);
 
 	if (status) {
-		tester_warn("HCI disconnect failed (0x%02x)", status);
-		tester_teardown_failed();
+		bttester_warn("HCI disconnect failed (0x%02x)", status);
+		l_tester_teardown_failed(tester);
 		return;
 	}
 
-	tester_wait(1, teardown_timeout, NULL);
+	l_tester_wait(tester, 1, teardown_timeout, NULL);
 }
 
 static void teardown_connection(const void *test_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	struct bt_hci_cmd_disconnect cmd;
 
 	cmd.handle = cpu_to_le16(user->handle_ut);
@@ -821,29 +816,29 @@ static void teardown_connection(const void *test_data)
 						&cmd, sizeof(cmd),
 						teardown_disconnect_status,
 								NULL, NULL)) {
-		tester_warn("Failed to send HCI disconnect command");
-		tester_test_failed();
+		bttester_warn("Failed to send HCI disconnect command");
+		l_tester_test_failed(tester);
 		return;
 	}
 }
 
 static void test_adv_report(const void *data, uint8_t size, void *user_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	uint8_t subevent = *((uint8_t *) data);
 	const struct bt_hci_evt_le_adv_report *lar = data + 1;
 
 	switch (subevent) {
 	case BT_HCI_EVT_LE_ADV_REPORT:
 		if (!memcmp(lar->addr, user->bdaddr_ut, 6))
-			tester_setup_complete();
+			l_tester_setup_complete(tester);
 		break;
 	}
 }
 
 static void setup_advertising_initiated(const void *test_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	struct bt_hci_cmd_set_event_mask sem;
 	struct bt_hci_cmd_le_set_event_mask lsem;
 	struct bt_hci_cmd_le_set_scan_enable lsse;
@@ -893,7 +888,7 @@ static void setup_advertising_initiated(const void *test_data)
 
 static void test_reset_in_advertising_state_timeout(void *user_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 	struct bt_hci_cmd_le_set_adv_enable lsae;
 	struct bt_hci_cmd_le_set_scan_enable lsse;
 
@@ -908,21 +903,21 @@ static void test_reset_in_advertising_state_timeout(void *user_data)
 	bt_hci_send(user->hci_lt, BT_HCI_CMD_LE_SET_SCAN_ENABLE,
 					&lsse, sizeof(lsse), NULL, NULL, NULL);
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 }
 
 static void test_reset_in_advertising_state(const void *test_data)
 {
-	struct user_data *user = tester_get_data();
+	struct user_data *user = l_tester_get_data(tester);
 
 	bt_hci_send(user->hci_ut, BT_HCI_CMD_RESET, NULL, 0, NULL, NULL, NULL);
 
-	tester_wait(5, test_reset_in_advertising_state_timeout, NULL);
+	l_tester_wait(tester, 5, test_reset_in_advertising_state_timeout, NULL);
 }
 
 int main(int argc, char *argv[])
 {
-	tester_init(&argc, &argv);
+	tester = bttester_init(&argc, &argv);
 
 	test_hci_local("Reset", NULL, NULL, test_reset);
 
@@ -969,5 +964,5 @@ int main(int argc, char *argv[])
 				setup_advertising_initiated,
 				test_reset_in_advertising_state, NULL);
 
-	return tester_run();
+	return bttester_run();
 }

--- a/tools/l2cap-tester.c
+++ b/tools/l2cap-tester.c
@@ -4,6 +4,7 @@
  *  BlueZ - Bluetooth protocol stack for Linux
  *
  *  Copyright (C) 2013  Intel Corporation. All rights reserved.
+
  *
  *
  */
@@ -17,7 +18,7 @@
 #include <errno.h>
 #include <stdbool.h>
 
-#include <glib.h>
+#include <ell/ell.h>
 
 #include "lib/bluetooth.h"
 #include "lib/l2cap.h"
@@ -27,7 +28,7 @@
 #include "emulator/bthost.h"
 #include "emulator/hciemu.h"
 
-#include "src/shared/tester.h"
+#include "src/shared/bttester.h"
 #include "src/shared/mgmt.h"
 
 struct test_data {
@@ -35,8 +36,9 @@ struct test_data {
 	struct mgmt *mgmt;
 	uint16_t mgmt_index;
 	struct hciemu *hciemu;
+	struct l_io *io;
+	struct l_io *io2;
 	enum hciemu_type hciemu_type;
-	unsigned int io_id;
 	uint16_t handle;
 	uint16_t scid;
 	uint16_t dcid;
@@ -85,27 +87,29 @@ struct l2cap_data {
 	bool shut_sock_wr;
 };
 
+static struct l_tester *tester;
+
 static void print_debug(const char *str, void *user_data)
 {
 	const char *prefix = user_data;
 
-	tester_print("%s%s", prefix, str);
+	bttester_print("%s%s", prefix, str);
 }
 
 static void read_info_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct mgmt_rp_read_info *rp = param;
 	char addr[18];
 	uint16_t manufacturer;
 	uint32_t supported_settings, current_settings;
 
-	tester_print("Read Info callback");
-	tester_print("  Status: 0x%02x", status);
+	bttester_print("Read Info callback");
+	bttester_print("  Status: 0x%02x", status);
 
 	if (status || !param) {
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
@@ -114,31 +118,31 @@ static void read_info_callback(uint8_t status, uint16_t length,
 	supported_settings = btohl(rp->supported_settings);
 	current_settings = btohl(rp->current_settings);
 
-	tester_print("  Address: %s", addr);
-	tester_print("  Version: 0x%02x", rp->version);
-	tester_print("  Manufacturer: 0x%04x", manufacturer);
-	tester_print("  Supported settings: 0x%08x", supported_settings);
-	tester_print("  Current settings: 0x%08x", current_settings);
-	tester_print("  Class: 0x%02x%02x%02x",
+	bttester_print("  Address: %s", addr);
+	bttester_print("  Version: 0x%02x", rp->version);
+	bttester_print("  Manufacturer: 0x%04x", manufacturer);
+	bttester_print("  Supported settings: 0x%08x", supported_settings);
+	bttester_print("  Current settings: 0x%08x", current_settings);
+	bttester_print("  Class: 0x%02x%02x%02x",
 			rp->dev_class[2], rp->dev_class[1], rp->dev_class[0]);
-	tester_print("  Name: %s", rp->name);
-	tester_print("  Short name: %s", rp->short_name);
+	bttester_print("  Name: %s", rp->name);
+	bttester_print("  Short name: %s", rp->short_name);
 
 	if (strcmp(hciemu_get_address(data->hciemu), addr)) {
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
-	tester_pre_setup_complete();
+	l_tester_pre_setup_complete(tester);
 }
 
 static void index_added_callback(uint16_t index, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Index Added callback");
-	tester_print("  Index: 0x%04x", index);
+	bttester_print("Index Added callback");
+	bttester_print("  Index: 0x%04x", index);
 
 	data->mgmt_index = index;
 
@@ -149,10 +153,10 @@ static void index_added_callback(uint16_t index, uint16_t length,
 static void index_removed_callback(uint16_t index, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Index Removed callback");
-	tester_print("  Index: 0x%04x", index);
+	bttester_print("Index Removed callback");
+	bttester_print("  Index: 0x%04x", index);
 
 	if (index != data->mgmt_index)
 		return;
@@ -162,19 +166,19 @@ static void index_removed_callback(uint16_t index, uint16_t length,
 	mgmt_unref(data->mgmt);
 	data->mgmt = NULL;
 
-	tester_post_teardown_complete();
+	l_tester_post_teardown_complete(tester);
 }
 
 static void read_index_list_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Read Index List callback");
-	tester_print("  Status: 0x%02x", status);
+	bttester_print("Read Index List callback");
+	bttester_print("  Status: 0x%02x", status);
 
 	if (status || !param) {
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
@@ -186,28 +190,28 @@ static void read_index_list_callback(uint8_t status, uint16_t length,
 
 	data->hciemu = hciemu_new(data->hciemu_type);
 	if (!data->hciemu) {
-		tester_warn("Failed to setup HCI emulation");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to setup HCI emulation");
+		l_tester_pre_setup_failed(tester);
 	}
 
-	if (tester_use_debug())
+	if (bttester_use_debug())
 		hciemu_set_debug(data->hciemu, print_debug, "hciemu: ", NULL);
 
-	tester_print("New hciemu instance created");
+	bttester_print("New hciemu instance created");
 }
 
 static void test_pre_setup(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
 	data->mgmt = mgmt_new_default();
 	if (!data->mgmt) {
-		tester_warn("Failed to setup management interface");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to setup management interface");
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
-	if (tester_use_debug())
+	if (bttester_use_debug())
 		mgmt_set_debug(data->mgmt, print_debug, "mgmt: ", NULL);
 
 	mgmt_send(data->mgmt, MGMT_OP_READ_INDEX_LIST, MGMT_INDEX_NONE, 0, NULL,
@@ -216,50 +220,46 @@ static void test_pre_setup(const void *test_data)
 
 static void test_post_teardown(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	if (data->io_id > 0) {
-		g_source_remove(data->io_id);
-		data->io_id = 0;
+	if (data->io) {
+		l_io_destroy(data->io);
+		data->io = NULL;
+	}
+
+	if (data->io2) {
+		l_io_destroy(data->io2);
+		data->io2 = NULL;
 	}
 
 	hciemu_unref(data->hciemu);
 	data->hciemu = NULL;
 }
 
-static void test_data_free(void *test_data)
-{
-	struct test_data *data = test_data;
-
-	free(data);
-}
-
 #define test_l2cap_bredr(name, data, setup, func) \
 	do { \
 		struct test_data *user; \
-		user = malloc(sizeof(struct test_data)); \
+		user = l_new(struct test_data, 1);	\
 		if (!user) \
 			break; \
 		user->hciemu_type = HCIEMU_TYPE_BREDR; \
-		user->io_id = 0; \
 		user->test_data = data; \
-		tester_add_full(name, data, \
+		l_tester_add_full(tester, name, data, \
 				test_pre_setup, setup, func, NULL, \
-				test_post_teardown, 2, user, test_data_free); \
+				test_post_teardown, 2, user, l_free); \
 	} while (0)
 
 #define test_l2cap_le(name, data, setup, func) \
 	do { \
 		struct test_data *user; \
-		user = malloc(sizeof(struct test_data)); \
+		user = l_new(struct test_data, 1);	\
 		if (!user) \
 			break; \
 		user->hciemu_type = HCIEMU_TYPE_LE; \
-		user->io_id = 0; \
 		user->test_data = data; \
-		tester_add_full(name, data, \
+		l_tester_add_full(tester, name, data,		   \
 				test_pre_setup, setup, func, NULL, \
-				test_post_teardown, 2, user, test_data_free); \
+				test_post_teardown, 2, user, l_free); \
 	} while (0)
 
 static uint8_t pair_device_pin[] = { 0x30, 0x30, 0x30, 0x30 }; /* "0000" */
@@ -596,7 +596,7 @@ static void client_cmd_complete(uint16_t opcode, uint8_t status,
 					const void *param, uint8_t len,
 					void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *test = data->test_data;
 	struct bthost *bthost;
 
@@ -605,14 +605,14 @@ static void client_cmd_complete(uint16_t opcode, uint8_t status,
 	switch (opcode) {
 	case BT_HCI_CMD_WRITE_SCAN_ENABLE:
 	case BT_HCI_CMD_LE_SET_ADV_ENABLE:
-		tester_print("Client set connectable status 0x%02x", status);
+		bttester_print("Client set connectable status 0x%02x", status);
 		if (!status && test && test->enable_ssp) {
 			bthost_write_ssp_mode(bthost, 0x01);
 			return;
 		}
 		break;
 	case BT_HCI_CMD_WRITE_SIMPLE_PAIRING_MODE:
-		tester_print("Client enable SSP status 0x%02x", status);
+		bttester_print("Client enable SSP status 0x%02x", status);
 		break;
 	default:
 		return;
@@ -620,9 +620,9 @@ static void client_cmd_complete(uint16_t opcode, uint8_t status,
 
 
 	if (status)
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 	else
-		tester_setup_complete();
+		l_tester_setup_complete(tester);
 }
 
 static void server_cmd_complete(uint16_t opcode, uint8_t status,
@@ -631,31 +631,31 @@ static void server_cmd_complete(uint16_t opcode, uint8_t status,
 {
 	switch (opcode) {
 	case BT_HCI_CMD_WRITE_SIMPLE_PAIRING_MODE:
-		tester_print("Server enable SSP status 0x%02x", status);
+		bttester_print("Server enable SSP status 0x%02x", status);
 		break;
 	default:
 		return;
 	}
 
 	if (status)
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 	else
-		tester_setup_complete();
+		l_tester_setup_complete(tester);
 }
 
 static void setup_powered_client_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
 	struct bthost *bthost;
 
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_print("Controller powered on");
+	bttester_print("Controller powered on");
 
 	bthost = hciemu_client_get_host(data->hciemu);
 	bthost_set_cmd_complete_cb(bthost, client_cmd_complete, user_data);
@@ -664,7 +664,7 @@ static void setup_powered_client_callback(uint8_t status, uint16_t length,
 		if (!l2data || !l2data->server_not_advertising)
 			bthost_set_adv_enable(bthost, 0x01);
 		else
-			tester_setup_complete();
+			l_tester_setup_complete(tester);
 	} else {
 		bthost_write_scan_enable(bthost, 0x03);
 	}
@@ -673,19 +673,19 @@ static void setup_powered_client_callback(uint8_t status, uint16_t length,
 static void setup_powered_server_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *test = data->test_data;
 	struct bthost *bthost;
 
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_print("Controller powered on");
+	bttester_print("Controller powered on");
 
 	if (!test->enable_ssp) {
-		tester_setup_complete();
+		l_tester_setup_complete(tester);
 		return;
 	}
 
@@ -699,7 +699,7 @@ static void user_confirm_request_callback(uint16_t index, uint16_t length,
 							void *user_data)
 {
 	const struct mgmt_ev_user_confirm_request *ev = param;
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *test = data->test_data;
 	struct mgmt_cp_user_confirm_reply cp;
 	uint16_t opcode;
@@ -743,18 +743,18 @@ static void pin_code_request_callback(uint16_t index, uint16_t length,
 
 static void bthost_send_rsp(const void *buf, uint16_t len, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
 	struct bthost *bthost;
 
 	if (l2data->expect_cmd_len && len != l2data->expect_cmd_len) {
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	if (l2data->expect_cmd && memcmp(buf, l2data->expect_cmd,
 						l2data->expect_cmd_len)) {
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -771,7 +771,7 @@ static void send_rsp_new_conn(uint16_t handle, void *user_data)
 	struct test_data *data = user_data;
 	struct bthost *bthost;
 
-	tester_print("New connection with handle 0x%04x", handle);
+	bttester_print("New connection with handle 0x%04x", handle);
 
 	data->handle = handle;
 
@@ -787,7 +787,7 @@ static void send_rsp_new_conn(uint16_t handle, void *user_data)
 
 static void setup_powered_common(void)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *test = data->test_data;
 	struct bthost *bthost = hciemu_client_get_host(data->hciemu);
 	unsigned char param[] = { 0x01 };
@@ -824,13 +824,13 @@ static void setup_powered_common(void)
 
 static void setup_powered_client(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *test = data->test_data;
 	unsigned char param[] = { 0x01 };
 
 	setup_powered_common();
 
-	tester_print("Powering on controller");
+	bttester_print("Powering on controller");
 
 	if (test && (test->expect_cmd || test->send_cmd)) {
 		struct bthost *bthost = hciemu_client_get_host(data->hciemu);
@@ -849,12 +849,12 @@ static void setup_powered_client(const void *test_data)
 
 static void setup_powered_server(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char param[] = { 0x01 };
 
 	setup_powered_common();
 
-	tester_print("Powering on controller");
+	bttester_print("Powering on controller");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_CONNECTABLE, data->mgmt_index,
 				sizeof(param), param, NULL, NULL, NULL);
@@ -875,116 +875,97 @@ static void test_basic(const void *test_data)
 
 	sk = socket(PF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP);
 	if (sk < 0) {
-		tester_warn("Can't create socket: %s (%d)", strerror(errno),
+		bttester_warn("Can't create socket: %s (%d)", strerror(errno),
 									errno);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	close(sk);
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 }
 
-static gboolean client_received_data(GIOChannel *io, GIOCondition cond,
-							gpointer user_data)
+static bool client_received_data(struct l_io *io, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
 	char buf[1024];
 	int sk;
 
-	sk = g_io_channel_unix_get_fd(io);
+	sk = l_io_get_fd(io);
 	if (read(sk, buf, l2data->data_len) != l2data->data_len) {
-		tester_warn("Unable to read %u bytes", l2data->data_len);
-		tester_test_failed();
-		return FALSE;
+		bttester_warn("Unable to read %u bytes", l2data->data_len);
+		l_tester_test_failed(tester);
+		return false;
 	}
 
 	if (memcmp(buf, l2data->read_data, l2data->data_len))
-		tester_test_failed();
+		l_tester_test_failed(tester);
 	else
-		tester_test_passed();
+		l_tester_test_passed(tester);
 
-	return FALSE;
+	return true;
 }
 
-static gboolean server_received_data(GIOChannel *io, GIOCondition cond,
-							gpointer user_data)
+static bool server_received_data(struct l_io *io, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
 	char buf[1024];
 	int sk;
 
-	sk = g_io_channel_unix_get_fd(io);
+	sk = l_io_get_fd(io);
 	if (read(sk, buf, l2data->data_len) != l2data->data_len) {
-		tester_warn("Unable to read %u bytes", l2data->data_len);
-		tester_test_failed();
-		return FALSE;
+		bttester_warn("Unable to read %u bytes", l2data->data_len);
+		l_tester_test_failed(tester);
+
+		l_io_destroy(io);
+		return false;
 	}
 
 	if (memcmp(buf, l2data->read_data, l2data->data_len))
-		tester_test_failed();
+		l_tester_test_failed(tester);
 	else
-		tester_test_passed();
+		l_tester_test_passed(tester);
 
-	return FALSE;
+	l_io_destroy(io);
+
+	return true;
 }
 
 static void bthost_received_data(const void *buf, uint16_t len,
 							void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
 
 	if (len != l2data->data_len) {
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	if (memcmp(buf, l2data->write_data, l2data->data_len))
-		tester_test_failed();
+		l_tester_test_failed(tester);
 	else
-		tester_test_passed();
+		l_tester_test_passed(tester);
 }
 
 static void server_bthost_received_data(const void *buf, uint16_t len,
 							void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
 
 	if (len != l2data->data_len) {
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	if (memcmp(buf, l2data->write_data, l2data->data_len))
-		tester_test_failed();
+		l_tester_test_failed(tester);
 	else
-		tester_test_passed();
-}
-
-static gboolean socket_closed_cb(GIOChannel *io, GIOCondition cond,
-							gpointer user_data)
-{
-	struct test_data *data = tester_get_data();
-	const struct l2cap_data *l2data = data->test_data;
-
-	if (l2data->shut_sock_wr) {
-		/* if socket is closed using SHUT_WR, L2CAP disconnection
-		 * response must be received first before G_IO_HUP event.
-		 */
-		if (data->host_disconnected)
-			tester_test_passed();
-		else {
-			tester_warn("G_IO_HUP received before receiving L2CAP disconnection");
-			tester_test_failed();
-		}
-	}
-
-	return FALSE;
+		l_tester_test_passed(tester);
 }
 
 static bool check_mtu(struct test_data *data, int sk)
@@ -1003,16 +984,16 @@ static bool check_mtu(struct test_data *data, int sk)
 		len = sizeof(l2o.imtu);
 		if (getsockopt(sk, SOL_BLUETOOTH, BT_RCVMTU,
 							&l2o.imtu, &len) < 0) {
-			tester_warn("getsockopt(BT_RCVMTU): %s (%d)",
-					strerror(errno), errno);
+			bttester_warn("getsockopt(BT_RCVMTU): %s (%d)",
+							strerror(errno), errno);
 			return false;
 		}
 
 		len = sizeof(l2o.omtu);
 		if (getsockopt(sk, SOL_BLUETOOTH, BT_SNDMTU,
 							&l2o.omtu, &len) < 0) {
-			tester_warn("getsockopt(BT_SNDMTU): %s (%d)",
-					strerror(errno), errno);
+			bttester_warn("getsockopt(BT_SNDMTU): %s (%d)",
+							strerror(errno), errno);
 			return false;
 		}
 	} else {
@@ -1020,26 +1001,61 @@ static bool check_mtu(struct test_data *data, int sk)
 		 * L2CAP_OPTIONS, so test support for it as well */
 		len = sizeof(l2o);
 		if (getsockopt(sk, SOL_L2CAP, L2CAP_OPTIONS, &l2o, &len) < 0) {
-			 tester_warn("getsockopt(L2CAP_OPTIONS): %s (%d)",
-						strerror(errno), errno);
-			 return false;
+			bttester_warn("getsockopt(L2CAP_OPTIONS): %s (%d)",
+							strerror(errno), errno);
+			return false;
 		 }
 	}
 
 	return true;
 }
 
-static gboolean l2cap_connect_cb(GIOChannel *io, GIOCondition cond,
-							gpointer user_data)
+static void l2cap_disconnect_cb(struct l_io *io, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
 	int err, sk_err, sk;
 	socklen_t len = sizeof(sk_err);
 
-	data->io_id = 0;
+	bttester_print("Disconnect callback");
+	if (l2data->shut_sock_wr) {
+		/* if socket is closed using SHUT_WR, L2CAP disconnection
+		 * response must be received first before EPOLLHUP event.
+		 */
+		if (data->host_disconnected)
+			l_tester_test_passed(tester);
+		else {
+			bttester_warn("HUP received before L2CAP disconnect");
+			l_tester_test_failed(tester);
+		}
 
-	sk = g_io_channel_unix_get_fd(io);
+		return;
+	}
+
+	sk = l_io_get_fd(io);
+
+	if (getsockopt(sk, SOL_SOCKET, SO_ERROR, &sk_err, &len) < 0)
+		err = -errno;
+	else
+		err = -sk_err;
+
+	if (l2data->expect_err) {
+
+		if (-err == l2data->expect_err)
+			l_tester_test_passed(tester);
+		else
+			l_tester_test_failed(tester);
+	}
+}
+
+static bool l2cap_connect_cb(struct l_io *io, void *user_data)
+{
+	struct test_data *data = l_tester_get_data(tester);
+	const struct l2cap_data *l2data = data->test_data;
+	int err, sk_err, sk;
+	socklen_t len = sizeof(sk_err);
+
+	sk = l_io_get_fd(io);
 
 	if (getsockopt(sk, SOL_SOCKET, SO_ERROR, &sk_err, &len) < 0)
 		err = -errno;
@@ -1047,27 +1063,27 @@ static gboolean l2cap_connect_cb(GIOChannel *io, GIOCondition cond,
 		err = -sk_err;
 
 	if (err < 0) {
-		tester_warn("Connect failed: %s (%d)", strerror(-err), -err);
+		bttester_warn("Connect failed: %s (%d)", strerror(-err), -err);
 		goto failed;
 	}
 
-	tester_print("Successfully connected");
+	bttester_print("Successfully connected");
 
 	if (!check_mtu(data, sk)) {
-		tester_test_failed();
-		return FALSE;
+		l_tester_test_failed(tester);
+		return false;
 	}
 
 	if (l2data->read_data) {
 		struct bthost *bthost;
 
 		bthost = hciemu_client_get_host(data->hciemu);
-		g_io_add_watch(io, G_IO_IN, client_received_data, NULL);
+		l_io_set_read_handler(io, client_received_data, NULL, NULL);
 
 		bthost_send_cid(bthost, data->handle, data->dcid,
 					l2data->read_data, l2data->data_len);
 
-		return FALSE;
+		return false;
 	} else if (l2data->write_data) {
 		struct bthost *bthost;
 		ssize_t ret;
@@ -1078,25 +1094,24 @@ static gboolean l2cap_connect_cb(GIOChannel *io, GIOCondition cond,
 
 		ret = write(sk, l2data->write_data, l2data->data_len);
 		if (ret != l2data->data_len) {
-			tester_warn("Unable to write all data");
-			tester_test_failed();
+			bttester_warn("Unable to write all data");
+			l_tester_test_failed(tester);
 		}
 
-		return FALSE;
+		return false;
 	} else if (l2data->shut_sock_wr) {
-		g_io_add_watch(io, G_IO_HUP, socket_closed_cb, NULL);
 		shutdown(sk, SHUT_WR);
 
-		return FALSE;
+		return false;
 	}
 
 failed:
 	if (-err != l2data->expect_err)
-		tester_test_failed();
+		l_tester_test_failed(tester);
 	else
-		tester_test_passed();
+		l_tester_test_passed(tester);
 
-	return FALSE;
+	return false;
 }
 
 static int create_l2cap_sock(struct test_data *data, uint16_t psm,
@@ -1111,14 +1126,14 @@ static int create_l2cap_sock(struct test_data *data, uint16_t psm,
 							BTPROTO_L2CAP);
 	if (sk < 0) {
 		err = -errno;
-		tester_warn("Can't create socket: %s (%d)", strerror(errno),
+		bttester_warn("Can't create socket: %s (%d)", strerror(errno),
 									errno);
 		return err;
 	}
 
 	master_bdaddr = hciemu_get_master_bdaddr(data->hciemu);
 	if (!master_bdaddr) {
-		tester_warn("No master bdaddr");
+		bttester_warn("No master bdaddr");
 		close(sk);
 		return -ENODEV;
 	}
@@ -1138,7 +1153,7 @@ static int create_l2cap_sock(struct test_data *data, uint16_t psm,
 
 	if (bind(sk, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
 		err = -errno;
-		tester_warn("Can't bind socket: %s (%d)", strerror(errno),
+		bttester_warn("Can't bind socket: %s (%d)", strerror(errno),
 									errno);
 		close(sk);
 		return err;
@@ -1153,8 +1168,8 @@ static int create_l2cap_sock(struct test_data *data, uint16_t psm,
 		if (setsockopt(sk, SOL_BLUETOOTH, BT_SECURITY, &sec,
 							sizeof(sec)) < 0) {
 			err = -errno;
-			tester_warn("Can't set security level: %s (%d)",
-						strerror(errno), errno);
+			bttester_warn("Can't set security level: %s (%d)",
+							strerror(errno), errno);
 			close(sk);
 			return err;
 		}
@@ -1164,8 +1179,8 @@ static int create_l2cap_sock(struct test_data *data, uint16_t psm,
 		if (setsockopt(sk, SOL_BLUETOOTH, BT_MODE, &mode,
 							sizeof(mode)) < 0) {
 			err = -errno;
-			tester_warn("Can't set mode: %s (%d)", strerror(errno),
-									errno);
+			bttester_warn("Can't set mode: %s (%d)",
+							strerror(errno), errno);
 			close(sk);
 			return err;
 		}
@@ -1181,7 +1196,7 @@ static int connect_l2cap_impl(int sk, const uint8_t *bdaddr,
 	int err;
 
 	if (!bdaddr) {
-		tester_warn("No client bdaddr");
+		bttester_warn("No client bdaddr");
 		return -ENODEV;
 	}
 
@@ -1195,7 +1210,7 @@ static int connect_l2cap_impl(int sk, const uint8_t *bdaddr,
 	err = connect(sk, (struct sockaddr *) &addr, sizeof(addr));
 	if (err < 0 && !(errno == EAGAIN || errno == EINPROGRESS)) {
 		err = -errno;
-		tester_warn("Can't connect socket: %s (%d)", strerror(errno),
+		bttester_warn("Can't connect socket: %s (%d)", strerror(errno),
 									errno);
 		return err;
 	}
@@ -1216,7 +1231,7 @@ static int connect_l2cap_sock(struct test_data *data, int sk, uint16_t psm,
 		client_bdaddr = hciemu_get_client_bdaddr(data->hciemu);
 
 	if (!client_bdaddr) {
-		tester_warn("No client bdaddr");
+		bttester_warn("No client bdaddr");
 		return -ENODEV;
 	}
 
@@ -1249,39 +1264,38 @@ static void client_l2cap_disconnect_cb(void *user_data)
 static void direct_adv_cmd_complete(uint16_t opcode, const void *param,
 						uint8_t len, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct bt_hci_cmd_le_set_adv_parameters *cp;
 	const uint8_t *expect_bdaddr;
 
 	if (opcode != BT_HCI_CMD_LE_SET_ADV_PARAMETERS)
 		return;
 
-	tester_print("Received advertising parameters HCI command");
+	bttester_print("Received advertising parameters HCI command");
 
 	cp = param;
 
 	/* Advertising as client should be direct advertising */
 	if (cp->type != 0x01) {
-		tester_warn("Invalid advertising type");
-		tester_test_failed();
+		bttester_warn("Invalid advertising type");
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	expect_bdaddr = hciemu_get_client_bdaddr(data->hciemu);
 	if (memcmp(expect_bdaddr, cp->direct_addr, 6)) {
-		tester_warn("Invalid direct address in adv params");
-		tester_test_failed();
+		bttester_warn("Invalid direct address in adv params");
+		l_tester_test_failed(tester);
 		return;
 	}
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 }
 
 static void test_connect(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
-	GIOChannel *io;
 	int sk;
 
 	if (l2data->server_psm) {
@@ -1308,68 +1322,68 @@ static void test_connect(const void *test_data)
 							l2data->mode);
 	if (sk < 0) {
 		if (sk == -ENOPROTOOPT)
-			tester_test_abort();
+			l_tester_test_abort(tester);
 		else
-			tester_test_failed();
+			l_tester_test_failed(tester);
 		return;
 	}
 
 	if (connect_l2cap_sock(data, sk, l2data->client_psm,
 							l2data->cid) < 0) {
 		close(sk);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
-	io = g_io_channel_unix_new(sk);
-	g_io_channel_set_close_on_unref(io, TRUE);
+	data->io = l_io_new(sk);
 
-	data->io_id = g_io_add_watch(io, G_IO_OUT, l2cap_connect_cb, NULL);
+	l_io_set_close_on_destroy(data->io, true);
 
-	g_io_channel_unref(io);
+	l_io_set_disconnect_handler(data->io, l2cap_disconnect_cb, NULL, NULL);
+	l_io_set_write_handler(data->io, l2cap_connect_cb, NULL, NULL);
 
-	tester_print("Connect in progress");
+	bttester_print("Connect in progress");
 }
 
 static void test_connect_reject(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
 	int sk;
 
 	sk = create_l2cap_sock(data, 0, l2data->cid, l2data->sec_level,
 							l2data->mode);
 	if (sk < 0) {
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	if (connect_l2cap_sock(data, sk, l2data->client_psm,
 							l2data->cid) < 0)
-		tester_test_passed();
+		l_tester_test_passed(tester);
 	else
-		tester_test_failed();
+		l_tester_test_failed(tester);
 
 	close(sk);
 }
 
-static int connect_socket(const uint8_t *client_bdaddr, GIOFunc connect_cb,
-								bool defer)
+static struct l_io *connect_socket(const uint8_t *client_bdaddr,
+					l_io_write_cb_t connect_cb, bool defer)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
-	GIOChannel *io;
+	struct l_io *io;
 	int sk;
 
 	sk = create_l2cap_sock(data, 0, l2data->cid, l2data->sec_level,
 							l2data->mode);
 	if (sk < 0) {
-		tester_print("Error in create_l2cap_sock");
+		bttester_print("Error in create_l2cap_sock");
 		if (sk == -ENOPROTOOPT)
-			tester_test_abort();
+			l_tester_test_abort(tester);
 		else
-			tester_test_failed();
-		return -1;
+			l_tester_test_failed(tester);
+		return NULL;
 	}
 
 	if (defer) {
@@ -1377,112 +1391,104 @@ static int connect_socket(const uint8_t *client_bdaddr, GIOFunc connect_cb,
 
 		if (setsockopt(sk, SOL_BLUETOOTH, BT_DEFER_SETUP, &opt,
 							sizeof(opt)) < 0) {
-			tester_print("Can't enable deferred setup: %s (%d)",
+			bttester_print("Can't enable deferred setup: %s (%d)",
 						strerror(errno), errno);
-			tester_test_failed();
-			return -1;
+			l_tester_test_failed(tester);
+			return NULL;
 		}
 	}
 
 	if (connect_l2cap_impl(sk, client_bdaddr, BDADDR_LE_PUBLIC,
 			l2data->client_psm, l2data->cid) < 0) {
-		tester_print("Error in connect_l2cap_sock");
+		bttester_print("Error in connect_l2cap_sock");
 		close(sk);
-		tester_test_failed();
-		return -1;
+		l_tester_test_failed(tester);
+		return NULL;
 	}
 
-	if (connect_cb) {
-		io = g_io_channel_unix_new(sk);
-		g_io_channel_set_close_on_unref(io, TRUE);
+	io = l_io_new(sk);
+	l_io_set_close_on_destroy(io, true);
+	l_io_set_write_handler(io, connect_cb, NULL, NULL);
 
-		data->io_id = g_io_add_watch(io, G_IO_OUT, connect_cb, NULL);
+	bttester_print("Connect in progress, sk = %d %s", sk,
+						defer ? "(deferred)" : "");
 
-		g_io_channel_unref(io);
-	}
-
-	tester_print("Connect in progress, sk = %d %s", sk,
-				defer ? "(deferred)" : "");
-
-	return sk;
+	return io;
 }
 
-static gboolean test_close_socket_1_part_3(gpointer arg)
+static void test_close_socket_1_part_3(void *arg)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Checking whether scan was properly stopped...");
+	bttester_print("Checking whether scan was properly stopped...");
 
 	if (data->sk != -1) {
-		tester_print("Error - scan was not enabled yet");
-		tester_test_failed();
-		return FALSE;
+		bttester_print("Error - scan was not enabled yet");
+		l_tester_test_failed(tester);
+		return;
 	}
 
 	if (hciemu_get_master_le_scan_enable(data->hciemu)) {
-		tester_print("Delayed check whether scann is off failed");
-		tester_test_failed();
-		return FALSE;
+		bttester_print("Delayed check whether scann is off failed");
+		l_tester_test_failed(tester);
+		return;
 	}
 
-	tester_test_passed();
-	return FALSE;
+	l_tester_test_passed(tester);
 }
 
-static gboolean test_close_socket_1_part_2(gpointer args)
+static void test_close_socket_1_part_2(void *args)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	int sk = data->sk;
 
-	tester_print("Will close socket during scan phase...");
+	bttester_print("Will close socket during scan phase...");
 
 	/* We tried to conect to LE device that is not advertising. It
 	 * was added to kernel whitelist, and scan was started. We
 	 * should be still scanning.
 	 */
 	if (!hciemu_get_master_le_scan_enable(data->hciemu)) {
-		tester_print("Error - should be still scanning");
-		tester_test_failed();
-		return FALSE;
+		bttester_print("Error - should be still scanning");
+		l_tester_test_failed(tester);
+		return;
 	}
 
 	/* Calling close() should remove device from  whitelist, and stop
 	 * the scan.
 	 */
 	if (close(sk) < 0) {
-		tester_print("Error when closing socket");
-		tester_test_failed();
-		return FALSE;
+		bttester_print("Error when closing socket");
+		l_tester_test_failed(tester);
+		return;
 	}
 
 	data->sk = -1;
 	/* tester_test_passed will be called when scan is stopped. */
-	return FALSE;
 }
 
-static gboolean test_close_socket_2_part_3(gpointer arg)
+static void test_close_socket_2_part_3(void *arg)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	int sk = data->sk;
 	int err;
 
 	/* Scan should be already over, we're trying to create connection */
 	if (hciemu_get_master_le_scan_enable(data->hciemu)) {
-		tester_print("Error - should no longer scan");
-		tester_test_failed();
-		return FALSE;
+		bttester_print("Error - should no longer scan");
+		l_tester_test_failed(tester);
+		return;
 	}
 
 	/* Calling close() should eventually cause CMD_LE_CREATE_CONN_CANCEL */
 	err = close(sk);
 	if (err < 0) {
-		tester_print("Error when closing socket");
-		tester_test_failed();
-		return FALSE;
+		bttester_print("Error when closing socket");
+		l_tester_test_failed(tester);
+		return;
 	}
 
 	/* CMD_LE_CREATE_CONN_CANCEL will trigger test pass. */
-	return FALSE;
 }
 
 static bool test_close_socket_cc_hook(const void *data, uint16_t len,
@@ -1491,9 +1497,9 @@ static bool test_close_socket_cc_hook(const void *data, uint16_t len,
 	return false;
 }
 
-static gboolean test_close_socket_2_part_2(gpointer arg)
+static void test_close_socket_2_part_2(void *arg)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct bthost *bthost = hciemu_client_get_host(data->hciemu);
 
 	/* Make sure CMD_LE_CREATE_CONN will not immediately result in
@@ -1507,44 +1513,43 @@ static gboolean test_close_socket_2_part_2(gpointer arg)
 	 */
 	bthost_set_adv_enable(bthost, 0x01);
 	bthost_set_adv_enable(bthost, 0x00);
-	return FALSE;
 }
 
 static void test_close_socket_scan_enabled(void)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
 
 	if (l2data == &le_client_close_socket_test_1)
-		g_idle_add(test_close_socket_1_part_2, NULL);
+		l_idle_oneshot(test_close_socket_1_part_2, NULL, NULL);
 	else if (l2data == &le_client_close_socket_test_2)
-		g_idle_add(test_close_socket_2_part_2, NULL);
+		l_idle_oneshot(test_close_socket_2_part_2, NULL, NULL);
 }
 
 static void test_close_socket_scan_disabled(void)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
 
 	if (l2data == &le_client_close_socket_test_1)
-		g_idle_add(test_close_socket_1_part_3, NULL);
+		l_idle_oneshot(test_close_socket_1_part_3, NULL, NULL);
 	else if (l2data == &le_client_close_socket_test_2)
-		g_idle_add(test_close_socket_2_part_3, NULL);
+		l_idle_oneshot(test_close_socket_2_part_3, NULL, NULL);
 }
 
 static void test_close_socket_conn_cancel(void)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
 
 	if (l2data == &le_client_close_socket_test_2)
-		tester_test_passed();
+		l_tester_test_passed(tester);
 }
 
 static void test_close_socket_router(uint16_t opcode, const void *param,
 					uint8_t length, void *user_data)
 {
-	/* tester_print("HCI Command 0x%04x length %u", opcode, length); */
+	/* bttester_print("HCI Command 0x%04x length %u", opcode, length); */
 	if (opcode == BT_HCI_CMD_LE_SET_SCAN_ENABLE) {
 		const struct bt_hci_cmd_le_set_scan_enable *scan_params = param;
 
@@ -1559,7 +1564,7 @@ static void test_close_socket_router(uint16_t opcode, const void *param,
 
 static void test_close_socket(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
 	const uint8_t *client_bdaddr;
 
@@ -1571,21 +1576,19 @@ static void test_close_socket(const void *test_data)
 	else
 		client_bdaddr = hciemu_get_client_bdaddr(data->hciemu);
 
-	data->sk = connect_socket(client_bdaddr, NULL, false);
+	data->io = connect_socket(client_bdaddr, NULL, false);
+	data->sk = l_io_get_fd(data->io);
 }
 
 static uint8_t test_2_connect_cb_cnt;
-static gboolean test_2_connect_cb(GIOChannel *io, GIOCondition cond,
-							gpointer user_data)
+static bool test_2_connect_cb(struct l_io *io, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
 	int err, sk_err, sk;
 	socklen_t len = sizeof(sk_err);
 
-	data->io_id = 0;
-
-	sk = g_io_channel_unix_get_fd(io);
+	sk = l_io_get_fd(io);
 
 	if (getsockopt(sk, SOL_SOCKET, SO_ERROR, &sk_err, &len) < 0)
 		err = -errno;
@@ -1593,52 +1596,52 @@ static gboolean test_2_connect_cb(GIOChannel *io, GIOCondition cond,
 		err = -sk_err;
 
 	if (err < 0) {
-		tester_warn("Connect failed: %s (%d)", strerror(-err), -err);
-		tester_test_failed();
-		return FALSE;
+		bttester_warn("Connect failed: %s (%d)", strerror(-err), -err);
+		l_tester_test_failed(tester);
+		return false;
 	}
 
-	tester_print("Successfully connected");
+	bttester_print("Successfully connected");
 	test_2_connect_cb_cnt++;
 
 	if (test_2_connect_cb_cnt == 2) {
 		close(data->sk);
 		close(data->sk2);
-		tester_test_passed();
+		l_tester_test_passed(tester);
 	}
 
 	if (l2data->close_1 && test_2_connect_cb_cnt == 1) {
 		close(data->sk2);
-		tester_test_passed();
+		l_tester_test_passed(tester);
 	}
 
-	return FALSE;
+	return false;
 }
 
-static gboolean enable_advertising(gpointer args)
+static void enable_advertising(void *args)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct bthost *bthost = hciemu_client_get_host(data->hciemu);
 
 	bthost_set_adv_enable(bthost, 0x01);
-	return FALSE;
 }
 
 static void test_connect_2_part_2(void)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
 	const uint8_t *client_bdaddr;
 
 	client_bdaddr = hciemu_get_client_bdaddr(data->hciemu);
-	data->sk2 = connect_socket(client_bdaddr, test_2_connect_cb, false);
+	data->io2 = connect_socket(client_bdaddr, test_2_connect_cb, false);
+	data->sk2 = l_io_get_fd(data->io2);
 
 	if (l2data->close_1) {
-		tester_print("Closing first socket! %d", data->sk);
+		bttester_print("Closing first socket! %d", data->sk);
 		close(data->sk);
 	}
 
-	g_idle_add(enable_advertising, NULL);
+	l_idle_oneshot(enable_advertising, NULL, NULL);
 }
 
 static uint8_t test_scan_enable_counter;
@@ -1647,20 +1650,20 @@ static void test_connect_2_router(uint16_t opcode, const void *param,
 {
 	const struct bt_hci_cmd_le_set_scan_enable *scan_params = param;
 
-	tester_print("HCI Command 0x%04x length %u", opcode, length);
+	bttester_print("HCI Command 0x%04x length %u", opcode, length);
 	if (opcode == BT_HCI_CMD_LE_SET_SCAN_ENABLE &&
 						scan_params->enable == true) {
 		test_scan_enable_counter++;
 		if (test_scan_enable_counter == 1)
 			test_connect_2_part_2();
 		else if (test_scan_enable_counter == 2)
-			g_idle_add(enable_advertising, NULL);
+			l_idle_oneshot(enable_advertising, NULL, NULL);
 	}
 }
 
 static void test_connect_2(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
 	const uint8_t *client_bdaddr;
 	bool defer;
@@ -1683,50 +1686,47 @@ static void test_connect_2(const void *test_data)
 
 	client_bdaddr = hciemu_get_client_bdaddr(data->hciemu);
 	if (l2data->close_1)
-		data->sk = connect_socket(client_bdaddr, NULL, defer);
+		data->io = connect_socket(client_bdaddr, NULL, defer);
 	else
-		data->sk = connect_socket(client_bdaddr, test_2_connect_cb,
+		data->io = connect_socket(client_bdaddr, test_2_connect_cb,
 								defer);
+
+	data->sk = l_io_get_fd(data->io);
 }
 
-static gboolean l2cap_listen_cb(GIOChannel *io, GIOCondition cond,
-							gpointer user_data)
+static bool l2cap_listen_cb(struct l_io *io, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
 	int sk, new_sk;
 
-	data->io_id = 0;
-
-	sk = g_io_channel_unix_get_fd(io);
+	sk = l_io_get_fd(io);
 
 	new_sk = accept(sk, NULL, NULL);
 	if (new_sk < 0) {
-		tester_warn("accept failed: %s (%u)", strerror(errno), errno);
-		tester_test_failed();
-		return FALSE;
+		bttester_warn("accept failed: %s (%u)", strerror(errno), errno);
+		l_tester_test_failed(tester);
+		return false;
 	}
 
 	if (!check_mtu(data, new_sk)) {
-		tester_test_failed();
-		return FALSE;
+		l_tester_test_failed(tester);
+		return false;
 	}
 
 	if (l2data->read_data) {
 		struct bthost *bthost;
-		GIOChannel *new_io;
+		struct l_io *new_io;
 
-		new_io = g_io_channel_unix_new(new_sk);
-		g_io_channel_set_close_on_unref(new_io, TRUE);
+		new_io = l_io_new(new_sk);
+		l_io_set_close_on_destroy(new_io, true);
 
 		bthost = hciemu_client_get_host(data->hciemu);
-		g_io_add_watch(new_io, G_IO_IN, server_received_data, NULL);
+		l_io_set_read_handler(new_io, server_received_data, NULL, NULL);
 		bthost_send_cid(bthost, data->handle, data->dcid,
 					l2data->read_data, l2data->data_len);
 
-		g_io_channel_unref(new_io);
-
-		return FALSE;
+		return false;
 	} else if (l2data->write_data) {
 		struct bthost *bthost;
 		ssize_t ret;
@@ -1739,20 +1739,20 @@ static gboolean l2cap_listen_cb(GIOChannel *io, GIOCondition cond,
 		close(new_sk);
 
 		if (ret != l2data->data_len) {
-			tester_warn("Unable to write all data");
-			tester_test_failed();
+			bttester_warn("Unable to write all data");
+			l_tester_test_failed(tester);
 		}
 
-		return FALSE;
+		return false;
 	}
 
-	tester_print("Successfully connected");
+	bttester_print("Successfully connected");
 
 	close(new_sk);
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 
-	return FALSE;
+	return false;
 }
 
 static void client_l2cap_rsp(uint8_t code, const void *data, uint16_t len,
@@ -1761,10 +1761,10 @@ static void client_l2cap_rsp(uint8_t code, const void *data, uint16_t len,
 	struct test_data *test_data = user_data;
 	const struct l2cap_data *l2data = test_data->test_data;
 
-	tester_print("Client received response code 0x%02x", code);
+	bttester_print("Client received response code 0x%02x", code);
 
 	if (code != l2data->expect_cmd_code) {
-		tester_warn("Unexpected L2CAP response code (expected 0x%02x)",
+		bttester_warn("Unexpected L2CAP response code (expect 0x%02x)",
 						l2data->expect_cmd_code);
 		return;
 	}
@@ -1783,26 +1783,26 @@ static void client_l2cap_rsp(uint8_t code, const void *data, uint16_t len,
 	}
 
 	if (!l2data->expect_cmd) {
-		tester_test_passed();
+		l_tester_test_passed(tester);
 		return;
 	}
 
 	if (l2data->expect_cmd_len != len) {
-		tester_warn("Unexpected L2CAP response length (%u != %u)",
+		bttester_warn("Unexpected L2CAP response length (%u != %u)",
 						len, l2data->expect_cmd_len);
 		goto failed;
 	}
 
 	if (memcmp(l2data->expect_cmd, data, len) != 0) {
-		tester_warn("Unexpected L2CAP response");
+		bttester_warn("Unexpected L2CAP response");
 		goto failed;
 	}
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 	return;
 
 failed:
-	tester_test_failed();
+	l_tester_test_failed(tester);
 }
 
 static void send_req_new_conn(uint16_t handle, void *user_data)
@@ -1811,7 +1811,7 @@ static void send_req_new_conn(uint16_t handle, void *user_data)
 	const struct l2cap_data *l2data = data->test_data;
 	struct bthost *bthost;
 
-	tester_print("New client connection with handle 0x%04x", handle);
+	bttester_print("New client connection with handle 0x%04x", handle);
 
 	data->handle = handle;
 
@@ -1823,7 +1823,7 @@ static void send_req_new_conn(uint16_t handle, void *user_data)
 		else
 			cb = NULL;
 
-		tester_print("Sending L2CAP Request from client");
+		bttester_print("Sending L2CAP Request from client");
 
 		bthost = hciemu_client_get_host(data->hciemu);
 		bthost_l2cap_req(bthost, handle, l2data->send_cmd_code,
@@ -1834,12 +1834,11 @@ static void send_req_new_conn(uint16_t handle, void *user_data)
 
 static void test_server(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct l2cap_data *l2data = data->test_data;
 	const uint8_t *master_bdaddr;
 	uint8_t addr_type;
 	struct bthost *bthost;
-	GIOChannel *io;
 	int sk;
 
 	if (l2data->server_psm || l2data->cid) {
@@ -1847,32 +1846,29 @@ static void test_server(const void *test_data)
 					l2data->cid, l2data->sec_level,
 					l2data->mode);
 		if (sk < 0) {
-			tester_test_failed();
+			l_tester_test_failed(tester);
 			return;
 		}
 
 		if (listen(sk, 5) < 0) {
-			tester_warn("listening on socket failed: %s (%u)",
-					strerror(errno), errno);
-			tester_test_failed();
+			bttester_warn("listening on socket failed: %s (%u)",
+							strerror(errno), errno);
+			l_tester_test_failed(tester);
 			close(sk);
 			return;
 		}
 
-		io = g_io_channel_unix_new(sk);
-		g_io_channel_set_close_on_unref(io, TRUE);
+		data->io = l_io_new(sk);
+		l_io_set_close_on_destroy(data->io, true);
+		l_io_set_read_handler(data->io, l2cap_listen_cb, NULL, NULL);
 
-		data->io_id = g_io_add_watch(io, G_IO_IN, l2cap_listen_cb,
-									NULL);
-		g_io_channel_unref(io);
-
-		tester_print("Listening for connections");
+		bttester_print("Listening for connections");
 	}
 
 	master_bdaddr = hciemu_get_master_bdaddr(data->hciemu);
 	if (!master_bdaddr) {
-		tester_warn("No master bdaddr");
-		tester_test_failed();
+		bttester_warn("No master bdaddr");
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -1889,32 +1885,32 @@ static void test_server(const void *test_data)
 
 static void test_getpeername_not_connected(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct sockaddr_l2 addr;
 	socklen_t len;
 	int sk;
 
 	sk = create_l2cap_sock(data, 0, 0, 0, 0);
 	if (sk < 0) {
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	len = sizeof(addr);
 	if (getpeername(sk, (struct sockaddr *) &addr, &len) == 0) {
-		tester_warn("getpeername succeeded on non-connected socket");
-		tester_test_failed();
+		bttester_warn("getpeername succeeded on non-connected socket");
+		l_tester_test_failed(tester);
 		goto done;
 	}
 
 	if (errno != ENOTCONN) {
-		tester_warn("Unexpexted getpeername error: %s (%d)",
+		bttester_warn("Unexpected getpeername error: %s (%d)",
 						strerror(errno), errno);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		goto done;
 	}
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 
 done:
 	close(sk);
@@ -1922,7 +1918,7 @@ done:
 
 int main(int argc, char *argv[])
 {
-	tester_init(&argc, &argv);
+	tester = bttester_init(&argc, &argv);
 
 	test_l2cap_bredr("Basic L2CAP Socket - Success", NULL,
 					setup_powered_client, test_basic);
@@ -2072,5 +2068,5 @@ int main(int argc, char *argv[])
 				&le_att_server_success_test_1,
 				setup_powered_server, test_server);
 
-	return tester_run();
+	return bttester_run();
 }

--- a/tools/mgmt-tester.c
+++ b/tools/mgmt-tester.c
@@ -18,7 +18,7 @@
 #include <errno.h>
 #include <unistd.h>
 
-#include <glib.h>
+#include <ell/ell.h>
 
 #include "lib/bluetooth.h"
 #include "lib/hci.h"
@@ -31,11 +31,11 @@
 #include "emulator/hciemu.h"
 
 #include "src/shared/util.h"
-#include "src/shared/tester.h"
+#include "src/shared/bttester.h"
 #include "src/shared/mgmt.h"
 
 struct test_data {
-	tester_data_func_t test_setup;
+	l_tester_data_func_t test_setup;
 	const void *test_data;
 	uint8_t expected_version;
 	uint16_t expected_manufacturer;
@@ -56,198 +56,6 @@ struct test_data {
 	int unmet_setup_conditions;
 	int sk;
 };
-
-static void print_debug(const char *str, void *user_data)
-{
-	const char *prefix = user_data;
-
-	tester_print("%s%s", prefix, str);
-}
-
-static void test_post_teardown(const void *test_data)
-{
-	struct test_data *data = tester_get_data();
-
-	if (data->sk >= 0)
-		close(data->sk);
-
-	hciemu_unref(data->hciemu);
-	data->hciemu = NULL;
-}
-
-static void test_pre_setup_failed(void)
-{
-	test_post_teardown(NULL);
-	tester_pre_setup_failed();
-}
-
-static void read_version_callback(uint8_t status, uint16_t length,
-					const void *param, void *user_data)
-{
-	struct test_data *data = tester_get_data();
-	const struct mgmt_rp_read_version *rp = param;
-
-	tester_print("Read Version callback");
-	tester_print("  Status: %s (0x%02x)", mgmt_errstr(status), status);
-
-	if (status || !param) {
-		test_pre_setup_failed();
-		return;
-	}
-
-	data->mgmt_version = rp->version;
-	data->mgmt_revision = btohs(rp->revision);
-
-	tester_print("  Version %u.%u",
-				data->mgmt_version, data->mgmt_revision);
-}
-
-static void read_commands_callback(uint8_t status, uint16_t length,
-					const void *param, void *user_data)
-{
-	tester_print("Read Commands callback");
-	tester_print("  Status: %s (0x%02x)", mgmt_errstr(status), status);
-
-	if (status || !param) {
-		test_pre_setup_failed();
-		return;
-	}
-}
-
-static bool check_settings(uint32_t supported, uint32_t expected)
-{
-	int i;
-
-	if (supported == expected)
-		return true;
-
-	for (i = 0; i < 17; i++) {
-		if (supported & BIT(i))
-			continue;
-
-		if (expected & BIT(i)) {
-			tester_warn("Expected bit %u not supported", i);
-			return false;
-		}
-	}
-
-	return true;
-}
-
-static void read_info_callback(uint8_t status, uint16_t length,
-					const void *param, void *user_data)
-{
-	struct test_data *data = tester_get_data();
-	const struct mgmt_rp_read_info *rp = param;
-	char addr[18];
-	uint16_t manufacturer;
-	uint32_t supported_settings, current_settings;
-	struct bthost *bthost;
-
-	tester_print("Read Info callback");
-	tester_print("  Status: %s (0x%02x)", mgmt_errstr(status), status);
-
-	if (status || !param) {
-		test_pre_setup_failed();
-		return;
-	}
-
-	ba2str(&rp->bdaddr, addr);
-	manufacturer = btohs(rp->manufacturer);
-	supported_settings = btohl(rp->supported_settings);
-	current_settings = btohl(rp->current_settings);
-
-	tester_print("  Address: %s", addr);
-	tester_print("  Version: 0x%02x", rp->version);
-	tester_print("  Manufacturer: 0x%04x", manufacturer);
-	tester_print("  Supported settings: 0x%08x", supported_settings);
-	tester_print("  Current settings: 0x%08x", current_settings);
-	tester_print("  Class: 0x%02x%02x%02x",
-			rp->dev_class[2], rp->dev_class[1], rp->dev_class[0]);
-	tester_print("  Name: %s", rp->name);
-	tester_print("  Short name: %s", rp->short_name);
-
-	if (strcmp(hciemu_get_address(data->hciemu), addr)) {
-		test_pre_setup_failed();
-		return;
-	}
-
-	if (rp->version != data->expected_version) {
-		tester_warn("Expected version: 0x%02x != 0x%02x",
-				rp->version, data->expected_version);
-		test_pre_setup_failed();
-		return;
-	}
-
-	if (manufacturer != data->expected_manufacturer) {
-		tester_warn("Expected manufacturer: 0x%04x != 0x%04x",
-				manufacturer, data->expected_manufacturer);
-		test_pre_setup_failed();
-		return;
-	}
-
-	if (!check_settings(supported_settings,
-				data->expected_supported_settings)) {
-		tester_warn("Expected supported settings: 0x%08x != 0x%08x",
-				supported_settings,
-				data->expected_supported_settings);
-		test_pre_setup_failed();
-		return;
-	}
-
-	if (!check_settings(current_settings, data->initial_settings)) {
-		tester_warn("Initial settings: 0x%08x != 0x%08x",
-				current_settings, data->initial_settings);
-		test_pre_setup_failed();
-		return;
-	}
-
-	if (rp->dev_class[0] != 0x00 || rp->dev_class[1] != 0x00 ||
-						rp->dev_class[2] != 0x00) {
-		test_pre_setup_failed();
-		return;
-	}
-
-	bthost = hciemu_client_get_host(data->hciemu);
-	bthost_notify_ready(bthost, tester_pre_setup_complete);
-}
-
-static void index_added_callback(uint16_t index, uint16_t length,
-					const void *param, void *user_data)
-{
-	struct test_data *data = tester_get_data();
-
-	tester_print("Index Added callback");
-	tester_print("  Index: 0x%04x", index);
-
-	data->mgmt_index = index;
-
-	mgmt_send(data->mgmt, MGMT_OP_READ_INFO, data->mgmt_index, 0, NULL,
-					read_info_callback, NULL, NULL);
-}
-
-static void index_removed_callback(uint16_t index, uint16_t length,
-					const void *param, void *user_data)
-{
-	struct test_data *data = tester_get_data();
-
-	tester_print("Index Removed callback");
-	tester_print("  Index: 0x%04x", index);
-
-	if (index != data->mgmt_index)
-		return;
-
-	mgmt_unregister_index(data->mgmt, data->mgmt_index);
-	mgmt_unregister_index(data->mgmt_alt, data->mgmt_index);
-
-	mgmt_unref(data->mgmt);
-	data->mgmt = NULL;
-
-	mgmt_unref(data->mgmt_alt);
-	data->mgmt_alt = NULL;
-
-	tester_post_teardown_complete();
-}
 
 struct generic_data {
 	bool setup_le_states;
@@ -307,17 +115,180 @@ struct generic_data {
 	uint8_t adv_data_len;
 };
 
+static struct l_tester *tester;
+
+static void print_debug(const char *str, void *user_data)
+{
+	const char *prefix = user_data;
+
+	bttester_print("%s%s", prefix, str);
+}
+
+static void test_post_teardown(const void *test_data)
+{
+	struct test_data *data = l_tester_get_data(tester);
+
+	if (data->sk >= 0)
+		close(data->sk);
+
+	hciemu_unref(data->hciemu);
+	data->hciemu = NULL;
+}
+
+static void test_pre_setup_complete(void)
+{
+	l_tester_pre_setup_complete(tester);
+}
+
+static bool check_settings(uint32_t supported, uint32_t expected)
+{
+	int i;
+
+	if (supported == expected)
+		return true;
+
+	for (i = 0; i < 17; i++) {
+		if (supported & BIT(i))
+			continue;
+
+		if (expected & BIT(i)) {
+			bttester_warn("Expected bit %u not supported", i);
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static void read_info_callback(uint8_t status, uint16_t length,
+					const void *param, void *user_data)
+{
+	struct test_data *data = l_tester_get_data(tester);
+	const struct mgmt_rp_read_info *rp = param;
+	char addr[18];
+	uint16_t manufacturer;
+	uint32_t supported_settings, current_settings;
+	struct bthost *bthost;
+
+	bttester_print("Read Info callback");
+	bttester_print("  Status: %s (0x%02x)", mgmt_errstr(status), status);
+
+	if (status || !param) {
+		test_post_teardown(NULL);
+		return;
+	}
+
+	ba2str(&rp->bdaddr, addr);
+	manufacturer = btohs(rp->manufacturer);
+	supported_settings = btohl(rp->supported_settings);
+	current_settings = btohl(rp->current_settings);
+
+	bttester_print("  Address: %s", addr);
+	bttester_print("  Version: 0x%02x", rp->version);
+	bttester_print("  Manufacturer: 0x%04x", manufacturer);
+	bttester_print("  Supported settings: 0x%08x", supported_settings);
+	bttester_print("  Current settings: 0x%08x", current_settings);
+	bttester_print("  Class: 0x%02x%02x%02x",
+			rp->dev_class[2], rp->dev_class[1], rp->dev_class[0]);
+	bttester_print("  Name: %s", rp->name);
+	bttester_print("  Short name: %s", rp->short_name);
+
+	if (strcmp(hciemu_get_address(data->hciemu), addr)) {
+		test_post_teardown(NULL);
+		return;
+	}
+
+	if (rp->version != data->expected_version) {
+		bttester_warn("Expected version: 0x%02x != 0x%02x",
+				rp->version, data->expected_version);
+		test_post_teardown(NULL);
+		return;
+	}
+
+	if (manufacturer != data->expected_manufacturer) {
+		bttester_warn("Expected manufacturer: 0x%04x != 0x%04x",
+				manufacturer, data->expected_manufacturer);
+		test_post_teardown(NULL);
+		return;
+	}
+
+	if (!check_settings(supported_settings,
+				data->expected_supported_settings)) {
+		bttester_warn("Expected supported settings: 0x%08x != 0x%08x",
+				supported_settings,
+				data->expected_supported_settings);
+		test_post_teardown(NULL);
+		return;
+	}
+
+	if (!check_settings(current_settings, data->initial_settings)) {
+		bttester_warn("Initial settings: 0x%08x != 0x%08x",
+				current_settings, data->initial_settings);
+		test_post_teardown(NULL);
+		return;
+	}
+
+	if (rp->dev_class[0] != 0x00 || rp->dev_class[1] != 0x00 ||
+						rp->dev_class[2] != 0x00) {
+		test_post_teardown(NULL);
+		return;
+	}
+
+	bthost = hciemu_client_get_host(data->hciemu);
+	bthost_notify_ready(bthost, test_pre_setup_complete);
+}
+
+static void index_added_callback(uint16_t index, uint16_t length,
+					const void *param, void *user_data)
+{
+	struct test_data *data = l_tester_get_data(tester);
+
+	bttester_print("Index Added callback");
+	bttester_print("  Index: 0x%04x", index);
+
+	data->mgmt_index = index;
+
+	mgmt_send(data->mgmt, MGMT_OP_READ_INFO, data->mgmt_index, 0, NULL,
+					read_info_callback, NULL, NULL);
+}
+
+static void index_removed_callback(uint16_t index, uint16_t length,
+					const void *param, void *user_data)
+{
+	struct test_data *data = l_tester_get_data(tester);
+
+	bttester_print("Index Removed callback");
+	bttester_print("  Index: 0x%04x", index);
+
+	if (index != data->mgmt_index)
+		return;
+
+	mgmt_unregister_index(data->mgmt, data->mgmt_index);
+	mgmt_unregister_index(data->mgmt_alt, data->mgmt_index);
+
+	mgmt_unref(data->mgmt);
+	data->mgmt = NULL;
+
+	mgmt_unref(data->mgmt_alt);
+	data->mgmt_alt = NULL;
+
+	if (l_tester_get_stage(tester) == L_TESTER_STAGE_PRE_SETUP)
+		l_tester_pre_setup_failed(tester);
+	else
+		l_tester_post_teardown_complete(tester);
+}
+
 static void read_index_list_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 
-	tester_print("Read Index List callback");
-	tester_print("  Status: %s (0x%02x)", mgmt_errstr(status), status);
+	bttester_print("Read Index List callback");
+	bttester_print("  Status: %s (0x%02x)", mgmt_errstr(status), status);
 
 	if (status || !param) {
-		test_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
@@ -329,51 +300,86 @@ static void read_index_list_callback(uint8_t status, uint16_t length,
 
 	data->hciemu = hciemu_new(data->hciemu_type);
 	if (!data->hciemu) {
-		tester_warn("Failed to setup HCI emulation");
-		test_pre_setup_failed();
+		bttester_warn("Failed to setup HCI emulation");
+		l_tester_pre_setup_failed(tester);
 	}
 
-	if (tester_use_debug())
+	if (bttester_use_debug())
 		hciemu_set_debug(data->hciemu, print_debug, "hciemu: ", NULL);
 
 	if (test && test->setup_le_states)
 		hciemu_set_master_le_states(data->hciemu, test->le_states);
 }
 
+static void read_commands_callback(uint8_t status, uint16_t length,
+					const void *param, void *user_data)
+{
+	struct test_data *data = l_tester_get_data(tester);
+
+	bttester_print("Read Commands callback");
+	bttester_print("  Status: %s (0x%02x)", mgmt_errstr(status), status);
+
+	if (status || !param) {
+		l_tester_pre_setup_failed(tester);
+		return;
+	}
+
+	mgmt_send(data->mgmt, MGMT_OP_READ_INDEX_LIST, MGMT_INDEX_NONE, 0, NULL,
+					read_index_list_callback, NULL, NULL);
+}
+
+static void read_version_callback(uint8_t status, uint16_t length,
+					const void *param, void *user_data)
+{
+	struct test_data *data = l_tester_get_data(tester);
+	const struct mgmt_rp_read_version *rp = param;
+
+	bttester_print("Read Version callback");
+	bttester_print("  Status: %s (0x%02x)", mgmt_errstr(status), status);
+
+	if (status || !param) {
+		l_tester_pre_setup_failed(tester);
+		return;
+	}
+
+	data->mgmt_version = rp->version;
+	data->mgmt_revision = btohs(rp->revision);
+
+	bttester_print("  Version %u.%u",
+				data->mgmt_version, data->mgmt_revision);
+
+	mgmt_send(data->mgmt, MGMT_OP_READ_COMMANDS, MGMT_INDEX_NONE, 0, NULL,
+					read_commands_callback, NULL, NULL);
+}
+
 static void test_pre_setup(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
 	data->mgmt = mgmt_new_default();
 	if (!data->mgmt) {
-		tester_warn("Failed to setup management interface");
-		test_pre_setup_failed();
+		bttester_warn("Failed to setup management interface");
+		test_post_teardown(NULL);
 		return;
 	}
 
 	data->mgmt_alt = mgmt_new_default();
 	if (!data->mgmt_alt) {
-		tester_warn("Failed to setup alternate management interface");
-		test_pre_setup_failed();
+		bttester_warn("Failed to setup alternate management interface");
+		test_post_teardown(NULL);
 
 		mgmt_unref(data->mgmt);
 		data->mgmt = NULL;
 		return;
 	}
 
-	if (tester_use_debug()) {
+	if (bttester_use_debug()) {
 		mgmt_set_debug(data->mgmt, print_debug, "mgmt: ", NULL);
 		mgmt_set_debug(data->mgmt_alt, print_debug, "mgmt-alt: ", NULL);
 	}
 
 	mgmt_send(data->mgmt, MGMT_OP_READ_VERSION, MGMT_INDEX_NONE, 0, NULL,
 					read_version_callback, NULL, NULL);
-
-	mgmt_send(data->mgmt, MGMT_OP_READ_COMMANDS, MGMT_INDEX_NONE, 0, NULL,
-					read_commands_callback, NULL, NULL);
-
-	mgmt_send(data->mgmt, MGMT_OP_READ_INDEX_LIST, MGMT_INDEX_NONE, 0, NULL,
-					read_index_list_callback, NULL, NULL);
 
 	data->sk = -1;
 }
@@ -382,48 +388,49 @@ static void test_add_condition(struct test_data *data)
 {
 	data->unmet_conditions++;
 
-	tester_print("Test condition added, total %d", data->unmet_conditions);
+	bttester_print("Test condition added, total %d",
+							data->unmet_conditions);
 }
 
 static void test_add_setup_condition(struct test_data *data)
 {
 	data->unmet_setup_conditions++;
 
-	tester_print("Test setup condition added, total %d",
-		     data->unmet_setup_conditions);
+	bttester_print("Test setup condition added, total %d",
+						data->unmet_setup_conditions);
 }
 
 static void test_setup_condition_complete(struct test_data *data)
 {
 	data->unmet_setup_conditions--;
 
-	tester_print("Test setup condition complete, %d left",
-		     data->unmet_setup_conditions);
+	bttester_print("Test setup condition complete, %d left",
+						data->unmet_setup_conditions);
 
 	if (data->unmet_setup_conditions > 0)
 		return;
 
-	tester_setup_complete();
+	l_tester_setup_complete(tester);
 }
 
 static void test_condition_complete(struct test_data *data)
 {
 	data->unmet_conditions--;
 
-	tester_print("Test condition complete, %d left",
+	bttester_print("Test condition complete, %d left",
 						data->unmet_conditions);
 
 	if (data->unmet_conditions > 0)
 		return;
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 }
 
 #define test_full(name, data, setup, func, timeout, type, version, \
 			expected_settings, settings) \
 	do { \
 		struct test_data *user; \
-		user = new0(struct test_data, 1); \
+		user = l_new(struct test_data, 1); \
 		user->hciemu_type = type; \
 		user->test_setup = setup; \
 		user->test_data = data; \
@@ -431,9 +438,9 @@ static void test_condition_complete(struct test_data *data)
 		user->expected_manufacturer = 0x003f; \
 		user->expected_supported_settings = expected_settings; \
 		user->initial_settings = settings; \
-		tester_add_full(name, data, \
+		l_tester_add_full(tester, name, data,			\
 				test_pre_setup, test_setup, func, NULL, \
-				test_post_teardown, timeout, user, free); \
+				test_post_teardown, timeout, user, l_free); \
 	} while (0)
 
 #define test_bredrle_full(name, data, setup, func, timeout) \
@@ -474,7 +481,7 @@ static void test_condition_complete(struct test_data *data)
 
 static void controller_setup(const void *test_data)
 {
-	tester_test_passed();
+	l_tester_test_passed(tester);
 }
 
 struct setup_mgmt_cmd {
@@ -2700,7 +2707,7 @@ static const struct generic_data pair_device_invalid_param_test_2 = {
 
 static const void *pair_device_send_param_func(uint16_t *len)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	static uint8_t param[8];
 
@@ -2721,7 +2728,7 @@ static const void *pair_device_send_param_func(uint16_t *len)
 
 static const void *pair_device_expect_param_func(uint16_t *len)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	static uint8_t param[7];
 
@@ -2808,7 +2815,7 @@ static const struct generic_data pair_device_power_off_test_1 = {
 
 static const void *client_bdaddr_param_func(uint8_t *len)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	static uint8_t bdaddr[6];
 
 	memcpy(bdaddr, hciemu_get_client_bdaddr(data->hciemu), 6);
@@ -2939,7 +2946,7 @@ static const struct generic_data pair_device_ssp_test_1 = {
 
 static const void *client_io_cap_param_func(uint8_t *len)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	static uint8_t param[9];
 
@@ -3122,33 +3129,33 @@ static bool ltk_is_sc(const struct mgmt_ltk_info *ltk)
 
 static bool verify_ltk(const void *param, uint16_t length)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	const struct mgmt_ev_new_long_term_key *ev = param;
 
 	if (length != sizeof(struct mgmt_ev_new_long_term_key)) {
-		tester_warn("Invalid new ltk length %u != %zu", length,
+		bttester_warn("Invalid new ltk length %u != %zu", length,
 				sizeof(struct mgmt_ev_new_long_term_key));
 		return false;
 	}
 
 	if (test->just_works && ltk_is_authenticated(&ev->key)) {
-		tester_warn("Authenticated key for just-works");
+		bttester_warn("Authenticated key for just-works");
 		return false;
 	}
 
 	if (!test->just_works && !ltk_is_authenticated(&ev->key)) {
-		tester_warn("Unauthenticated key for MITM");
+		bttester_warn("Unauthenticated key for MITM");
 		return false;
 	}
 
 	if (test->expect_sc_key && !ltk_is_sc(&ev->key)) {
-		tester_warn("Non-LE SC key for SC pairing");
+		bttester_warn("Non-LE SC key for SC pairing");
 		return false;
 	}
 
 	if (!test->expect_sc_key && ltk_is_sc(&ev->key)) {
-		tester_warn("SC key for Non-SC pairing");
+		bttester_warn("SC key for Non-SC pairing");
 		return false;
 	}
 
@@ -3304,33 +3311,33 @@ static bool lk_is_sc(const struct mgmt_link_key_info *lk)
 
 static bool verify_link_key(const void *param, uint16_t length)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	const struct mgmt_ev_new_link_key *ev = param;
 
 	if (length != sizeof(struct mgmt_ev_new_link_key)) {
-		tester_warn("Invalid new Link Key length %u != %zu", length,
+		bttester_warn("Invalid new Link Key length %u != %zu", length,
 				sizeof(struct mgmt_ev_new_link_key));
 		return false;
 	}
 
 	if (test->just_works && lk_is_authenticated(&ev->key)) {
-		tester_warn("Authenticated key for just-works");
+		bttester_warn("Authenticated key for just-works");
 		return false;
 	}
 
 	if (!test->just_works && !lk_is_authenticated(&ev->key)) {
-		tester_warn("Unauthenticated key for MITM");
+		bttester_warn("Unauthenticated key for MITM");
 		return false;
 	}
 
 	if (test->expect_sc_key && !lk_is_sc(&ev->key)) {
-		tester_warn("Non-LE SC key for SC pairing");
+		bttester_warn("Non-LE SC key for SC pairing");
 		return false;
 	}
 
 	if (!test->expect_sc_key && lk_is_sc(&ev->key)) {
-		tester_warn("SC key for Non-SC pairing");
+		bttester_warn("SC key for Non-SC pairing");
 		return false;
 	}
 
@@ -3465,7 +3472,7 @@ static const struct generic_data pairing_acceptor_ssp_3 = {
 
 static const void *client_io_cap_reject_param_func(uint8_t *len)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	static uint8_t param[7];
 
 	memcpy(param, hciemu_get_client_bdaddr(data->hciemu), 6);
@@ -3814,7 +3821,7 @@ static const struct generic_data set_privacy_nval_param_test = {
 
 static const void *get_conn_info_send_param_func(uint16_t *len)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	static uint8_t param[7];
 
 	memcpy(param, hciemu_get_client_bdaddr(data->hciemu), 6);
@@ -3827,7 +3834,7 @@ static const void *get_conn_info_send_param_func(uint16_t *len)
 
 static const void *get_conn_info_expect_param_func(uint16_t *len)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	static uint8_t param[10];
 
 	memcpy(param, hciemu_get_client_bdaddr(data->hciemu), 6);
@@ -3843,7 +3850,7 @@ static const void *get_conn_info_expect_param_func(uint16_t *len)
 
 static const void *get_conn_info_error_expect_param_func(uint16_t *len)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	static uint8_t param[10];
 
 	/* All unset parameters shall be 0 in case of error */
@@ -3875,7 +3882,7 @@ static const struct generic_data get_conn_info_ncon_test = {
 
 static const void *get_conn_info_expect_param_power_off_func(uint16_t *len)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	static uint8_t param[10];
 
 	memcpy(param, hciemu_get_client_bdaddr(data->hciemu), 6);
@@ -5510,7 +5517,7 @@ static void client_cmd_complete(uint16_t opcode, uint8_t status,
 					const void *param, uint8_t len,
 					void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	struct bthost *bthost;
 
@@ -5520,7 +5527,7 @@ static void client_cmd_complete(uint16_t opcode, uint8_t status,
 	case BT_HCI_CMD_WRITE_SCAN_ENABLE:
 	case BT_HCI_CMD_LE_SET_ADV_ENABLE:
 	case BT_HCI_CMD_LE_SET_EXT_ADV_ENABLE:
-		tester_print("Client set connectable: %s (0x%02x)",
+		bttester_print("Client set connectable: %s (0x%02x)",
 						mgmt_errstr(status), status);
 		if (!status && test->client_enable_ssp) {
 			bthost_write_ssp_mode(bthost, 0x01);
@@ -5528,7 +5535,7 @@ static void client_cmd_complete(uint16_t opcode, uint8_t status,
 		}
 		break;
 	case BT_HCI_CMD_WRITE_SIMPLE_PAIRING_MODE:
-		tester_print("Client enable SSP: %s (0x%02x)",
+		bttester_print("Client enable SSP: %s (0x%02x)",
 						mgmt_errstr(status), status);
 		break;
 	default:
@@ -5536,14 +5543,14 @@ static void client_cmd_complete(uint16_t opcode, uint8_t status,
 	}
 
 	if (status)
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 	else
-		tester_setup_complete();
+		l_tester_setup_complete(tester);
 }
 
 static void setup_bthost(void)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	struct bthost *bthost;
 
@@ -5562,7 +5569,7 @@ static void setup_bthost(void)
 
 static void setup_pairing_acceptor(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 
 	if (!test->io_cap)
@@ -5579,22 +5586,22 @@ static void setup_powered_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_print("Controller powered on");
+	bttester_print("Controller powered on");
 
 	setup_bthost();
 }
 
 static void setup_class(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char param[] = { 0x01 };
 	unsigned char class_param[] = { 0x01, 0x0c };
 
-	tester_print("Setting device class and powering on");
+	bttester_print("Setting device class and powering on");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_DEV_CLASS, data->mgmt_index,
 				sizeof(class_param), class_param,
@@ -5608,40 +5615,40 @@ static void setup_class(const void *test_data)
 static void discovering_event(uint16_t index, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct mgmt_ev_discovering *ev = param;
 
 	mgmt_unregister(data->mgmt, data->mgmt_discov_ev_id);
 
 	if (length != sizeof(*ev)) {
-		tester_warn("Incorrect discovering event length");
-		tester_setup_failed();
+		bttester_warn("Incorrect discovering event length");
+		l_tester_setup_failed(tester);
 		return;
 	}
 
 	if (!ev->discovering) {
-		tester_warn("Unexpected discovery stopped event");
-		tester_setup_failed();
+		bttester_warn("Unexpected discovery stopped event");
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_setup_complete();
+	l_tester_setup_complete(tester);
 }
 
 static void setup_discovery_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_print("Discovery started");
+	bttester_print("Discovery started");
 }
 
 static void setup_start_discovery(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	const void *send_param = test->setup_send_param;
 	uint16_t send_len = test->setup_send_len;
@@ -5658,10 +5665,10 @@ static void setup_start_discovery(const void *test_data)
 
 static void setup_multi_uuid32(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Powering on controller (with 32-bit UUID)");
+	bttester_print("Powering on controller (with 32-bit UUID)");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_SSP, data->mgmt_index,
 				sizeof(param), param, NULL, NULL, NULL);
@@ -5683,7 +5690,7 @@ static void setup_multi_uuid32(const void *test_data)
 
 static void setup_multi_uuid32_2(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char param[] = { 0x01 };
 	unsigned char uuid_param[] = {
 			0xfb, 0x34, 0x9b, 0x5f, 0x80, 0x00, 0x00, 0x80,
@@ -5691,7 +5698,7 @@ static void setup_multi_uuid32_2(const void *test_data)
 			0x00 };
 	int i;
 
-	tester_print("Powering on controller (with many 32-bit UUIDs)");
+	bttester_print("Powering on controller (with many 32-bit UUIDs)");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_SSP, data->mgmt_index,
 				sizeof(param), param, NULL, NULL, NULL);
@@ -5711,10 +5718,10 @@ static void setup_multi_uuid32_2(const void *test_data)
 
 static void setup_multi_uuid128(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Powering on controller (with 128-bit UUID)");
+	bttester_print("Powering on controller (with 128-bit UUID)");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_SSP, data->mgmt_index,
 				sizeof(param), param, NULL, NULL, NULL);
@@ -5730,7 +5737,7 @@ static void setup_multi_uuid128(const void *test_data)
 
 static void setup_multi_uuid128_2(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char param[] = { 0x01 };
 	unsigned char uuid_param[] = {
 			0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
@@ -5738,7 +5745,7 @@ static void setup_multi_uuid128_2(const void *test_data)
 			0x00 };
 	int i;
 
-	tester_print("Powering on controller (with many 128-bit UUIDs)");
+	bttester_print("Powering on controller (with many 128-bit UUIDs)");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_SSP, data->mgmt_index,
 				sizeof(param), param, NULL, NULL, NULL);
@@ -5757,10 +5764,10 @@ static void setup_multi_uuid128_2(const void *test_data)
 
 static void setup_multi_uuid16(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Powering on controller (with SPP UUID)");
+	bttester_print("Powering on controller (with SPP UUID)");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_SSP, data->mgmt_index,
 				sizeof(param), param, NULL, NULL, NULL);
@@ -5782,7 +5789,7 @@ static void setup_multi_uuid16(const void *test_data)
 
 static void setup_multi_uuid16_2(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char param[] = { 0x01 };
 	unsigned char uuid_param[] = {
 			0xfb, 0x34, 0x9b, 0x5f, 0x80, 0x00, 0x00, 0x80,
@@ -5790,7 +5797,7 @@ static void setup_multi_uuid16_2(const void *test_data)
 			0x00 };
 	int i;
 
-	tester_print("Powering on controller (with many 16-bit UUIDs)");
+	bttester_print("Powering on controller (with many 16-bit UUIDs)");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_SSP, data->mgmt_index,
 				sizeof(param), param, NULL, NULL, NULL);
@@ -5810,10 +5817,10 @@ static void setup_multi_uuid16_2(const void *test_data)
 
 static void setup_uuid_mix(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Powering on controller (with mixed UUIDs)");
+	bttester_print("Powering on controller (with mixed UUIDs)");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_SSP, data->mgmt_index,
 				sizeof(param), param, NULL, NULL, NULL);
@@ -5842,12 +5849,12 @@ static void setup_uuid_mix(const void *test_data)
 
 static void setup_add_device(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char param[] = { 0x01 };
 	const unsigned char *add_param;
 	size_t add_param_len;
 
-	tester_print("Powering on controller (with added device)");
+	bttester_print("Powering on controller (with added device)");
 
 	if (data->hciemu_type == HCIEMU_TYPE_LE) {
 		add_param = add_device_success_param_2;
@@ -5872,11 +5879,11 @@ static void setup_add_advertising_callback(uint8_t status, uint16_t length,
 				(struct mgmt_rp_add_advertising *) param;
 
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_print("Add Advertising setup complete (instance %d)",
+	bttester_print("Add Advertising setup complete (instance %d)",
 								rp->instance);
 
 	setup_bthost();
@@ -5901,12 +5908,12 @@ static void setup_add_adv_param(struct mgmt_cp_add_advertising *cp,
 
 static void setup_add_advertising_not_powered(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct mgmt_cp_add_advertising *cp;
 	unsigned char adv_param[sizeof(*cp) + TESTER_ADD_ADV_DATA_LEN];
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Adding advertising instance while unpowered");
+	bttester_print("Adding advertising instance while unpowered");
 
 	cp = (struct mgmt_cp_add_advertising *) adv_param;
 	setup_add_adv_param(cp, 1);
@@ -5923,12 +5930,12 @@ static void setup_add_advertising_not_powered(const void *test_data)
 
 static void setup_add_advertising(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct mgmt_cp_add_advertising *cp;
 	unsigned char adv_param[sizeof(*cp) + TESTER_ADD_ADV_DATA_LEN];
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Adding advertising instance while powered");
+	bttester_print("Adding advertising instance while powered");
 
 	cp = (struct mgmt_cp_add_advertising *) adv_param;
 	setup_add_adv_param(cp, 1);
@@ -5949,12 +5956,12 @@ static void setup_add_advertising(const void *test_data)
 
 static void setup_add_advertising_connectable(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct mgmt_cp_add_advertising *cp;
 	unsigned char adv_param[sizeof(*cp) + TESTER_ADD_ADV_DATA_LEN];
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Adding advertising instance while connectable");
+	bttester_print("Adding advertising instance while connectable");
 
 	cp = (struct mgmt_cp_add_advertising *) adv_param;
 	setup_add_adv_param(cp, 1);
@@ -5986,7 +5993,7 @@ static int create_le_att_sock(struct test_data *data)
 							BTPROTO_L2CAP);
 	if (sk < 0) {
 		err = -errno;
-		tester_warn("Can't create socket: %s (%d)", strerror(errno),
+		bttester_warn("Can't create socket: %s (%d)", strerror(errno),
 									errno);
 		return err;
 	}
@@ -5999,7 +6006,7 @@ static int create_le_att_sock(struct test_data *data)
 
 	if (bind(sk, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
 		err = -errno;
-		tester_warn("Can't bind socket: %s (%d)", strerror(errno),
+		bttester_warn("Can't bind socket: %s (%d)", strerror(errno),
 									errno);
 		close(sk);
 		return err;
@@ -6007,7 +6014,7 @@ static int create_le_att_sock(struct test_data *data)
 
 	if (listen(sk, 1) < 0) {
 		err = -errno;
-		tester_warn("Can't bind socket: %s (%d)", strerror(errno),
+		bttester_warn("Can't bind socket: %s (%d)", strerror(errno),
 									errno);
 		close(sk);
 		return err;
@@ -6020,11 +6027,11 @@ static int create_le_att_sock(struct test_data *data)
 
 static void setup_advertise_while_connected(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct mgmt_cp_add_advertising *cp;
 	uint8_t adv_param[sizeof(*cp) + TESTER_ADD_ADV_DATA_LEN];
 
-	tester_print("Adding advertising instances");
+	bttester_print("Adding advertising instances");
 
 	cp = (struct mgmt_cp_add_advertising *) adv_param;
 	setup_add_adv_param(cp, 1);
@@ -6046,17 +6053,17 @@ static void setup_advertise_while_connected(const void *test_data)
 	 * connect. Socket is closed in test_post_teardown
 	 */
 	if (create_le_att_sock(data) < 0)
-		tester_test_failed();
+		l_tester_test_failed(tester);
 }
 
 static void setup_add_advertising_timeout(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct mgmt_cp_add_advertising *cp;
 	unsigned char adv_param[sizeof(*cp) + TESTER_ADD_ADV_DATA_LEN];
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Adding advertising instance with timeout");
+	bttester_print("Adding advertising instance with timeout");
 
 	cp = (struct mgmt_cp_add_advertising *) adv_param;
 	setup_add_adv_param(cp, 1);
@@ -6078,12 +6085,12 @@ static void setup_add_advertising_timeout(const void *test_data)
 
 static void setup_add_advertising_duration(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct mgmt_cp_add_advertising *cp;
 	unsigned char adv_param[sizeof(*cp) + TESTER_ADD_ADV_DATA_LEN];
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Adding instance with long timeout/short duration");
+	bttester_print("Adding instance with long timeout/short duration");
 
 	cp = (struct mgmt_cp_add_advertising *) adv_param;
 	setup_add_adv_param(cp, 1);
@@ -6107,11 +6114,11 @@ static void setup_add_advertising_duration(const void *test_data)
 static void setup_power_cycle_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char param_off[] = { 0x00 };
 
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
@@ -6124,12 +6131,12 @@ static void setup_power_cycle_callback(uint8_t status, uint16_t length,
 
 static void setup_add_advertising_power_cycle(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct mgmt_cp_add_advertising *cp;
 	unsigned char adv_param[sizeof(*cp) + TESTER_ADD_ADV_DATA_LEN];
 	unsigned char param_on[] = { 0x01 };
 
-	tester_print("Adding instance without timeout and power cycle");
+	bttester_print("Adding instance without timeout and power cycle");
 
 	cp = (struct mgmt_cp_add_advertising *) adv_param;
 	setup_add_adv_param(cp, 1);
@@ -6150,12 +6157,12 @@ static void setup_add_advertising_power_cycle(const void *test_data)
 
 static void setup_set_and_add_advertising(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct mgmt_cp_add_advertising *cp;
 	unsigned char adv_param[sizeof(*cp) + TESTER_ADD_ADV_DATA_LEN];
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Set and add advertising instance");
+	bttester_print("Set and add advertising instance");
 
 	cp = (struct mgmt_cp_add_advertising *) adv_param;
 	setup_add_adv_param(cp, 1);
@@ -6182,16 +6189,16 @@ static void setup_multi_adv_second_instance(uint8_t status, uint16_t length,
 		const void *param, void *user_data) {
 	struct mgmt_rp_add_advertising *rp =
 				(struct mgmt_rp_add_advertising *) param;
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct mgmt_cp_add_advertising *cp;
 	unsigned char adv_param[sizeof(*cp) + TESTER_ADD_ADV_DATA_LEN];
 
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_print("Add Advertising setup complete (instance %d)",
+	bttester_print("Add Advertising setup complete (instance %d)",
 								rp->instance);
 
 	cp = (struct mgmt_cp_add_advertising *) adv_param;
@@ -6207,12 +6214,12 @@ static void setup_multi_adv_second_instance(uint8_t status, uint16_t length,
 
 static void setup_multi_adv(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct mgmt_cp_add_advertising *cp;
 	unsigned char adv_param[sizeof(*cp) + TESTER_ADD_ADV_DATA_LEN];
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Adding two instances with timeout 1 and duration 1");
+	bttester_print("Adding two instances with timeout 1 and duration 1");
 
 	cp = (struct mgmt_cp_add_advertising *) adv_param;
 	setup_add_adv_param(cp, 1);
@@ -6236,14 +6243,14 @@ static void setup_multi_adv(const void *test_data)
 static void setup_complete(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_print("Initial settings completed");
+	bttester_print("Initial settings completed");
 
 	if (data->test_setup)
 		data->test_setup(data);
@@ -6255,7 +6262,7 @@ static void setup_set_unpowered_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
@@ -6265,15 +6272,15 @@ static void setup_set_unpowered_callback(uint8_t status, uint16_t length,
 static void setup_set_le_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char power_param[] = { 0x00 };
 
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_print("Disabling power");
+	bttester_print("Disabling power");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_POWERED, data->mgmt_index,
 						sizeof(power_param),
@@ -6284,10 +6291,10 @@ static void setup_set_le_callback(uint8_t status, uint16_t length,
 
 static void setup_ext_adv_not_powered(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Enabling LE");
+	bttester_print("Enabling LE");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_LE, data->mgmt_index,
 						sizeof(param), &param,
@@ -6299,7 +6306,7 @@ static void setup_set_ext_adv_params_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
@@ -6308,9 +6315,9 @@ static void setup_set_ext_adv_params_callback(uint8_t status, uint16_t length,
 
 static void setup_ext_adv_params(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Setting Extended Adv Params");
+	bttester_print("Setting Extended Adv Params");
 
 	mgmt_send(data->mgmt, MGMT_OP_ADD_EXT_ADV_PARAMS, data->mgmt_index,
 					sizeof(ext_adv_params_valid),
@@ -6378,8 +6385,8 @@ static void user_passkey_request_callback(uint16_t index, uint16_t length,
 	struct mgmt_cp_user_passkey_reply cp;
 
 	if (test->just_works) {
-		tester_warn("User Passkey Request for just-works case");
-		tester_test_failed();
+		bttester_warn("User Passkey Request for just-works case");
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -6399,7 +6406,7 @@ static void user_passkey_request_callback(uint16_t index, uint16_t length,
 
 static void test_setup(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	struct bthost *bthost = hciemu_client_get_host(data->hciemu);
 	const uint16_t *cmd;
@@ -6448,7 +6455,7 @@ proceed:
 		if (data->test_setup)
 			data->test_setup(data);
 		else
-			tester_setup_complete();
+			l_tester_setup_complete(tester);
 		return;
 	}
 
@@ -6498,31 +6505,31 @@ proceed:
 static void command_generic_new_settings(uint16_t index, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("New settings event received");
+	bttester_print("New settings event received");
 
 	mgmt_unregister(data->mgmt, data->mgmt_settings_id);
 
-	tester_test_failed();
+	l_tester_test_failed(tester);
 }
 
 static void command_generic_new_settings_alt(uint16_t index, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	uint32_t settings;
 
 	if (length != 4) {
-		tester_warn("Invalid parameter size for new settings event");
-		tester_test_failed();
+		bttester_warn("Invalid parameter size for new settings event");
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	settings = get_le32(param);
 
-	tester_print("New settings 0x%08x received", settings);
+	bttester_print("New settings 0x%08x received", settings);
 
 	if (test->expect_settings_unset) {
 		if ((settings & test->expect_settings_unset) != 0)
@@ -6537,7 +6544,7 @@ static void command_generic_new_settings_alt(uint16_t index, uint16_t length,
 		return;
 
 done:
-	tester_print("Unregistering new settings notification");
+	bttester_print("Unregistering new settings notification");
 
 	mgmt_unregister(data->mgmt_alt, data->mgmt_alt_settings_id);
 
@@ -6546,18 +6553,18 @@ done:
 
 static bool verify_alt_ev(const void *param, uint16_t length)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 
 	if (length != test->expect_alt_ev_len) {
-		tester_warn("Invalid length %u != %u", length,
+		bttester_warn("Invalid length %u != %u", length,
 						test->expect_alt_ev_len);
 		return false;
 	}
 
 	if (test->expect_alt_ev_param &&
 			memcmp(test->expect_alt_ev_param, param, length)) {
-		tester_warn("Event parameters do not match");
+		bttester_warn("Event parameters do not match");
 		return false;
 	}
 
@@ -6568,11 +6575,12 @@ static void command_generic_event_alt(uint16_t index, uint16_t length,
 							const void *param,
 							void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	bool (*verify)(const void *param, uint16_t length);
 
-	tester_print("New %s event received", mgmt_evstr(test->expect_alt_ev));
+	bttester_print("New %s event received",
+					mgmt_evstr(test->expect_alt_ev));
 
 	mgmt_unregister(data->mgmt_alt, data->mgmt_alt_ev_id);
 
@@ -6582,9 +6590,9 @@ static void command_generic_event_alt(uint16_t index, uint16_t length,
 		verify = verify_alt_ev;
 
 	if (!verify(param, length)) {
-		tester_warn("Incorrect %s event parameters",
+		bttester_warn("Incorrect %s event parameters",
 					mgmt_evstr(test->expect_alt_ev));
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -6594,16 +6602,17 @@ static void command_generic_event_alt(uint16_t index, uint16_t length,
 static void command_generic_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	const void *expect_param = test->expect_param;
 	uint16_t expect_len = test->expect_len;
 
-	tester_print("%s (0x%04x): %s (0x%02x)", mgmt_opstr(test->send_opcode),
-			test->send_opcode, mgmt_errstr(status), status);
+	bttester_print("%s (0x%04x): %s (0x%02x)",
+			mgmt_opstr(test->send_opcode), test->send_opcode,
+						mgmt_errstr(status), status);
 
 	if (status != test->expect_status) {
-		tester_test_abort();
+		l_tester_test_abort(tester);
 		return;
 	}
 
@@ -6612,18 +6621,18 @@ static void command_generic_callback(uint8_t status, uint16_t length,
 			expect_param = test->expect_func(&expect_len);
 
 		if (length != expect_len) {
-			tester_warn("Invalid cmd response parameter size");
-			tester_test_failed();
+			bttester_warn("Invalid cmd response parameter size");
+			l_tester_test_failed(tester);
 			return;
 		}
 
 		if (expect_param && expect_len > 0 &&
 					memcmp(param, expect_param, length)) {
-			tester_warn("Unexpected cmd response parameter value");
+			bttester_warn("Unexpected cmd response param value");
 			util_hexdump('>', param, length, print_debug, "");
 			util_hexdump('!', expect_param, length, print_debug,
 								"");
-			tester_test_failed();
+			l_tester_test_failed(tester);
 			return;
 		}
 	}
@@ -6639,20 +6648,20 @@ static void command_setup_hci_callback(uint16_t opcode, const void *param,
 	const void *setup_expect_hci_param = test->setup_expect_hci_param;
 	uint8_t setup_expect_hci_len = test->setup_expect_hci_len;
 
-	tester_print("HCI Command 0x%04x length %u", opcode, length);
+	bttester_print("HCI Command 0x%04x length %u", opcode, length);
 
 	if (opcode != test->setup_expect_hci_command)
 		return;
 
 	if (length != setup_expect_hci_len) {
-		tester_warn("Invalid parameter size for HCI command");
-		tester_test_failed();
+		bttester_warn("Invalid parameter size for HCI command");
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	if (memcmp(param, setup_expect_hci_param, length) != 0) {
-		tester_warn("Unexpected HCI command parameter value");
-		tester_test_failed();
+		bttester_warn("Unexpected HCI command parameter value");
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -6669,7 +6678,7 @@ static void command_hci_callback(uint16_t opcode, const void *param,
 	uint8_t expect_hci_len = test->expect_hci_len;
 	int ret;
 
-	tester_print("HCI Command 0x%04x length %u", opcode, length);
+	bttester_print("HCI Command 0x%04x length %u", opcode, length);
 
 	if (opcode != test->expect_hci_command)
 		return;
@@ -6678,8 +6687,8 @@ static void command_hci_callback(uint16_t opcode, const void *param,
 		expect_hci_param = test->expect_hci_func(&expect_hci_len);
 
 	if (length != expect_hci_len) {
-		tester_warn("Invalid parameter size for HCI command");
-		tester_test_failed();
+		bttester_warn("Invalid parameter size for HCI command");
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -6687,11 +6696,12 @@ static void command_hci_callback(uint16_t opcode, const void *param,
 		ret = test->expect_hci_param_check_func(param, length);
 	else
 		ret = memcmp(param, expect_hci_param, length);
+
 	if (ret != 0) {
-		tester_warn("Unexpected HCI command parameter value:");
+		bttester_warn("Unexpected HCI command parameter value:");
 		util_hexdump('>', param, length, print_debug, "");
 		util_hexdump('!', expect_hci_param, length, print_debug, "");
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -6702,7 +6712,7 @@ static void setup_mgmt_cmd_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 	test_setup_condition_complete(user_data);
@@ -6710,15 +6720,15 @@ static void setup_mgmt_cmd_callback(uint8_t status, uint16_t length,
 
 static void setup_command_generic(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	const void *send_param = test->setup_send_param;
 	uint16_t send_len = test->setup_send_len;
 	size_t i = 0;
 
 	if (test->setup_expect_hci_command) {
-		tester_print("Registering setup expected HCI command callback");
-		tester_print("Setup expected HCI command 0x%04x",
+		bttester_print("Registering setup expected HCI command cb");
+		bttester_print("Setup expected HCI command 0x%04x",
 					 test->setup_expect_hci_command);
 		hciemu_add_master_post_command_hook(data->hciemu,
 					command_setup_hci_callback, data);
@@ -6726,7 +6736,7 @@ static void setup_command_generic(const void *test_data)
 	}
 
 	if (test->setup_send_opcode) {
-		tester_print("Setup sending %s (0x%04x)",
+		bttester_print("Setup sending %s (0x%04x)",
 				mgmt_opstr(test->setup_send_opcode),
 				test->setup_send_opcode);
 		mgmt_send(data->mgmt, test->setup_send_opcode, data->mgmt_index,
@@ -6737,14 +6747,14 @@ static void setup_command_generic(const void *test_data)
 		return;
 	}
 
-	tester_print("Sending setup opcode array");
+	bttester_print("Sending setup opcode array");
 	for (; test->setup_mgmt_cmd_arr + i; ++i) {
 		const struct setup_mgmt_cmd *cmd = test->setup_mgmt_cmd_arr + i;
 
 		if (cmd->send_opcode == 0x00)
 			break;
 
-		tester_print("Setup sending %s (0x%04x)",
+		bttester_print("Setup sending %s (0x%04x)",
 				mgmt_opstr(cmd->send_opcode),
 				cmd->send_opcode);
 
@@ -8292,12 +8302,12 @@ static void setup_add_adv_param_1m(struct mgmt_cp_add_advertising *cp,
 
 static void setup_add_advertising_1m(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct mgmt_cp_add_advertising *cp;
 	unsigned char adv_param[sizeof(*cp) + TESTER_ADD_ADV_DATA_LEN];
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Adding advertising instance while powered");
+	bttester_print("Adding advertising instance while powered");
 
 	cp = (struct mgmt_cp_add_advertising *) adv_param;
 	setup_add_adv_param_1m(cp, 1);
@@ -8348,12 +8358,12 @@ static const struct generic_data add_ext_advertising_conn_on_1m = {
 
 static void setup_add_advertising_connectable_1m(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct mgmt_cp_add_advertising *cp;
 	unsigned char adv_param[sizeof(*cp) + TESTER_ADD_ADV_DATA_LEN];
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Adding advertising instance while connectable");
+	bttester_print("Adding advertising instance while connectable");
 
 	cp = (struct mgmt_cp_add_advertising *) adv_param;
 	setup_add_adv_param_1m(cp, 1);
@@ -8735,18 +8745,18 @@ static void set_phy_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_print("Set PHY Success");
+	bttester_print("Set PHY Success");
 
-	tester_setup_complete();
+	l_tester_setup_complete(tester);
 }
 
 static void setup_phy_configuration(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	const void *send_param = test->setup_send_param;
 	uint16_t send_len = test->setup_send_len;
@@ -8781,7 +8791,7 @@ static bool power_off(uint16_t index)
 
 static void test_command_generic(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	const void *send_param = test->send_param;
 	uint16_t send_len = test->send_len;
@@ -8791,7 +8801,7 @@ static void test_command_generic(const void *test_data)
 	index = test->send_index_none ? MGMT_INDEX_NONE : data->mgmt_index;
 
 	if (test->expect_settings_set || test->expect_settings_unset) {
-		tester_print("Registering new settings notification");
+		bttester_print("Registering new settings notification");
 
 		id = mgmt_register(data->mgmt, MGMT_EV_NEW_SETTINGS, index,
 				command_generic_new_settings, NULL, NULL);
@@ -8804,7 +8814,7 @@ static void test_command_generic(const void *test_data)
 	}
 
 	if (test->expect_alt_ev) {
-		tester_print("Registering %s notification",
+		bttester_print("Registering %s notification",
 					mgmt_evstr(test->expect_alt_ev));
 		id = mgmt_register(data->mgmt_alt, test->expect_alt_ev, index,
 					command_generic_event_alt, NULL, NULL);
@@ -8813,18 +8823,18 @@ static void test_command_generic(const void *test_data)
 	}
 
 	if (test->expect_hci_command) {
-		tester_print("Registering HCI command callback");
+		bttester_print("Registering HCI command callback");
 		hciemu_add_master_post_command_hook(data->hciemu,
 						command_hci_callback, data);
 		test_add_condition(data);
 	}
 
 	if (test->send_opcode == 0x0000) {
-		tester_print("Executing no-op test");
+		bttester_print("Executing no-op test");
 		return;
 	}
 
-	tester_print("Sending %s (0x%04x)", mgmt_opstr(test->send_opcode),
+	bttester_print("Sending %s (0x%04x)", mgmt_opstr(test->send_opcode),
 							test->send_opcode);
 
 	if (test->send_func)
@@ -8846,17 +8856,17 @@ static void test_command_generic(const void *test_data)
 
 static void check_scan(void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
 	if (hciemu_get_master_le_scan_enable(data->hciemu)) {
-		tester_warn("LE scan still enabled");
-		tester_test_failed();
+		bttester_warn("LE scan still enabled");
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	if (hciemu_get_master_scan_enable(data->hciemu)) {
-		tester_warn("BR/EDR scan still enabled");
-		tester_test_failed();
+		bttester_warn("BR/EDR scan still enabled");
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -8865,16 +8875,16 @@ static void check_scan(void *user_data)
 
 static void test_remove_device(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
 	test_command_generic(test_data);
-	tester_wait(1, check_scan, NULL);
+	l_tester_wait(tester, 1, check_scan, NULL);
 	test_add_condition(data);
 }
 
 static void trigger_device_found(void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	struct bthost *bthost;
 
@@ -8903,21 +8913,21 @@ static void trigger_device_found(void *user_data)
 
 static void test_device_found(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
 	test_command_generic(test_data);
 
 	/* Make sure discovery is enabled before enabling advertising. */
-	tester_wait(1, trigger_device_found, NULL);
+	l_tester_wait(tester, 1, trigger_device_found, NULL);
 	test_add_condition(data);
 }
 
 static void pairing_new_conn(uint16_t handle, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct bthost *bthost;
 
-	tester_print("New connection with handle 0x%04x", handle);
+	bttester_print("New connection with handle 0x%04x", handle);
 
 	bthost = hciemu_client_get_host(data->hciemu);
 
@@ -8926,7 +8936,7 @@ static void pairing_new_conn(uint16_t handle, void *user_data)
 
 static void test_pairing_acceptor(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	const uint8_t *master_bdaddr;
 	struct bthost *bthost;
@@ -8935,7 +8945,7 @@ static void test_pairing_acceptor(const void *test_data)
 	if (test->expect_alt_ev) {
 		unsigned int id;
 
-		tester_print("Registering %s notification",
+		bttester_print("Registering %s notification",
 					mgmt_evstr(test->expect_alt_ev));
 		id = mgmt_register(data->mgmt_alt, test->expect_alt_ev,
 					data->mgmt_index,
@@ -8946,8 +8956,8 @@ static void test_pairing_acceptor(const void *test_data)
 
 	master_bdaddr = hciemu_get_master_bdaddr(data->hciemu);
 	if (!master_bdaddr) {
-		tester_warn("No master bdaddr");
-		tester_test_failed();
+		bttester_warn("No master bdaddr");
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -8965,12 +8975,12 @@ static void test_pairing_acceptor(const void *test_data)
 static void connected_event(uint16_t index, uint16_t length, const void *param,
 							void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	const void *send_param = test->send_param;
 	uint16_t send_len = test->send_len;
 
-	tester_print("Sending %s 0x%04x", mgmt_opstr(test->send_opcode),
+	bttester_print("Sending %s 0x%04x", mgmt_opstr(test->send_opcode),
 							test->send_opcode);
 
 	if (test->send_func)
@@ -8995,13 +9005,13 @@ static void connected_event(uint16_t index, uint16_t length, const void *param,
 
 static void test_command_generic_connect(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned int id;
 	const uint8_t *master_bdaddr;
 	uint8_t addr_type;
 	struct bthost *bthost;
 
-	tester_print("Registering %s notification",
+	bttester_print("Registering %s notification",
 					mgmt_evstr(MGMT_EV_DEVICE_CONNECTED));
 	id = mgmt_register(data->mgmt_alt, MGMT_EV_DEVICE_CONNECTED,
 				data->mgmt_index, connected_event,
@@ -9011,8 +9021,8 @@ static void test_command_generic_connect(const void *test_data)
 
 	master_bdaddr = hciemu_get_master_bdaddr(data->hciemu);
 	if (!master_bdaddr) {
-		tester_warn("No master bdaddr");
-		tester_test_failed();
+		bttester_warn("No master bdaddr");
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -9030,10 +9040,10 @@ static bool test_adv_enable_hook(const void *data, uint16_t len,
 	const uint8_t *status = data;
 
 	if (*status == 0) {
-		tester_print("Advertising enabled");
+		bttester_print("Advertising enabled");
 		test_condition_complete(test_data);
 	} else {
-		tester_print("Advertising enabled error 0x%02x", *status);
+		bttester_print("Advertising enabled error 0x%02x", *status);
 	}
 
 	return true;
@@ -9042,15 +9052,15 @@ static bool test_adv_enable_hook(const void *data, uint16_t len,
 static void disconnected_event(uint16_t index, uint16_t length,
 					const void *param, void *user_data)
 {
-	tester_test_failed();
+	l_tester_test_failed(tester);
 }
 
 static void le_connected_event(uint16_t index, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Device connected");
+	bttester_print("Device connected");
 
 	test_add_condition(data);
 
@@ -9081,11 +9091,11 @@ static void add_device_callback(uint8_t status, uint16_t len, const void *param,
 	const uint8_t *master_bdaddr;
 
 	if (status != 0) {
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
-	tester_print("Device added");
+	bttester_print("Device added");
 
 	/* If advertising is enabled on client that means we can stop here and
 	 * just wait for connection
@@ -9095,8 +9105,8 @@ static void add_device_callback(uint8_t status, uint16_t len, const void *param,
 
 	master_bdaddr = hciemu_get_master_bdaddr(data->hciemu);
 	if (!master_bdaddr) {
-		tester_warn("No master bdaddr");
-		tester_test_failed();
+		bttester_warn("No master bdaddr");
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -9109,12 +9119,12 @@ static void add_device_callback(uint8_t status, uint16_t len, const void *param,
 
 static void test_connected_and_advertising(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct generic_data *test = data->test_data;
 	const uint8_t *client_bdaddr;
 	struct mgmt_cp_add_device cp;
 
-	tester_print("Registering %s notification",
+	bttester_print("Registering %s notification",
 					mgmt_evstr(MGMT_EV_DEVICE_CONNECTED));
 
 	test_add_condition(data);
@@ -9124,8 +9134,8 @@ static void test_connected_and_advertising(const void *test_data)
 
 	client_bdaddr = hciemu_get_client_bdaddr(data->hciemu);
 	if (!client_bdaddr) {
-		tester_warn("No client bdaddr");
-		tester_test_failed();
+		bttester_warn("No client bdaddr");
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -9155,15 +9165,15 @@ static void read_50_controller_cap_complete(uint8_t status, uint16_t length,
 	uint8_t tag_type;
 
 	if (status || !param) {
-		tester_warn("Failed to read advertising features: %s (0x%02x)",
+		bttester_warn("Read advertising features failed: %s (0x%02x)",
 						mgmt_errstr(status), status);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 	}
 
 	if (sizeof(rp->cap_len) + rp->cap_len != length) {
-		tester_warn("Controller capabilities malformed, size %zu != %u",
+		bttester_warn("Controller capabilities malformed, sz %zu != %u",
 				sizeof(rp->cap_len) + rp->cap_len, length);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 	}
 
 	while (offset < rp->cap_len) {
@@ -9173,11 +9183,12 @@ static void read_50_controller_cap_complete(uint8_t status, uint16_t length,
 		switch (tag_type) {
 		case MGMT_CAP_LE_TX_PWR:
 			if ((tag_len - sizeof(tag_type)) != 2) {
-				tester_warn("TX power had unexpected length %d",
-					tag_len);
+				bttester_warn("TX power unexpected length %d",
+								tag_len);
 				break;
 			}
-			tester_print("Expected Tx Power discovered: %d-%d",
+
+			bttester_print("Expected Tx Power discovered: %d-%d",
 					ptr[offset], ptr[offset+1]);
 			test_condition_complete(data);
 		}
@@ -9189,7 +9200,7 @@ static void read_50_controller_cap_complete(uint8_t status, uint16_t length,
 
 static void test_50_controller_cap_response(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
 	test_add_condition(data);
 
@@ -9201,7 +9212,7 @@ static void test_50_controller_cap_response(const void *test_data)
 
 int main(int argc, char *argv[])
 {
-	tester_init(&argc, &argv);
+	tester = bttester_init(&argc, &argv);
 
 	test_bredrle("Controller setup",
 				NULL, NULL, controller_setup);
@@ -10697,5 +10708,5 @@ int main(int argc, char *argv[])
 				setup_ext_adv_params,
 				test_command_generic);
 
-	return tester_run();
+	return bttester_run();
 }

--- a/tools/rfcomm-tester.c
+++ b/tools/rfcomm-tester.c
@@ -18,7 +18,7 @@
 #include <errno.h>
 #include <stdbool.h>
 
-#include <glib.h>
+#include <ell/ell.h>
 
 #include "lib/bluetooth.h"
 #include "lib/rfcomm.h"
@@ -28,16 +28,16 @@
 #include "emulator/bthost.h"
 #include "emulator/hciemu.h"
 
-#include "src/shared/tester.h"
+#include "src/shared/bttester.h"
 #include "src/shared/mgmt.h"
 
 struct test_data {
 	struct mgmt *mgmt;
 	uint16_t mgmt_index;
 	struct hciemu *hciemu;
+	struct l_io *io;
 	enum hciemu_type hciemu_type;
 	const void *test_data;
-	unsigned int io_id;
 	uint16_t conn_handle;
 };
 
@@ -59,27 +59,29 @@ struct rfcomm_server_data {
 	uint16_t data_len;
 };
 
+static struct l_tester *tester;
+
 static void print_debug(const char *str, void *user_data)
 {
 	const char *prefix = user_data;
 
-	tester_print("%s%s", prefix, str);
+	bttester_print("%s%s", prefix, str);
 }
 
 static void read_info_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct mgmt_rp_read_info *rp = param;
 	char addr[18];
 	uint16_t manufacturer;
 	uint32_t supported_settings, current_settings;
 
-	tester_print("Read Info callback");
-	tester_print("  Status: 0x%02x", status);
+	bttester_print("Read Info callback");
+	bttester_print("  Status: 0x%02x", status);
 
 	if (status || !param) {
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
@@ -88,31 +90,31 @@ static void read_info_callback(uint8_t status, uint16_t length,
 	supported_settings = btohl(rp->supported_settings);
 	current_settings = btohl(rp->current_settings);
 
-	tester_print("  Address: %s", addr);
-	tester_print("  Version: 0x%02x", rp->version);
-	tester_print("  Manufacturer: 0x%04x", manufacturer);
-	tester_print("  Supported settings: 0x%08x", supported_settings);
-	tester_print("  Current settings: 0x%08x", current_settings);
-	tester_print("  Class: 0x%02x%02x%02x",
+	bttester_print("  Address: %s", addr);
+	bttester_print("  Version: 0x%02x", rp->version);
+	bttester_print("  Manufacturer: 0x%04x", manufacturer);
+	bttester_print("  Supported settings: 0x%08x", supported_settings);
+	bttester_print("  Current settings: 0x%08x", current_settings);
+	bttester_print("  Class: 0x%02x%02x%02x",
 			rp->dev_class[2], rp->dev_class[1], rp->dev_class[0]);
-	tester_print("  Name: %s", rp->name);
-	tester_print("  Short name: %s", rp->short_name);
+	bttester_print("  Name: %s", rp->name);
+	bttester_print("  Short name: %s", rp->short_name);
 
 	if (strcmp(hciemu_get_address(data->hciemu), addr)) {
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
-	tester_pre_setup_complete();
+	l_tester_pre_setup_complete(tester);
 }
 
 static void index_added_callback(uint16_t index, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Index Added callback");
-	tester_print("  Index: 0x%04x", index);
+	bttester_print("Index Added callback");
+	bttester_print("  Index: 0x%04x", index);
 
 	data->mgmt_index = index;
 
@@ -123,10 +125,10 @@ static void index_added_callback(uint16_t index, uint16_t length,
 static void index_removed_callback(uint16_t index, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Index Removed callback");
-	tester_print("  Index: 0x%04x", index);
+	bttester_print("Index Removed callback");
+	bttester_print("  Index: 0x%04x", index);
 
 	if (index != data->mgmt_index)
 		return;
@@ -136,19 +138,19 @@ static void index_removed_callback(uint16_t index, uint16_t length,
 	mgmt_unref(data->mgmt);
 	data->mgmt = NULL;
 
-	tester_post_teardown_complete();
+	l_tester_post_teardown_complete(tester);
 }
 
 static void read_index_list_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Read Index List callback");
-	tester_print("  Status: 0x%02x", status);
+	bttester_print("Read Index List callback");
+	bttester_print("  Status: 0x%02x", status);
 
 	if (status || !param) {
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
@@ -160,28 +162,28 @@ static void read_index_list_callback(uint8_t status, uint16_t length,
 
 	data->hciemu = hciemu_new(data->hciemu_type);
 	if (!data->hciemu) {
-		tester_warn("Failed to setup HCI emulation");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to setup HCI emulation");
+		l_tester_pre_setup_failed(tester);
 	}
 
-	if (tester_use_debug())
+	if (bttester_use_debug())
 		hciemu_set_debug(data->hciemu, print_debug, "hciemu: ", NULL);
 
-	tester_print("New hciemu instance created");
+	bttester_print("New hciemu instance created");
 }
 
 static void test_pre_setup(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
 	data->mgmt = mgmt_new_default();
 	if (!data->mgmt) {
-		tester_warn("Failed to setup management interface");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to setup management interface");
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
-	if (tester_use_debug())
+	if (bttester_use_debug())
 		mgmt_set_debug(data->mgmt, print_debug, "mgmt: ", NULL);
 
 	mgmt_send(data->mgmt, MGMT_OP_READ_INDEX_LIST, MGMT_INDEX_NONE, 0, NULL,
@@ -190,11 +192,11 @@ static void test_pre_setup(const void *test_data)
 
 static void test_post_teardown(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	if (data->io_id > 0) {
-		g_source_remove(data->io_id);
-		data->io_id = 0;
+	if (data->io) {
+		l_io_destroy(data->io);
+		data->io = NULL;
 	}
 
 	hciemu_unref(data->hciemu);
@@ -205,7 +207,7 @@ static void test_data_free(void *test_data)
 {
 	struct test_data *data = test_data;
 
-	free(data);
+	l_free(data);
 }
 
 static void client_connectable_complete(uint16_t opcode, uint8_t status,
@@ -219,26 +221,26 @@ static void client_connectable_complete(uint16_t opcode, uint8_t status,
 		return;
 	}
 
-	tester_print("Client set connectable status 0x%02x", status);
+	bttester_print("Client set connectable status 0x%02x", status);
 
 	if (status)
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 	else
-		tester_setup_complete();
+		l_tester_setup_complete(tester);
 }
 
 static void setup_powered_client_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct bthost *bthost;
 
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_print("Controller powered on");
+	bttester_print("Controller powered on");
 
 	bthost = hciemu_client_get_host(data->hciemu);
 	bthost_set_cmd_complete_cb(bthost, client_connectable_complete, data);
@@ -247,10 +249,10 @@ static void setup_powered_client_callback(uint8_t status, uint16_t length,
 
 static void setup_powered_client(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Powering on controller");
+	bttester_print("Powering on controller");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_POWERED, data->mgmt_index,
 			sizeof(param), param, setup_powered_client_callback,
@@ -261,21 +263,21 @@ static void setup_powered_server_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_print("Controller powered on");
+	bttester_print("Controller powered on");
 
-	tester_setup_complete();
+	l_tester_setup_complete(tester);
 }
 
 static void setup_powered_server(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Powering on controller");
+	bttester_print("Powering on controller");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_CONNECTABLE, data->mgmt_index,
 				sizeof(param), param,
@@ -347,15 +349,15 @@ static void test_basic(const void *test_data)
 
 	sk = socket(PF_BLUETOOTH, SOCK_STREAM, BTPROTO_RFCOMM);
 	if (sk < 0) {
-		tester_warn("Can't create socket: %s (%d)", strerror(errno),
+		bttester_warn("Can't create socket: %s (%d)", strerror(errno),
 									errno);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	close(sk);
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 }
 
 static int create_rfcomm_sock(bdaddr_t *address, uint8_t channel)
@@ -395,44 +397,62 @@ static int connect_rfcomm_sock(int sk, const bdaddr_t *bdaddr, uint8_t channel)
 	return 0;
 }
 
-static gboolean client_received_data(GIOChannel *io, GIOCondition cond,
-							gpointer user_data)
+static bool client_received_data(struct l_io *io, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct rfcomm_client_data *cli = data->test_data;
 	int sk;
 	ssize_t ret;
 	char buf[248];
 
-	sk = g_io_channel_unix_get_fd(io);
+	sk = l_io_get_fd(io);
 
 	ret = read(sk, buf, cli->data_len);
 	if (cli->data_len != ret) {
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return false;
 	}
 
 	if (memcmp(cli->read_data, buf, cli->data_len))
-		tester_test_failed();
+		l_tester_test_failed(tester);
 	else
-		tester_test_passed();
+		l_tester_test_passed(tester);
 
 	return false;
 }
 
-static gboolean rc_connect_cb(GIOChannel *io, GIOCondition cond,
-							gpointer user_data)
+static void rc_disconnect_cb(struct l_io *io, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct rfcomm_client_data *cli = data->test_data;
 	socklen_t len = sizeof(int);
 	int sk, err, sk_err;
 
-	tester_print("Connected");
+	bttester_print("Disconnected");
 
-	data->io_id = 0;
+	sk = l_io_get_fd(io);
 
-	sk = g_io_channel_unix_get_fd(io);
+	if (getsockopt(sk, SOL_SOCKET, SO_ERROR, &sk_err, &len) < 0)
+		err = -errno;
+	else
+		err = -sk_err;
+
+	if (cli->expected_connect_err && err == cli->expected_connect_err)
+		l_tester_test_passed(tester);
+	else
+		l_tester_test_failed(tester);
+}
+
+static bool rc_connect_cb(struct l_io *io, void *user_data)
+{
+	struct test_data *data = l_tester_get_data(tester);
+	const struct rfcomm_client_data *cli = data->test_data;
+	socklen_t len = sizeof(int);
+	int sk, err, sk_err;
+
+	bttester_print("Connected");
+
+	sk = l_io_get_fd(io);
 
 	if (getsockopt(sk, SOL_SOCKET, SO_ERROR, &sk_err, &len) < 0)
 		err = -errno;
@@ -440,25 +460,25 @@ static gboolean rc_connect_cb(GIOChannel *io, GIOCondition cond,
 		err = -sk_err;
 
 	if (cli->expected_connect_err && err == cli->expected_connect_err) {
-		tester_test_passed();
+		l_tester_test_passed(tester);
 		return false;
 	}
 
 	if (cli->send_data) {
 		ssize_t ret;
 
-		tester_print("Writing %u bytes of data", cli->data_len);
+		bttester_print("Writing %u bytes of data", cli->data_len);
 
 		ret = write(sk, cli->send_data, cli->data_len);
 		if (cli->data_len != ret) {
-			tester_warn("Failed to write %u bytes: %s (%d)",
+			bttester_warn("Failed to write %u bytes: %s (%d)",
 					cli->data_len, strerror(errno), errno);
-			tester_test_failed();
+			l_tester_test_failed(tester);
 		}
 
 		return false;
 	} else if (cli->read_data) {
-		g_io_add_watch(io, G_IO_IN, client_received_data, NULL);
+		l_io_set_read_handler(io, client_received_data, NULL, NULL);
 		bthost_send_rfcomm_data(hciemu_client_get_host(data->hciemu),
 						data->conn_handle,
 						cli->client_channel,
@@ -467,9 +487,9 @@ static gboolean rc_connect_cb(GIOChannel *io, GIOCondition cond,
 	}
 
 	if (err < 0)
-		tester_test_failed();
+		l_tester_test_failed(tester);
 	else
-		tester_test_passed();
+		l_tester_test_passed(tester);
 
 	return false;
 }
@@ -477,47 +497,47 @@ static gboolean rc_connect_cb(GIOChannel *io, GIOCondition cond,
 static void client_hook_func(const void *data, uint16_t len,
 							void *user_data)
 {
-	struct test_data *test_data = tester_get_data();
+	struct test_data *test_data = l_tester_get_data(tester);
 	const struct rfcomm_client_data *cli = test_data->test_data;
 	ssize_t ret;
 
-	tester_print("bthost received %u bytes of data", len);
+	bttester_print("bthost received %u bytes of data", len);
 
 	if (cli->data_len != len) {
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	ret = memcmp(cli->send_data, data, len);
 	if (ret)
-		tester_test_failed();
+		l_tester_test_failed(tester);
 	else
-		tester_test_passed();
+		l_tester_test_passed(tester);
 }
 
 static void server_hook_func(const void *data, uint16_t len,
 							void *user_data)
 {
-	struct test_data *test_data = tester_get_data();
+	struct test_data *test_data = l_tester_get_data(tester);
 	const struct rfcomm_server_data *srv = test_data->test_data;
 	ssize_t ret;
 
 	if (srv->data_len != len) {
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	ret = memcmp(srv->send_data, data, len);
 	if (ret)
-		tester_test_failed();
+		l_tester_test_failed(tester);
 	else
-		tester_test_passed();
+		l_tester_test_passed(tester);
 }
 
 static void rfcomm_connect_cb(uint16_t handle, uint16_t cid,
 						void *user_data, bool status)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct rfcomm_client_data *cli = data->test_data;
 	struct bthost *bthost = hciemu_client_get_host(data->hciemu);
 
@@ -531,11 +551,10 @@ static void rfcomm_connect_cb(uint16_t handle, uint16_t cid,
 
 static void test_connect(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct bthost *bthost = hciemu_client_get_host(data->hciemu);
 	const struct rfcomm_client_data *cli = data->test_data;
 	const uint8_t *client_addr, *master_addr;
-	GIOChannel *io;
 	int sk;
 
 	bthost_add_l2cap_server(bthost, 0x0003, NULL, NULL, NULL);
@@ -550,59 +569,58 @@ static void test_connect(const void *test_data)
 	if (connect_rfcomm_sock(sk, (const bdaddr_t *) client_addr,
 					cli->client_channel) < 0) {
 		close(sk);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
-	io = g_io_channel_unix_new(sk);
-	g_io_channel_set_close_on_unref(io, TRUE);
+	data->io = l_io_new(sk);
+	l_io_set_close_on_destroy(data->io, true);
+	l_io_set_disconnect_handler(data->io, rc_disconnect_cb, NULL, NULL);
 
-	data->io_id = g_io_add_watch(io, G_IO_OUT, rc_connect_cb, NULL);
+	if (!l_io_set_write_handler(data->io, rc_connect_cb, NULL, NULL)) {
+		l_tester_test_failed(tester);
+		return;
+	}
 
-	g_io_channel_unref(io);
-
-	tester_print("Connect in progress %d", sk);
+	bttester_print("Connect in progress %d", sk);
 }
 
-static gboolean server_received_data(GIOChannel *io, GIOCondition cond,
-							gpointer user_data)
+static bool server_received_data(struct l_io *io, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct rfcomm_server_data *srv = data->test_data;
 	char buf[1024];
 	ssize_t ret;
 	int sk;
 
-	sk = g_io_channel_unix_get_fd(io);
+	sk = l_io_get_fd(io);
 
 	ret = read(sk, buf, srv->data_len);
 	if (ret != srv->data_len) {
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return false;
 	}
 
 	if (memcmp(buf, srv->read_data, srv->data_len))
-		tester_test_failed();
+		l_tester_test_failed(tester);
 	else
-		tester_test_passed();
+		l_tester_test_passed(tester);
 
 	return false;
 }
 
-static gboolean rfcomm_listen_cb(GIOChannel *io, GIOCondition cond,
-							gpointer user_data)
+static bool rfcomm_listen_cb(struct l_io *io, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct rfcomm_server_data *srv = data->test_data;
 	int sk, new_sk;
 
-	data->io_id = 0;
 
-	sk = g_io_channel_unix_get_fd(io);
+	sk = l_io_get_fd(io);
 
 	new_sk = accept(sk, NULL, NULL);
 	if (new_sk < 0) {
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return false;
 	}
 
@@ -611,26 +629,23 @@ static gboolean rfcomm_listen_cb(GIOChannel *io, GIOCondition cond,
 
 		ret = write(new_sk, srv->send_data, srv->data_len);
 		if (ret != srv->data_len)
-			tester_test_failed();
+			l_tester_test_failed(tester);
 
 		close(new_sk);
 		return false;
 	} else if (srv->read_data) {
-		GIOChannel *new_io;
+		struct l_io *new_io;
 
-		new_io = g_io_channel_unix_new(new_sk);
-		g_io_channel_set_close_on_unref(new_io, TRUE);
+		new_io = l_io_new(new_sk);
+		l_io_set_close_on_destroy(new_io, true);
+		l_io_set_read_handler(new_io, server_received_data, NULL, NULL);
 
-		data->io_id = g_io_add_watch(new_io, G_IO_IN,
-						server_received_data, NULL);
-
-		g_io_channel_unref(new_io);
 		return false;
 	}
 
 	close(new_sk);
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 
 	return false;
 }
@@ -638,7 +653,7 @@ static gboolean rfcomm_listen_cb(GIOChannel *io, GIOCondition cond,
 static void connection_cb(uint16_t handle, uint16_t cid, void *user_data,
 								bool status)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct rfcomm_server_data *srv = data->test_data;
 	struct bthost *bthost = hciemu_client_get_host(data->hciemu);
 
@@ -653,14 +668,14 @@ static void connection_cb(uint16_t handle, uint16_t cid, void *user_data,
 	}
 
 	if (srv->expected_status == status)
-		tester_test_passed();
+		l_tester_test_passed(tester);
 	else
-		tester_test_failed();
+		l_tester_test_failed(tester);
 }
 
 static void client_new_conn(uint16_t handle, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct rfcomm_server_data *srv = data->test_data;
 	struct bthost *bthost;
 
@@ -673,36 +688,34 @@ static void client_new_conn(uint16_t handle, void *user_data)
 
 static void test_server(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct rfcomm_server_data *srv = data->test_data;
 	const uint8_t *master_addr;
 	struct bthost *bthost;
-	GIOChannel *io;
 	int sk;
 
 	master_addr = hciemu_get_master_bdaddr(data->hciemu);
 
 	sk = create_rfcomm_sock((bdaddr_t *) master_addr, srv->server_channel);
 	if (sk < 0) {
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	if (listen(sk, 5) < 0) {
-		tester_warn("listening on socket failed: %s (%u)",
-				strerror(errno), errno);
-		tester_test_failed();
+		bttester_warn("listening on socket failed: %s (%u)",
+							strerror(errno), errno);
+		l_tester_test_failed(tester);
 		close(sk);
 		return;
 	}
 
-	io = g_io_channel_unix_new(sk);
-	g_io_channel_set_close_on_unref(io, TRUE);
+	data->io = l_io_new(sk);
+	l_io_set_close_on_destroy(data->io, true);
 
-	data->io_id = g_io_add_watch(io, G_IO_IN, rfcomm_listen_cb, NULL);
-	g_io_channel_unref(io);
+	l_io_set_read_handler(data->io, rfcomm_listen_cb, NULL, NULL);
 
-	tester_print("Listening for connections");
+	bttester_print("Listening for connections");
 
 	bthost = hciemu_client_get_host(data->hciemu);
 	bthost_set_connect_cb(bthost, client_new_conn, data);
@@ -713,20 +726,19 @@ static void test_server(const void *test_data)
 #define test_rfcomm(name, data, setup, func) \
 	do { \
 		struct test_data *user; \
-		user = malloc(sizeof(struct test_data)); \
+		user = l_new(struct test_data, 1);	\
 		if (!user) \
 			break; \
 		user->hciemu_type = HCIEMU_TYPE_BREDR; \
 		user->test_data = data; \
-		user->io_id = 0; \
-		tester_add_full(name, data, \
+		l_tester_add_full(tester, name, data,		   \
 				test_pre_setup, setup, func, NULL, \
 				test_post_teardown, 2, user, test_data_free); \
 	} while (0)
 
 int main(int argc, char *argv[])
 {
-	tester_init(&argc, &argv);
+	tester = bttester_init(&argc, &argv);
 
 	test_rfcomm("Basic RFCOMM Socket - Success", NULL,
 					setup_powered_client, test_basic);
@@ -751,5 +763,5 @@ int main(int argc, char *argv[])
 	test_rfcomm("Basic RFCOMM Socket Server - Conn Refused", &listen_nval,
 					setup_powered_server, test_server);
 
-	return tester_run();
+	return bttester_run();
 }

--- a/tools/sco-tester.c
+++ b/tools/sco-tester.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// spdx-License-Identifier: GPL-2.0-or-later
 /*
  *
  *  BlueZ - Bluetooth protocol stack for Linux
@@ -17,7 +17,7 @@
 #include <errno.h>
 #include <stdbool.h>
 
-#include <glib.h>
+#include <ell/ell.h>
 
 #include "lib/bluetooth.h"
 #include "lib/sco.h"
@@ -27,7 +27,7 @@
 #include "emulator/bthost.h"
 #include "emulator/hciemu.h"
 
-#include "src/shared/tester.h"
+#include "src/shared/bttester.h"
 #include "src/shared/mgmt.h"
 
 struct test_data {
@@ -36,7 +36,7 @@ struct test_data {
 	uint16_t mgmt_index;
 	struct hciemu *hciemu;
 	enum hciemu_type hciemu_type;
-	unsigned int io_id;
+	struct l_io *io;
 	bool disable_esco;
 };
 
@@ -44,27 +44,29 @@ struct sco_client_data {
 	int expect_err;
 };
 
+static struct l_tester *tester;
+
 static void print_debug(const char *str, void *user_data)
 {
 	const char *prefix = user_data;
 
-	tester_print("%s%s", prefix, str);
+	bttester_print("%s%s", prefix, str);
 }
 
 static void read_info_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct mgmt_rp_read_info *rp = param;
 	char addr[18];
 	uint16_t manufacturer;
 	uint32_t supported_settings, current_settings;
 
-	tester_print("Read Info callback");
-	tester_print("  Status: 0x%02x", status);
+	bttester_print("Read Info callback");
+	bttester_print("  Status: 0x%02x", status);
 
 	if (status || !param) {
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
@@ -73,31 +75,31 @@ static void read_info_callback(uint8_t status, uint16_t length,
 	supported_settings = btohl(rp->supported_settings);
 	current_settings = btohl(rp->current_settings);
 
-	tester_print("  Address: %s", addr);
-	tester_print("  Version: 0x%02x", rp->version);
-	tester_print("  Manufacturer: 0x%04x", manufacturer);
-	tester_print("  Supported settings: 0x%08x", supported_settings);
-	tester_print("  Current settings: 0x%08x", current_settings);
-	tester_print("  Class: 0x%02x%02x%02x",
+	bttester_print("  Address: %s", addr);
+	bttester_print("  Version: 0x%02x", rp->version);
+	bttester_print("  Manufacturer: 0x%04x", manufacturer);
+	bttester_print("  Supported settings: 0x%08x", supported_settings);
+	bttester_print("  Current settings: 0x%08x", current_settings);
+	bttester_print("  Class: 0x%02x%02x%02x",
 			rp->dev_class[2], rp->dev_class[1], rp->dev_class[0]);
-	tester_print("  Name: %s", rp->name);
-	tester_print("  Short name: %s", rp->short_name);
+	bttester_print("  Name: %s", rp->name);
+	bttester_print("  Short name: %s", rp->short_name);
 
 	if (strcmp(hciemu_get_address(data->hciemu), addr)) {
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
-	tester_pre_setup_complete();
+	l_tester_pre_setup_complete(tester);
 }
 
 static void index_added_callback(uint16_t index, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Index Added callback");
-	tester_print("  Index: 0x%04x", index);
+	bttester_print("Index Added callback");
+	bttester_print("  Index: 0x%04x", index);
 
 	data->mgmt_index = index;
 
@@ -108,10 +110,10 @@ static void index_added_callback(uint16_t index, uint16_t length,
 static void index_removed_callback(uint16_t index, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Index Removed callback");
-	tester_print("  Index: 0x%04x", index);
+	bttester_print("Index Removed callback");
+	bttester_print("  Index: 0x%04x", index);
 
 	if (index != data->mgmt_index)
 		return;
@@ -121,19 +123,19 @@ static void index_removed_callback(uint16_t index, uint16_t length,
 	mgmt_unref(data->mgmt);
 	data->mgmt = NULL;
 
-	tester_post_teardown_complete();
+	l_tester_post_teardown_complete(tester);
 }
 
 static void read_index_list_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Read Index List callback");
-	tester_print("  Status: 0x%02x", status);
+	bttester_print("Read Index List callback");
+	bttester_print("  Status: 0x%02x", status);
 
 	if (status || !param) {
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
@@ -145,20 +147,20 @@ static void read_index_list_callback(uint8_t status, uint16_t length,
 
 	data->hciemu = hciemu_new(HCIEMU_TYPE_BREDRLE);
 	if (!data->hciemu) {
-		tester_warn("Failed to setup HCI emulation");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to setup HCI emulation");
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
-	if (tester_use_debug())
+	if (bttester_use_debug())
 		hciemu_set_debug(data->hciemu, print_debug, "hciemu: ", NULL);
 
-	tester_print("New hciemu instance created");
+	bttester_print("New hciemu instance created");
 
 	if (data->disable_esco) {
 		uint8_t *features;
 
-		tester_print("Disabling eSCO packet type support");
+		bttester_print("Disabling eSCO packet type support");
 
 		features = hciemu_get_features(data->hciemu);
 		if (features)
@@ -168,16 +170,16 @@ static void read_index_list_callback(uint8_t status, uint16_t length,
 
 static void test_pre_setup(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
 	data->mgmt = mgmt_new_default();
 	if (!data->mgmt) {
-		tester_warn("Failed to setup management interface");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to setup management interface");
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
-	if (tester_use_debug())
+	if (bttester_use_debug())
 		mgmt_set_debug(data->mgmt, print_debug, "mgmt: ", NULL);
 
 	mgmt_send(data->mgmt, MGMT_OP_READ_INDEX_LIST, MGMT_INDEX_NONE, 0, NULL,
@@ -186,7 +188,7 @@ static void test_pre_setup(const void *test_data)
 
 static void test_post_teardown(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
 	hciemu_unref(data->hciemu);
 	data->hciemu = NULL;
@@ -196,25 +198,26 @@ static void test_data_free(void *test_data)
 {
 	struct test_data *data = test_data;
 
-	if (data->io_id > 0)
-		g_source_remove(data->io_id);
+	if (data->io) {
+		l_io_destroy(data->io);
+		data->io = NULL;
+	}
 
-	free(data);
+	l_free(data);
 }
 
 #define test_sco_full(name, data, setup, func, _disable_esco) \
 	do { \
 		struct test_data *user; \
-		user = malloc(sizeof(struct test_data)); \
+		user = l_new(struct test_data, 1); \
 		if (!user) \
 			break; \
 		user->hciemu_type = HCIEMU_TYPE_BREDRLE; \
-		user->io_id = 0; \
 		user->test_data = data; \
 		user->disable_esco = _disable_esco; \
-		tester_add_full(name, data, \
-				test_pre_setup, setup, func, NULL, \
-				test_post_teardown, 2, user, test_data_free); \
+		l_tester_add_full(tester, name, data, test_pre_setup, setup, \
+					func, NULL, test_post_teardown, 2, \
+					user, test_data_free); \
 	} while (0)
 
 #define test_sco(name, data, setup, func) \
@@ -238,26 +241,26 @@ static void client_connectable_complete(uint16_t opcode, uint8_t status,
 	if (opcode != BT_HCI_CMD_WRITE_SCAN_ENABLE)
 		return;
 
-	tester_print("Client set connectable status 0x%02x", status);
+	bttester_print("Client set connectable status 0x%02x", status);
 
 	if (status)
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 	else
-		tester_setup_complete();
+		l_tester_setup_complete(tester);
 }
 
 static void setup_powered_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct bthost *bthost;
 
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_print("Controller powered on");
+	bttester_print("Controller powered on");
 
 	bthost = hciemu_client_get_host(data->hciemu);
 	bthost_set_cmd_complete_cb(bthost, client_connectable_complete, data);
@@ -266,10 +269,10 @@ static void setup_powered_callback(uint8_t status, uint16_t length,
 
 static void setup_powered(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Powering on controller");
+	bttester_print("Powering on controller");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_CONNECTABLE, data->mgmt_index,
 					sizeof(param), param,
@@ -288,7 +291,7 @@ static void setup_powered(const void *test_data)
 
 static void test_framework(const void *test_data)
 {
-	tester_test_passed();
+	l_tester_test_passed(tester);
 }
 
 static void test_socket(const void *test_data)
@@ -297,15 +300,15 @@ static void test_socket(const void *test_data)
 
 	sk = socket(PF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_SCO);
 	if (sk < 0) {
-		tester_warn("Can't create socket: %s (%d)", strerror(errno),
+		bttester_warn("Can't create socket: %s (%d)", strerror(errno),
 									errno);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	close(sk);
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 }
 
 static void test_getsockopt(const void *test_data)
@@ -316,9 +319,9 @@ static void test_getsockopt(const void *test_data)
 
 	sk = socket(PF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_SCO);
 	if (sk < 0) {
-		tester_warn("Can't create socket: %s (%d)", strerror(errno),
+		bttester_warn("Can't create socket: %s (%d)", strerror(errno),
 									errno);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -327,19 +330,19 @@ static void test_getsockopt(const void *test_data)
 
 	err = getsockopt(sk, SOL_BLUETOOTH, BT_VOICE, &voice, &len);
 	if (err < 0) {
-		tester_warn("Can't get socket option : %s (%d)",
+		bttester_warn("Can't get socket option : %s (%d)",
 							strerror(errno), errno);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		goto end;
 	}
 
 	if (voice.setting != BT_VOICE_CVSD_16BIT) {
-		tester_warn("Invalid voice setting");
-		tester_test_failed();
+		bttester_warn("Invalid voice setting");
+		l_tester_test_failed(tester);
 		goto end;
 	}
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 
 end:
 	close(sk);
@@ -353,9 +356,9 @@ static void test_setsockopt(const void *test_data)
 
 	sk = socket(PF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_SCO);
 	if (sk < 0) {
-		tester_warn("Can't create socket: %s (%d)", strerror(errno),
+		bttester_warn("Can't create socket: %s (%d)", strerror(errno),
 									errno);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		goto end;
 	}
 
@@ -365,15 +368,15 @@ static void test_setsockopt(const void *test_data)
 
 	err = getsockopt(sk, SOL_BLUETOOTH, BT_VOICE, &voice, &len);
 	if (err < 0) {
-		tester_warn("Can't get socket option : %s (%d)",
+		bttester_warn("Can't get socket option : %s (%d)",
 							strerror(errno), errno);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		goto end;
 	}
 
 	if (voice.setting != BT_VOICE_CVSD_16BIT) {
-		tester_warn("Invalid voice setting");
-		tester_test_failed();
+		bttester_warn("Invalid voice setting");
+		l_tester_test_failed(tester);
 		goto end;
 	}
 
@@ -382,9 +385,9 @@ static void test_setsockopt(const void *test_data)
 
 	err = setsockopt(sk, SOL_BLUETOOTH, BT_VOICE, &voice, sizeof(voice));
 	if (err < 0) {
-		tester_warn("Can't set socket option : %s (%d)",
+		bttester_warn("Can't set socket option : %s (%d)",
 							strerror(errno), errno);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		goto end;
 	}
 
@@ -393,19 +396,19 @@ static void test_setsockopt(const void *test_data)
 
 	err = getsockopt(sk, SOL_BLUETOOTH, BT_VOICE, &voice, &len);
 	if (err < 0) {
-		tester_warn("Can't get socket option : %s (%d)",
+		bttester_warn("Can't get socket option : %s (%d)",
 							strerror(errno), errno);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		goto end;
 	}
 
 	if (voice.setting != BT_VOICE_TRANSPARENT) {
-		tester_warn("Invalid voice setting");
-		tester_test_failed();
+		bttester_warn("Invalid voice setting");
+		l_tester_test_failed(tester);
 		goto end;
 	}
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 
 end:
 	close(sk);
@@ -421,14 +424,14 @@ static int create_sco_sock(struct test_data *data)
 								BTPROTO_SCO);
 	if (sk < 0) {
 		err = -errno;
-		tester_warn("Can't create socket: %s (%d)", strerror(errno),
+		bttester_warn("Can't create socket: %s (%d)", strerror(errno),
 									errno);
 		return err;
 	}
 
 	master_bdaddr = hciemu_get_master_bdaddr(data->hciemu);
 	if (!master_bdaddr) {
-		tester_warn("No master bdaddr");
+		bttester_warn("No master bdaddr");
 		return -ENODEV;
 	}
 
@@ -438,7 +441,7 @@ static int create_sco_sock(struct test_data *data)
 
 	if (bind(sk, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
 		err = -errno;
-		tester_warn("Can't bind socket: %s (%d)", strerror(errno),
+		bttester_warn("Can't bind socket: %s (%d)", strerror(errno),
 									errno);
 		close(sk);
 		return err;
@@ -455,7 +458,7 @@ static int connect_sco_sock(struct test_data *data, int sk)
 
 	client_bdaddr = hciemu_get_client_bdaddr(data->hciemu);
 	if (!client_bdaddr) {
-		tester_warn("No client bdaddr");
+		bttester_warn("No client bdaddr");
 		return -ENODEV;
 	}
 
@@ -466,7 +469,7 @@ static int connect_sco_sock(struct test_data *data, int sk)
 	err = connect(sk, (struct sockaddr *) &addr, sizeof(addr));
 	if (err < 0 && !(errno == EAGAIN || errno == EINPROGRESS)) {
 		err = -errno;
-		tester_warn("Can't connect socket: %s (%d)", strerror(errno),
+		bttester_warn("Can't connect socket: %s (%d)", strerror(errno),
 									errno);
 		return err;
 	}
@@ -474,17 +477,14 @@ static int connect_sco_sock(struct test_data *data, int sk)
 	return 0;
 }
 
-static gboolean sco_connect_cb(GIOChannel *io, GIOCondition cond,
-							gpointer user_data)
+static bool sco_connect_cb(struct l_io *io, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct sco_client_data *scodata = data->test_data;
 	int err, sk_err, sk;
 	socklen_t len = sizeof(sk_err);
 
-	data->io_id = 0;
-
-	sk = g_io_channel_unix_get_fd(io);
+	sk = l_io_get_fd(io);
 
 	if (getsockopt(sk, SOL_SOCKET, SO_ERROR, &sk_err, &len) < 0)
 		err = -errno;
@@ -492,56 +492,53 @@ static gboolean sco_connect_cb(GIOChannel *io, GIOCondition cond,
 		err = -sk_err;
 
 	if (err < 0)
-		tester_warn("Connect failed: %s (%d)", strerror(-err), -err);
+		bttester_warn("Connect failed: %s (%d)", strerror(-err), -err);
 	else
-		tester_print("Successfully connected");
+		bttester_print("Successfully connected");
 
 	if (-err != scodata->expect_err)
-		tester_test_failed();
+		l_tester_test_failed(tester);
 	else
-		tester_test_passed();
+		l_tester_test_passed(tester);
 
-	return FALSE;
+	return false;
 }
 
 static void test_connect(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
-	GIOChannel *io;
+	struct test_data *data = l_tester_get_data(tester);
 	int sk;
 
 	sk = create_sco_sock(data);
 	if (sk < 0) {
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	if (connect_sco_sock(data, sk) < 0) {
 		close(sk);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
-	io = g_io_channel_unix_new(sk);
-	g_io_channel_set_close_on_unref(io, TRUE);
+	data->io = l_io_new(sk);
+	l_io_set_close_on_destroy(data->io, true);
 
-	data->io_id = g_io_add_watch(io, G_IO_OUT, sco_connect_cb, NULL);
+	l_io_set_write_handler(data->io, sco_connect_cb, NULL, NULL);
 
-	g_io_channel_unref(io);
-
-	tester_print("Connect in progress");
+	bttester_print("Connect in progress");
 }
 
 static void test_connect_transp(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct sco_client_data *scodata = data->test_data;
 	int sk, err;
 	struct bt_voice voice;
 
 	sk = create_sco_sock(data);
 	if (sk < 0) {
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -550,22 +547,22 @@ static void test_connect_transp(const void *test_data)
 
 	err = setsockopt(sk, SOL_BLUETOOTH, BT_VOICE, &voice, sizeof(voice));
 	if (err < 0) {
-		tester_warn("Can't set socket option : %s (%d)",
+		bttester_warn("Can't set socket option : %s (%d)",
 							strerror(errno), errno);
-		tester_test_failed();
+		l_tester_test_failed(tester);
 		goto end;
 	}
 
 	err = connect_sco_sock(data, sk);
 
-	tester_warn("Connect returned %s (%d), expected %s (%d)",
-			strerror(-err), -err,
-			strerror(scodata->expect_err), scodata->expect_err);
+	bttester_warn("Connect returned %s (%d), expected %s (%d)",
+								strerror(-err),
+		-err, strerror(scodata->expect_err), scodata->expect_err);
 
 	if (-err != scodata->expect_err)
-		tester_test_failed();
+		l_tester_test_failed(tester);
 	else
-		tester_test_passed();
+		l_tester_test_passed(tester);
 
 end:
 	close(sk);
@@ -573,7 +570,7 @@ end:
 
 int main(int argc, char *argv[])
 {
-	tester_init(&argc, &argv);
+	tester = bttester_init(&argc, &argv);
 
 	test_sco("Basic Framework - Success", NULL, setup_powered,
 							test_framework);
@@ -599,5 +596,5 @@ int main(int argc, char *argv[])
 	test_sco_11("SCO mSBC 1.1 - Failure", &connect_failure, setup_powered,
 							test_connect_transp);
 
-	return tester_run();
+	return bttester_run();
 }

--- a/tools/smp-tester.c
+++ b/tools/smp-tester.c
@@ -18,7 +18,7 @@
 #include <stdbool.h>
 #include <sys/socket.h>
 
-#include <glib.h>
+#include <ell/ell.h>
 
 #include "lib/bluetooth.h"
 #include "lib/hci.h"
@@ -30,7 +30,7 @@
 
 #include "src/shared/crypto.h"
 #include "src/shared/ecc.h"
-#include "src/shared/tester.h"
+#include "src/shared/bttester.h"
 #include "src/shared/mgmt.h"
 
 #define SMP_CID 0x0006
@@ -41,7 +41,6 @@ struct test_data {
 	uint16_t mgmt_index;
 	struct hciemu *hciemu;
 	enum hciemu_type hciemu_type;
-	unsigned int io_id;
 	uint8_t ia[6];
 	uint8_t ia_type;
 	uint8_t ra[6];
@@ -82,27 +81,29 @@ struct smp_data {
 	bool sc;
 };
 
+static struct l_tester *tester;
+
 static void print_debug(const char *str, void *user_data)
 {
 	const char *prefix = user_data;
 
-	tester_print("%s%s", prefix, str);
+	bttester_print("%s%s", prefix, str);
 }
 
 static void read_info_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct mgmt_rp_read_info *rp = param;
 	char addr[18];
 	uint16_t manufacturer;
 	uint32_t supported_settings, current_settings;
 
-	tester_print("Read Info callback");
-	tester_print("  Status: 0x%02x", status);
+	bttester_print("Read Info callback");
+	bttester_print("  Status: 0x%02x", status);
 
 	if (status || !param) {
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
@@ -111,31 +112,31 @@ static void read_info_callback(uint8_t status, uint16_t length,
 	supported_settings = btohl(rp->supported_settings);
 	current_settings = btohl(rp->current_settings);
 
-	tester_print("  Address: %s", addr);
-	tester_print("  Version: 0x%02x", rp->version);
-	tester_print("  Manufacturer: 0x%04x", manufacturer);
-	tester_print("  Supported settings: 0x%08x", supported_settings);
-	tester_print("  Current settings: 0x%08x", current_settings);
-	tester_print("  Class: 0x%02x%02x%02x",
+	bttester_print("  Address: %s", addr);
+	bttester_print("  Version: 0x%02x", rp->version);
+	bttester_print("  Manufacturer: 0x%04x", manufacturer);
+	bttester_print("  Supported settings: 0x%08x", supported_settings);
+	bttester_print("  Current settings: 0x%08x", current_settings);
+	bttester_print("  Class: 0x%02x%02x%02x",
 			rp->dev_class[2], rp->dev_class[1], rp->dev_class[0]);
-	tester_print("  Name: %s", rp->name);
-	tester_print("  Short name: %s", rp->short_name);
+	bttester_print("  Name: %s", rp->name);
+	bttester_print("  Short name: %s", rp->short_name);
 
 	if (strcmp(hciemu_get_address(data->hciemu), addr)) {
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
-	tester_pre_setup_complete();
+	l_tester_pre_setup_complete(tester);
 }
 
 static void index_added_callback(uint16_t index, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Index Added callback");
-	tester_print("  Index: 0x%04x", index);
+	bttester_print("Index Added callback");
+	bttester_print("  Index: 0x%04x", index);
 
 	data->mgmt_index = index;
 
@@ -146,10 +147,10 @@ static void index_added_callback(uint16_t index, uint16_t length,
 static void index_removed_callback(uint16_t index, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Index Removed callback");
-	tester_print("  Index: 0x%04x", index);
+	bttester_print("Index Removed callback");
+	bttester_print("  Index: 0x%04x", index);
 
 	if (index != data->mgmt_index)
 		return;
@@ -159,19 +160,19 @@ static void index_removed_callback(uint16_t index, uint16_t length,
 	mgmt_unref(data->mgmt);
 	data->mgmt = NULL;
 
-	tester_post_teardown_complete();
+	l_tester_post_teardown_complete(tester);
 }
 
 static void read_index_list_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Read Index List callback");
-	tester_print("  Status: 0x%02x", status);
+	bttester_print("Read Index List callback");
+	bttester_print("  Status: 0x%02x", status);
 
 	if (status || !param) {
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
@@ -183,36 +184,36 @@ static void read_index_list_callback(uint8_t status, uint16_t length,
 
 	data->hciemu = hciemu_new(data->hciemu_type);
 	if (!data->hciemu) {
-		tester_warn("Failed to setup HCI emulation");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to setup HCI emulation");
+		l_tester_pre_setup_failed(tester);
 	}
 
-	if (tester_use_debug())
+	if (bttester_use_debug())
 		hciemu_set_debug(data->hciemu, print_debug, "hciemu: ", NULL);
 
-	tester_print("New hciemu instance created");
+	bttester_print("New hciemu instance created");
 }
 
 static void test_pre_setup(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
 	data->crypto = bt_crypto_new();
 	if (!data->crypto) {
-		tester_warn("Failed to setup crypto");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to setup crypto");
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
 	data->mgmt = mgmt_new_default();
 	if (!data->mgmt) {
-		tester_warn("Failed to setup management interface");
+		bttester_warn("Failed to setup management interface");
 		bt_crypto_unref(data->crypto);
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
-	if (tester_use_debug())
+	if (bttester_use_debug())
 		mgmt_set_debug(data->mgmt, print_debug, "mgmt: ", NULL);
 
 	mgmt_send(data->mgmt, MGMT_OP_READ_INDEX_LIST, MGMT_INDEX_NONE, 0, NULL,
@@ -221,12 +222,7 @@ static void test_pre_setup(const void *test_data)
 
 static void test_post_teardown(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
-
-	if (data->io_id > 0) {
-		g_source_remove(data->io_id);
-		data->io_id = 0;
-	}
+	struct test_data *data = l_tester_get_data(tester);
 
 	if (data->crypto) {
 		bt_crypto_unref(data->crypto);
@@ -237,44 +233,38 @@ static void test_post_teardown(const void *test_data)
 	data->hciemu = NULL;
 }
 
-static void test_data_free(void *test_data)
-{
-	struct test_data *data = test_data;
-
-	free(data);
-}
-
 static void test_add_condition(struct test_data *data)
 {
 	data->unmet_conditions++;
 
-	tester_print("Test condition added, total %d", data->unmet_conditions);
+	bttester_print("Test condition added, total %d",
+						data->unmet_conditions);
 }
 
 static void test_condition_complete(struct test_data *data)
 {
 	data->unmet_conditions--;
 
-	tester_print("Test condition complete, %d left",
+	bttester_print("Test condition complete, %d left",
 						data->unmet_conditions);
 
 	if (data->unmet_conditions > 0)
 		return;
 
-	tester_test_passed();
+	l_tester_test_passed(tester);
 }
 
 #define test_smp(name, data, setup, func) \
 	do { \
 		struct test_data *user; \
-		user = calloc(1, sizeof(struct test_data)); \
+		user = l_new(struct test_data, 1);	\
 		if (!user) \
 			break; \
 		user->hciemu_type = HCIEMU_TYPE_BREDRLE; \
 		user->test_data = data; \
-		tester_add_full(name, data, \
+		l_tester_add_full(tester, name, data, \
 				test_pre_setup, setup, func, NULL, \
-				test_post_teardown, 2, user, test_data_free); \
+				test_post_teardown, 2, user, l_free); \
 	} while (0)
 
 static const uint8_t smp_nval_req_1[] = { 0x0b, 0x00 };
@@ -287,7 +277,7 @@ static const struct smp_req_rsp nval_req_1[] = {
 
 static const struct smp_data smp_server_nval_req_1_test = {
 	.req = nval_req_1,
-	.req_count = G_N_ELEMENTS(nval_req_1),
+	.req_count = L_ARRAY_SIZE(nval_req_1),
 };
 
 static const uint8_t smp_nval_req_2[7] = { 0x01 };
@@ -300,7 +290,7 @@ static const struct smp_req_rsp srv_nval_req_1[] = {
 
 static const struct smp_data smp_server_nval_req_2_test = {
 	.req = srv_nval_req_1,
-	.req_count = G_N_ELEMENTS(srv_nval_req_1),
+	.req_count = L_ARRAY_SIZE(srv_nval_req_1),
 };
 
 static const uint8_t smp_nval_req_3[] = { 0x01, 0xff };
@@ -313,7 +303,7 @@ static const struct smp_req_rsp srv_nval_req_2[] = {
 
 static const struct smp_data smp_server_nval_req_3_test = {
 	.req = srv_nval_req_2,
-	.req_count = G_N_ELEMENTS(srv_nval_req_2),
+	.req_count = L_ARRAY_SIZE(srv_nval_req_2),
 };
 
 static const uint8_t smp_basic_req_1[] = {	0x01,	/* Pairing Request */
@@ -347,7 +337,7 @@ static const struct smp_req_rsp srv_basic_req_1[] = {
 
 static const struct smp_data smp_server_basic_req_1_test = {
 	.req = srv_basic_req_1,
-	.req_count = G_N_ELEMENTS(srv_basic_req_1),
+	.req_count = L_ARRAY_SIZE(srv_basic_req_1),
 };
 
 static const struct smp_req_rsp cli_basic_req_1[] = {
@@ -361,7 +351,7 @@ static const struct smp_req_rsp cli_basic_req_1[] = {
 
 static const struct smp_data smp_client_basic_req_1_test = {
 	.req = cli_basic_req_1,
-	.req_count = G_N_ELEMENTS(cli_basic_req_1),
+	.req_count = L_ARRAY_SIZE(cli_basic_req_1),
 };
 
 static const uint8_t smp_basic_req_2[] = {	0x01,	/* Pairing Request */
@@ -384,7 +374,7 @@ static const struct smp_req_rsp cli_basic_req_2[] = {
 
 static const struct smp_data smp_client_basic_req_2_test = {
 	.req = cli_basic_req_2,
-	.req_count = G_N_ELEMENTS(cli_basic_req_1),
+	.req_count = L_ARRAY_SIZE(cli_basic_req_1),
 	.mitm = true,
 };
 
@@ -393,7 +383,7 @@ static void user_confirm_request_callback(uint16_t index, uint16_t length,
 							void *user_data)
 {
 	const struct mgmt_ev_user_confirm_request *ev = param;
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct mgmt_cp_user_confirm_reply cp;
 
 	memset(&cp, 0, sizeof(cp));
@@ -423,7 +413,7 @@ static const struct smp_req_rsp cli_sc_req_1[] = {
 
 static const struct smp_data smp_client_sc_req_1_test = {
 	.req = cli_sc_req_1,
-	.req_count = G_N_ELEMENTS(cli_sc_req_1),
+	.req_count = L_ARRAY_SIZE(cli_sc_req_1),
 	.sc = true,
 };
 
@@ -449,7 +439,7 @@ static const struct smp_req_rsp cli_sc_req_2[] = {
 
 static const struct smp_data smp_client_sc_req_2_test = {
 	.req = cli_sc_req_2,
-	.req_count = G_N_ELEMENTS(cli_sc_req_2),
+	.req_count = L_ARRAY_SIZE(cli_sc_req_2),
 	.sc = true,
 };
 
@@ -460,26 +450,26 @@ static void client_connectable_complete(uint16_t opcode, uint8_t status,
 	if (opcode != BT_HCI_CMD_LE_SET_ADV_ENABLE)
 		return;
 
-	tester_print("Client set connectable status 0x%02x", status);
+	bttester_print("Client set connectable status 0x%02x", status);
 
 	if (status)
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 	else
-		tester_setup_complete();
+		l_tester_setup_complete(tester);
 }
 
 static void setup_powered_client_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct bthost *bthost;
 
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_print("Controller powered on");
+	bttester_print("Controller powered on");
 
 	bthost = hciemu_client_get_host(data->hciemu);
 	bthost_set_cmd_complete_cb(bthost, client_connectable_complete, data);
@@ -489,15 +479,15 @@ static void setup_powered_client_callback(uint8_t status, uint16_t length,
 static void make_pk(struct test_data *data)
 {
 	if (!ecc_make_key(data->local_pk, data->local_sk)) {
-		tester_print("Failed to general local ECDH keypair");
-		tester_setup_failed();
+		bttester_print("Failed to general local ECDH keypair");
+		l_tester_setup_failed(tester);
 		return;
 	}
 }
 
 static void setup_powered_client(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct smp_data *smp = data->test_data;
 	unsigned char param[] = { 0x01 };
 
@@ -505,7 +495,7 @@ static void setup_powered_client(const void *test_data)
 			data->mgmt_index, user_confirm_request_callback,
 			data, NULL);
 
-	tester_print("Powering on controller");
+	bttester_print("Powering on controller");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_LE, data->mgmt_index,
 				sizeof(param), param, NULL, NULL, NULL);
@@ -529,16 +519,16 @@ static void pair_device_complete(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_warn("Pairing failed: %s", mgmt_errstr(status));
+		bttester_warn("Pairing failed: %s", mgmt_errstr(status));
 		return;
 	}
 
-	tester_print("Pairing succeedded");
+	bttester_print("Pairing succeedded");
 }
 
 static const void *get_pdu(const uint8_t *pdu)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct smp_data *smp = data->test_data;
 	uint8_t opcode = pdu[0];
 	static uint8_t buf[65];
@@ -579,7 +569,7 @@ static const void *get_pdu(const uint8_t *pdu)
 
 static bool verify_random(const uint8_t rnd[16])
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	uint8_t confirm[16];
 
 	if (!bt_crypto_c1(data->crypto, data->tk, data->rrnd, data->prsp,
@@ -588,7 +578,7 @@ static bool verify_random(const uint8_t rnd[16])
 		return false;
 
 	if (memcmp(data->pcnf, confirm, sizeof(data->pcnf)) != 0) {
-		tester_warn("Confirmation values don't match");
+		bttester_warn("Confirmation values don't match");
 		return false;
 	}
 
@@ -620,13 +610,13 @@ static void smp_server(const void *data, uint16_t len, void *user_data)
 	const void *pdu;
 
 	if (len < 1) {
-		tester_warn("Received too small SMP PDU");
+		bttester_warn("Received too small SMP PDU");
 		goto failed;
 	}
 
 	opcode = *((const uint8_t *) data);
 
-	tester_print("Received SMP opcode 0x%02x", opcode);
+	bttester_print("Received SMP opcode 0x%02x", opcode);
 
 	if (test_data->counter >= smp->req_count) {
 		test_condition_complete(test_data);
@@ -638,7 +628,7 @@ static void smp_server(const void *data, uint16_t len, void *user_data)
 		goto next;
 
 	if (req->expect_len != len) {
-		tester_warn("Unexpected SMP PDU length (%u != %u)",
+		bttester_warn("Unexpected SMP PDU length (%u != %u)",
 							len, req->expect_len);
 		goto failed;
 	}
@@ -673,7 +663,7 @@ static void smp_server(const void *data, uint16_t len, void *user_data)
 	}
 
 	if (memcmp(req->expect, data, len) != 0) {
-		tester_warn("Unexpected SMP PDU");
+		bttester_warn("Unexpected SMP PDU");
 		goto failed;
 	}
 
@@ -698,7 +688,7 @@ next:
 	return;
 
 failed:
-	tester_test_failed();
+	l_tester_test_failed(tester);
 }
 
 static void command_hci_callback(uint16_t opcode, const void *param,
@@ -709,7 +699,7 @@ static void command_hci_callback(uint16_t opcode, const void *param,
 	const void *expect_hci_param = smp->expect_hci_param;
 	uint8_t expect_hci_len = smp->expect_hci_len;
 
-	tester_print("HCI Command 0x%04x length %u", opcode, length);
+	bttester_print("HCI Command 0x%04x length %u", opcode, length);
 
 	if (opcode != smp->expect_hci_command)
 		return;
@@ -718,14 +708,14 @@ static void command_hci_callback(uint16_t opcode, const void *param,
 		expect_hci_param = smp->expect_hci_func(&expect_hci_len);
 
 	if (length != expect_hci_len) {
-		tester_warn("Invalid parameter size for HCI command");
-		tester_test_failed();
+		bttester_warn("Invalid parameter size for HCI command");
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	if (memcmp(param, expect_hci_param, length) != 0) {
-		tester_warn("Unexpected HCI command parameter value");
-		tester_test_failed();
+		bttester_warn("Unexpected HCI command parameter value");
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -740,7 +730,7 @@ static void smp_new_conn(uint16_t handle, void *user_data)
 	const struct smp_req_rsp *req;
 	const void *pdu;
 
-	tester_print("New SMP client connection with handle 0x%04x", handle);
+	bttester_print("New SMP client connection with handle 0x%04x", handle);
 
 	data->handle = handle;
 
@@ -754,7 +744,7 @@ static void smp_new_conn(uint16_t handle, void *user_data)
 	if (!req->send)
 		return;
 
-	tester_print("Sending SMP PDU");
+	bttester_print("Sending SMP PDU");
 
 	pdu = get_pdu(req->send);
 	bthost_send_cid(bthost, handle, SMP_CID, pdu, req->send_len);
@@ -769,15 +759,15 @@ static void init_bdaddr(struct test_data *data)
 
 	master_bdaddr = hciemu_get_master_bdaddr(data->hciemu);
 	if (!master_bdaddr) {
-		tester_warn("No master bdaddr");
-		tester_test_failed();
+		bttester_warn("No master bdaddr");
+		l_tester_test_failed(tester);
 		return;
 	}
 
 	client_bdaddr = hciemu_get_client_bdaddr(data->hciemu);
 	if (!client_bdaddr) {
-		tester_warn("No client bdaddr");
-		tester_test_failed();
+		bttester_warn("No client bdaddr");
+		l_tester_test_failed(tester);
 		return;
 	}
 
@@ -795,7 +785,7 @@ static void init_bdaddr(struct test_data *data)
 
 static void test_client(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct smp_data *smp = data->test_data;
 	struct mgmt_cp_pair_device cp;
 	struct bthost *bthost;
@@ -807,7 +797,7 @@ static void test_client(const void *test_data)
 	test_add_condition(data);
 
 	if (smp->expect_hci_command) {
-		tester_print("Registering HCI command callback");
+		bttester_print("Registering HCI command callback");
 		hciemu_add_master_post_command_hook(data->hciemu,
 						command_hci_callback, data);
 		test_add_condition(data);
@@ -823,25 +813,25 @@ static void test_client(const void *test_data)
 	mgmt_send(data->mgmt, MGMT_OP_PAIR_DEVICE, data->mgmt_index,
 			sizeof(cp), &cp, pair_device_complete, NULL, NULL);
 
-	tester_print("Pairing in progress");
+	bttester_print("Pairing in progress");
 }
 
 static void setup_powered_server_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_print("Controller powered on");
+	bttester_print("Controller powered on");
 
-	tester_setup_complete();
+	l_tester_setup_complete(tester);
 }
 
 static void setup_powered_server(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct smp_data *smp = data->test_data;
 	unsigned char param[] = { 0x01 };
 
@@ -849,7 +839,7 @@ static void setup_powered_server(const void *test_data)
 			data->mgmt_index, user_confirm_request_callback,
 			data, NULL);
 
-	tester_print("Powering on controller");
+	bttester_print("Powering on controller");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_LE, data->mgmt_index,
 				sizeof(param), param, NULL, NULL, NULL);
@@ -873,7 +863,7 @@ static void setup_powered_server(const void *test_data)
 
 static void test_server(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct smp_data *smp = data->test_data;
 	struct bthost *bthost;
 
@@ -888,7 +878,7 @@ static void test_server(const void *test_data)
 	bthost_hci_connect(bthost, data->ra, BDADDR_LE_PUBLIC);
 
 	if (smp->expect_hci_command) {
-		tester_print("Registering HCI command callback");
+		bttester_print("Registering HCI command callback");
 		hciemu_add_master_post_command_hook(data->hciemu,
 						command_hci_callback, data);
 		test_add_condition(data);
@@ -897,7 +887,7 @@ static void test_server(const void *test_data)
 
 int main(int argc, char *argv[])
 {
-	tester_init(&argc, &argv);
+	tester = bttester_init(&argc, &argv);
 
 	test_smp("SMP Server - Basic Request 1",
 					&smp_server_basic_req_1_test,
@@ -926,5 +916,5 @@ int main(int argc, char *argv[])
 					&smp_client_sc_req_2_test,
 					setup_powered_client, test_client);
 
-	return tester_run();
+	return bttester_run();
 }

--- a/tools/userchan-tester.c
+++ b/tools/userchan-tester.c
@@ -12,26 +12,18 @@
 #include <config.h>
 #endif
 
-#include <stdlib.h>
-#include <stdint.h>
-#include <unistd.h>
-#include <errno.h>
-#include <stdbool.h>
-
-#include <glib.h>
+#include <ell/ell.h>
 
 #include "lib/bluetooth.h"
 #include "lib/hci.h"
 #include "lib/mgmt.h"
 
-#include "monitor/bt.h"
 #include "emulator/bthost.h"
 #include "emulator/hciemu.h"
 
-#include "src/shared/tester.h"
+#include "src/shared/bttester.h"
 #include "src/shared/mgmt.h"
 #include "src/shared/hci.h"
-#include "src/shared/util.h"
 
 struct test_data {
 	struct mgmt *mgmt;
@@ -42,27 +34,29 @@ struct test_data {
 	unsigned int remove_id;
 };
 
+static struct l_tester *tester;
+
 static void mgmt_debug(const char *str, void *user_data)
 {
 	const char *prefix = user_data;
 
-	tester_print("%s%s", prefix, str);
+	bttester_print("%s%s", prefix, str);
 }
 
 static void read_info_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	const struct mgmt_rp_read_info *rp = param;
 	char addr[18];
 	uint16_t manufacturer;
 	uint32_t supported_settings, current_settings;
 
-	tester_print("Read Info callback");
-	tester_print("  Status: 0x%02x", status);
+	bttester_print("Read Info callback");
+	bttester_print("  Status: 0x%02x", status);
 
 	if (status || !param) {
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
@@ -71,31 +65,29 @@ static void read_info_callback(uint8_t status, uint16_t length,
 	supported_settings = btohl(rp->supported_settings);
 	current_settings = btohl(rp->current_settings);
 
-	tester_print("  Address: %s", addr);
-	tester_print("  Version: 0x%02x", rp->version);
-	tester_print("  Manufacturer: 0x%04x", manufacturer);
-	tester_print("  Supported settings: 0x%08x", supported_settings);
-	tester_print("  Current settings: 0x%08x", current_settings);
-	tester_print("  Class: 0x%02x%02x%02x",
+	bttester_print("  Address: %s", addr);
+	bttester_print("  Version: 0x%02x", rp->version);
+	bttester_print("  Manufacturer: 0x%04x", manufacturer);
+	bttester_print("  Supported settings: 0x%08x", supported_settings);
+	bttester_print("  Current settings: 0x%08x", current_settings);
+	bttester_print("  Class: 0x%02x%02x%02x",
 			rp->dev_class[2], rp->dev_class[1], rp->dev_class[0]);
-	tester_print("  Name: %s", rp->name);
-	tester_print("  Short name: %s", rp->short_name);
+	bttester_print("  Name: %s", rp->name);
+	bttester_print("  Short name: %s", rp->short_name);
 
-	if (strcmp(hciemu_get_address(data->hciemu), addr)) {
-		tester_pre_setup_failed();
-		return;
-	}
-
-	tester_pre_setup_complete();
+	if (strcmp(hciemu_get_address(data->hciemu), addr))
+		l_tester_pre_setup_failed(tester);
+	else
+		l_tester_pre_setup_complete(tester);
 }
 
 static void index_added_callback(uint16_t index, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Index Added callback");
-	tester_print("  Index: 0x%04x", index);
+	bttester_print("Index Added callback");
+	bttester_print("  Index: 0x%04x", index);
 
 	if (data->mgmt_index != MGMT_INDEX_NONE)
 		return;
@@ -109,10 +101,10 @@ static void index_added_callback(uint16_t index, uint16_t length,
 static void index_removed_callback(uint16_t index, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Index Removed callback");
-	tester_print("  Index: 0x%04x", index);
+	bttester_print("Index Removed callback");
+	bttester_print("  Index: 0x%04x", index);
 
 	if (index != data->mgmt_index)
 		return;
@@ -120,7 +112,7 @@ static void index_removed_callback(uint16_t index, uint16_t length,
 	if (data->remove_id) {
 		mgmt_unregister(data->mgmt, data->remove_id);
 		data->remove_id = 0;
-		tester_test_passed();
+		l_tester_test_passed(tester);
 		return;
 	}
 
@@ -129,19 +121,19 @@ static void index_removed_callback(uint16_t index, uint16_t length,
 	mgmt_unref(data->mgmt);
 	data->mgmt = NULL;
 
-	tester_post_teardown_complete();
+	l_tester_post_teardown_complete(tester);
 }
 
 static void read_index_list_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
-	tester_print("Read Index List callback");
-	tester_print("  Status: 0x%02x", status);
+	bttester_print("Read Index List callback");
+	bttester_print("  Status: 0x%02x", status);
 
 	if (status || !param) {
-		tester_pre_setup_failed();
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
@@ -150,25 +142,25 @@ static void read_index_list_callback(uint8_t status, uint16_t length,
 
 	data->hciemu = hciemu_new(data->hciemu_type);
 	if (!data->hciemu) {
-		tester_warn("Failed to setup HCI emulation");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to setup HCI emulation");
+		l_tester_pre_setup_failed(tester);
 	}
 
-	tester_print("New hciemu instance created");
+	bttester_print("New hciemu instance created");
 }
 
 static void test_pre_setup(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
 	data->mgmt = mgmt_new_default();
 	if (!data->mgmt) {
-		tester_warn("Failed to setup management interface");
-		tester_pre_setup_failed();
+		bttester_warn("Failed to setup management interface");
+		l_tester_pre_setup_failed(tester);
 		return;
 	}
 
-	if (tester_use_debug())
+	if (bttester_use_debug())
 		mgmt_set_debug(data->mgmt, mgmt_debug, "mgmt: ", NULL);
 
 	mgmt_send(data->mgmt, MGMT_OP_READ_INDEX_LIST, MGMT_INDEX_NONE, 0, NULL,
@@ -177,7 +169,7 @@ static void test_pre_setup(const void *test_data)
 
 static void test_post_teardown(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 
 	mgmt_register(data->mgmt, MGMT_EV_INDEX_REMOVED, data->mgmt_index,
 					index_removed_callback,
@@ -187,32 +179,25 @@ static void test_post_teardown(const void *test_data)
 	data->hciemu = NULL;
 }
 
-static void test_data_free(void *test_data)
-{
-	struct test_data *data = test_data;
-
-	free(data);
-}
-
 static void setup_powered_client_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_print("Controller powered on");
+	bttester_print("Controller powered on");
 
-	tester_setup_complete();
+	l_tester_setup_complete(tester);
 }
 
 static void setup_powered(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	unsigned char param[] = { 0x01 };
 
-	tester_print("Powering on controller");
+	bttester_print("Powering on controller");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_POWERED, data->mgmt_index,
 			sizeof(param), param, setup_powered_client_callback,
@@ -224,39 +209,39 @@ static void toggle_powered(const void *test_data);
 static void toggle_powered_client_callback(uint8_t status, uint16_t length,
 					const void *param, void *user_data)
 {
-	bool power = PTR_TO_INT(user_data);
+	uint32_t power = L_PTR_TO_UINT(user_data);
 
 	if (status != MGMT_STATUS_SUCCESS) {
-		tester_setup_failed();
+		l_tester_setup_failed(tester);
 		return;
 	}
 
-	tester_print("Controller powered %s", power ? "on" : "off");
+	bttester_print("Controller powered %s", power ? "on" : "off");
 
 	if (power)
 		toggle_powered(false);
 	else
-		tester_setup_complete();
+		l_tester_setup_complete(tester);
 }
 
 static void toggle_powered(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
-	bool power = PTR_TO_INT(test_data);
+	struct test_data *data = l_tester_get_data(tester);
+	uint32_t power = L_PTR_TO_UINT(test_data);
 	unsigned char param[1];
 
-	param[0] = power ? 0x01 : 0x00;
+	param[0] = power;
 
-	tester_print("Powering %s controller", power ? "on" : "off");
+	bttester_print("Powering %s controller", power != 0 ? "on" : "off");
 
 	mgmt_send(data->mgmt, MGMT_OP_SET_POWERED, data->mgmt_index,
 			sizeof(param), param, toggle_powered_client_callback,
-			INT_TO_PTR(power), NULL);
+			L_UINT_TO_PTR(power), NULL);
 }
 
 static void test_open_success(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct bt_hci *hci;
 
 	data->remove_id = mgmt_register(data->mgmt, MGMT_EV_INDEX_REMOVED,
@@ -273,49 +258,49 @@ static void test_open_success(const void *test_data)
 	mgmt_unregister(data->mgmt, data->remove_id);
 	data->remove_id = 0;
 
-	tester_test_failed();
+	l_tester_test_failed(tester);
 }
 
 static void test_open_failed(const void *test_data)
 {
-	struct test_data *data = tester_get_data();
+	struct test_data *data = l_tester_get_data(tester);
 	struct bt_hci *hci;
 
 	hci = bt_hci_new_user_channel(data->mgmt_index);
 	if (!hci) {
-		tester_test_passed();
+		l_tester_test_passed(tester);
 		return;
 	}
 
 	bt_hci_unref(hci);
-	tester_test_failed();
+	l_tester_test_failed(tester);
 }
 
 #define test_user(name, data, setup, func) \
 	do { \
 		struct test_data *user; \
-		user = malloc(sizeof(struct test_data)); \
+		user = l_malloc(sizeof(struct test_data)); \
 		if (!user) \
 			break; \
 		user->hciemu_type = HCIEMU_TYPE_BREDR; \
 		user->mgmt_index = MGMT_INDEX_NONE; \
 		user->test_data = data; \
 		user->remove_id = 0; \
-		tester_add_full(name, data, \
-				test_pre_setup, setup, func, NULL, \
-				test_post_teardown, 2, user, test_data_free); \
+		l_tester_add_full(tester, name, data, test_pre_setup, setup, \
+					func, NULL, test_post_teardown, 2,\
+					user, l_free); \
 	} while (0)
 
 int main(int argc, char *argv[])
 {
-	tester_init(&argc, &argv);
+	tester = bttester_init(&argc, &argv);
 
 	test_user("User channel open - Success", NULL,
 					NULL, test_open_success);
 	test_user("User channel open - Failed", NULL,
 					setup_powered, test_open_failed);
-	test_user("User channel open - Power Toggle Success", INT_TO_PTR(true),
-					toggle_powered, test_open_success);
+	test_user("User channel open - Power Toggle Success",
+			L_UINT_TO_PTR(0x1), toggle_powered, test_open_success);
 
-	return tester_run();
+	return bttester_run();
 }


### PR DESCRIPTION

v2: Fix build error with external ELL

************
This patch set contains a proposed approach to convert noninteractive
tester tools to use ELL primitives removing GLib dependencies.

Two new files emulator/hciemu-ell.c and src/shared/bttester.c are
created as an intermediate step before removing their GLib-based counterparts
subject to the vetting/approval of this patch set.

Inga Stotland (11):
shared/bttester: tester framework wrapper to use ELL
emulator/hciemu: Create ELL based version of hciemu
tools/gap-tester: Convert to use ELL library
tools/sco-tester: Convert to use ELL library
tools/userchan-tester: Convert to use ELL library
tools/smp-tester: Convert to use ELL library
tools/bnep-tester: Convert to use ELL library
tools/l2cap-tester: Convert to use ELL library
tools/mgmt-tester: Convert to use ELL library
tools/rfcomm-tester: Convert to use ELL library
tools/hci-tester: Convert to use ELL library

Makefile.am             |   4 +-
Makefile.tools          |  36 +-
emulator/hciemu-ell.c   | 645 +++++++++++++++++++++++++++++++++++
src/shared/bttester.c   | 279 +++++++++++++++
src/shared/bttester.h   |  28 ++
