### PR TITLE
[PW_SID:480039] [Bluez,v1] core: Add RSSI sampling period in system parameter


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,26 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  code-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        path: src
+    - name: Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/src/adv_monitor.c
+++ b/src/adv_monitor.c
@@ -25,6 +25,7 @@
 #include "lib/mgmt.h"
 
 #include "adapter.h"
+#include "btd.h"
 #include "dbus-common.h"
 #include "device.h"
 #include "log.h"
@@ -49,7 +50,6 @@
 #define ADV_MONITOR_DEFAULT_HIGH_TIMEOUT 10	/* second */
 #define ADV_MONITOR_UNSET_SAMPLING_PERIOD 256	/* 100 ms */
 #define ADV_MONITOR_MAX_SAMPLING_PERIOD	255	/* 100 ms */
-#define ADV_MONITOR_DEFAULT_SAMPLING_PERIOD 0	/* 100 ms */
 
 struct btd_adv_monitor_manager {
 	struct btd_adapter *adapter;
@@ -831,7 +831,7 @@ static bool parse_rssi_and_timeout(struct adv_monitor *monitor,
 		h_rssi_timeout = ADV_MONITOR_DEFAULT_HIGH_TIMEOUT;
 
 	if (sampling_period == ADV_MONITOR_UNSET_SAMPLING_PERIOD)
-		sampling_period = ADV_MONITOR_DEFAULT_SAMPLING_PERIOD;
+		sampling_period = btd_opts.advmon.rssi_sampling_period;
 
 	if (h_rssi < ADV_MONITOR_MIN_RSSI || h_rssi > ADV_MONITOR_MAX_RSSI ||
 		l_rssi < ADV_MONITOR_MIN_RSSI ||

--- a/src/btd.h
+++ b/src/btd.h
@@ -89,6 +89,10 @@ struct btd_avdtp_opts {
 	uint8_t  stream_mode;
 };
 
+struct btd_advmon_opts {
+	uint8_t		rssi_sampling_period;
+};
+
 struct btd_opts {
 	char		*name;
 	uint32_t	class;
@@ -122,6 +126,8 @@ struct btd_opts {
 	uint8_t		key_size;
 
 	enum jw_repairing_t jw_repairing;
+
+	struct btd_advmon_opts	advmon;
 };
 
 extern struct btd_opts btd_opts;

--- a/src/main.c
+++ b/src/main.c
@@ -145,6 +145,11 @@ static const char *avdtp_options[] = {
 	NULL
 };
 
+static const char *advmon_options[] = {
+	"RSSISamplingPeriod",
+	NULL
+};
+
 static const struct group_table {
 	const char *name;
 	const char **options;
@@ -155,6 +160,7 @@ static const struct group_table {
 	{ "Policy",	policy_options },
 	{ "GATT",	gatt_options },
 	{ "AVDTP",	avdtp_options },
+	{ "AdvMon",	advmon_options },
 	{ }
 };
 
@@ -793,6 +799,18 @@ static void parse_config(GKeyFile *config)
 		}
 	}
 
+	val = g_key_file_get_integer(config, "AdvMon", "RSSISamplingPeriod",
+									&err);
+	if (err) {
+		DBG("%s", err->message);
+		g_clear_error(&err);
+	} else {
+		val = MIN(val, 0xFF);
+		val = MAX(val, 0);
+		DBG("RSSISamplingPeriod=%d", val);
+		btd_opts.advmon.rssi_sampling_period = val;
+	}
+
 	parse_br_config(config);
 	parse_le_config(config);
 }
@@ -832,6 +850,8 @@ static void init_defaults(void)
 
 	btd_opts.avdtp.session_mode = BT_IO_MODE_BASIC;
 	btd_opts.avdtp.stream_mode = BT_IO_MODE_BASIC;
+
+	btd_opts.advmon.rssi_sampling_period = 0;
 }
 
 static void log_handler(const gchar *log_domain, GLogLevelFlags log_level,

--- a/src/main.conf
+++ b/src/main.conf
@@ -244,3 +244,9 @@
 # The value is in seconds.
 # Default: 2
 #ResumeDelay = 2
+
+[AdvMon]
+# Default RSSI Sampling Period. This is used when a client registers an
+# advertisement monitor and leaves the RSSISamplingPeriod unset.
+# Default: 0
+#RSSISamplingPeriod=0


### PR DESCRIPTION

From: Yun-Hao Chung <howardchung@chromium.org>

Add an option in main.conf to configure the default RSSI sampling
period for advertisement monitor.

Reviewed-by: apusaka@chromium.org
Reviewed-by: mmandlik@chromium.org
Reviewed-by: mcchou@chromium.org
