### PR TITLE
[PW_SID:480695] [BlueZ,v2,1/2] config: Show error if rst2man not found when manpages are enabled


### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -328,6 +328,9 @@ AC_ARG_ENABLE(manpages, AC_HELP_STRING([--enable-manpages],
 					[enable_manpages=${enableval}])
 if (test "${enable_manpages}" != "no"); then
 	AC_CHECK_PROGS(RST2MAN, [rst2man rst2man.py], "no")
+	if (test "${RST2MAN}" = "no" ); then
+		AC_MSG_ERROR([rst2man is required])
+	fi
 fi
 AM_CONDITIONAL(MANPAGES, test "${enable_manpages}" = "yes")
 AM_CONDITIONAL(RUN_RST2MAN, test "${enable_manpages}" = "yes" && test "${RST2MAN}" != "no")

--- a/configure.ac
+++ b/configure.ac
@@ -323,8 +323,8 @@ AC_ARG_ENABLE(datafiles, AC_HELP_STRING([--disable-datafiles],
 					[enable_datafiles=${enableval}])
 AM_CONDITIONAL(DATAFILES, test "${enable_datafiles}" != "no")
 
-AC_ARG_ENABLE(manpages, AC_HELP_STRING([--enable-manpages],
-			[enable building of manual pages]),
+AC_ARG_ENABLE(manpages, AC_HELP_STRING([--disable-manpages],
+			[disable building of manual pages]),
 					[enable_manpages=${enableval}])
 if (test "${enable_manpages}" != "no"); then
 	AC_CHECK_PROGS(RST2MAN, [rst2man rst2man.py], "no")
@@ -332,8 +332,8 @@ if (test "${enable_manpages}" != "no"); then
 		AC_MSG_ERROR([rst2man is required])
 	fi
 fi
-AM_CONDITIONAL(MANPAGES, test "${enable_manpages}" = "yes")
-AM_CONDITIONAL(RUN_RST2MAN, test "${enable_manpages}" = "yes" && test "${RST2MAN}" != "no")
+AM_CONDITIONAL(MANPAGES, test "${enable_manpages}" != "no")
+AM_CONDITIONAL(RUN_RST2MAN, test "${enable_manpages}" != "no" && test "${RST2MAN}" != "no")
 
 AC_ARG_ENABLE(testing, AC_HELP_STRING([--enable-testing],
 			[enable testing tools]),


### PR DESCRIPTION

From: Tedd Ho-Jeong An <tedd.an@intel.com>

This patch adds a check if the conversion tool is installed when the
manpages is enabled, and show error if it is not installed.
