### PR TITLE
[PW_SID:484525] [BlueZ,1/3] shared/util: Add bt_uuid128_to_str


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,26 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  code-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        path: src
+    - name: Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/monitor/packet.c
+++ b/monitor/packet.c
@@ -3282,18 +3282,13 @@ static void print_uuid128_list(const char *label, const void *data,
 {
 	uint8_t count = data_len / 16;
 	unsigned int i;
-	char uuidstr[MAX_LEN_UUID_STR];
 
 	print_field("%s: %u entr%s", label, count, count == 1 ? "y" : "ies");
 
 	for (i = 0; i < count; i++) {
 		const uint8_t *uuid = data + (i * 16);
 
-		sprintf(uuidstr, "%8.8x-%4.4x-%4.4x-%4.4x-%8.8x%4.4x",
-				get_le32(&uuid[12]), get_le16(&uuid[10]),
-				get_le16(&uuid[8]), get_le16(&uuid[6]),
-				get_le32(&uuid[2]), get_le16(&uuid[0]));
-		print_field("  %s (%s)", bt_uuidstr_to_str(uuidstr), uuidstr);
+		print_field("  %s", bt_uuid128_to_str(uuid));
 	}
 }
 
@@ -12006,16 +12001,6 @@ static void mgmt_print_name(const void *data)
 	print_field("Short name: %s", (char *) (data + 249));
 }
 
-static void mgmt_print_uuid(const void *data)
-{
-	const uint8_t *uuid = data;
-
-	print_field("UUID: %8.8x-%4.4x-%4.4x-%4.4x-%8.8x%4.4x",
-				get_le32(&uuid[12]), get_le16(&uuid[10]),
-				get_le16(&uuid[8]), get_le16(&uuid[6]),
-				get_le32(&uuid[2]), get_le16(&uuid[0]));
-}
-
 static void mgmt_print_io_capability(uint8_t capability)
 {
 	const char *str;
@@ -12261,7 +12246,7 @@ static void mgmt_print_exp_feature(const void *data)
 	uint32_t flags = get_le32(data + 16);
 	uint32_t mask;
 
-	mgmt_print_uuid(data);
+	print_field("UUID: %s", bt_uuid128_to_str(data));
 	print_field("Flags: 0x%8.8x", flags);
 
 	mask = print_bitfield(2, flags, mgmt_exp_feature_flags_table);
@@ -12457,7 +12442,7 @@ static void mgmt_add_uuid_cmd(const void *data, uint16_t size)
 {
 	uint8_t service_class = get_u8(data + 16);
 
-	mgmt_print_uuid(data);
+	print_field("UUID: %s", bt_uuid128_to_str(data));
 	print_field("Service class: 0x%2.2x", service_class);
 }
 
@@ -12468,7 +12453,7 @@ static void mgmt_add_uuid_rsp(const void *data, uint16_t size)
 
 static void mgmt_remove_uuid_cmd(const void *data, uint16_t size)
 {
-	mgmt_print_uuid(data);
+	print_field("UUID: %s", bt_uuid128_to_str(data));
 }
 
 static void mgmt_remove_uuid_rsp(const void *data, uint16_t size)
@@ -13092,7 +13077,7 @@ static void mgmt_start_service_discovery_cmd(const void *data, uint16_t size)
 	}
 
 	for (i = 0; i < num_uuids; i++)
-		mgmt_print_uuid(data + 4 + (i * 16));
+		print_field("UUID: %s", bt_uuid128_to_str(data + 4 + (i * 16)));
 }
 
 static void mgmt_start_service_discovery_rsp(const void *data, uint16_t size)
@@ -13352,7 +13337,7 @@ static void mgmt_set_exp_feature_cmd(const void *data, uint16_t size)
 {
 	uint8_t enable = get_u8(data + 16);
 
-	mgmt_print_uuid(data);
+	print_field("UUID: %s", bt_uuid128_to_str(data));
 	print_enable("Action", enable);
 }
 

--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -1042,6 +1042,18 @@ const char *bt_uuid32_to_str(uint32_t uuid)
 	return "Unknown";
 }
 
+const char *bt_uuid128_to_str(const uint8_t uuid[16])
+{
+	char uuidstr[37];
+
+	sprintf(uuidstr, "%8.8x-%4.4x-%4.4x-%4.4x-%8.8x%4.4x",
+				get_le32(&uuid[12]), get_le16(&uuid[10]),
+				get_le16(&uuid[8]), get_le16(&uuid[6]),
+				get_le32(&uuid[2]), get_le16(&uuid[0]));
+
+	return bt_uuidstr_to_str(uuidstr);
+}
+
 const char *bt_uuidstr_to_str(const char *uuid)
 {
 	uint32_t val;

--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -1019,6 +1019,12 @@ static const struct {
 	{ "6e400001-b5a3-f393-e0a9-e50e24dcca9e", "Nordic UART Service" },
 	{ "6e400002-b5a3-f393-e0a9-e50e24dcca9e", "Nordic UART TX"	},
 	{ "6e400003-b5a3-f393-e0a9-e50e24dcca9e", "Nordic UART RX"	},
+	/* BlueZ Experimental Features */
+	{ "d4992530-b9ec-469f-ab01-6c481c47da1c", "BlueZ Experimental Debug" },
+	{ "671b10b5-42c0-4696-9227-eb28d1b049d6",
+		"BlueZ Experimental Simultaneous Central and Peripheral" },
+	{ "15c0a148-c273-11ea-b3de-0242ac130004",
+		"BlueZ Experimental LL privacy" },
 	{ }
 };
 

--- a/src/shared/util.h
+++ b/src/shared/util.h
@@ -107,6 +107,7 @@ void util_clear_uid(unsigned int *bitmap, uint8_t id);
 
 const char *bt_uuid16_to_str(uint16_t uuid);
 const char *bt_uuid32_to_str(uint32_t uuid);
+const char *bt_uuid128_to_str(const uint8_t uuid[16]);
 const char *bt_uuidstr_to_str(const char *uuid);
 const char *bt_appear_to_str(uint16_t appearance);
 


### PR DESCRIPTION

From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This adds bt_uuid128_to_str which can be used to convert UUID 128 bit
binary format into string.
