### PR TITLE
[PW_SID:485351] [BlueZ] tools/mgmt-tester: Fix "Remove Ext Advertising" case


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,26 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  code-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        path: src
+    - name: Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/tools/mgmt-tester.c
+++ b/tools/mgmt-tester.c
@@ -6671,7 +6671,7 @@ static void command_hci_callback(uint16_t opcode, const void *param,
 
 	tester_print("HCI Command 0x%04x length %u", opcode, length);
 
-	if (opcode != test->expect_hci_command)
+	if (opcode != test->expect_hci_command || data->unmet_conditions <= 0)
 		return;
 
 	if (test->expect_hci_func)
@@ -7720,6 +7720,10 @@ static const char set_ext_adv_disable_param[] = {
 	0x00, 0x00,
 };
 
+static const char set_ext_adv_disable_param_1[] = {
+	0x00, 0x01, 0x01, 0x00, 0x00, 0x00
+};
+
 static const struct generic_data add_ext_advertising_timeout_expired = {
 	.expect_alt_ev = MGMT_EV_ADVERTISING_REMOVED,
 	.expect_alt_ev_param = advertising_instance1_param,
@@ -7747,8 +7751,8 @@ static const struct generic_data remove_ext_advertising_success_1 = {
 	.expect_alt_ev_param = advertising_instance1_param,
 	.expect_alt_ev_len = sizeof(advertising_instance1_param),
 	.expect_hci_command = BT_HCI_CMD_LE_SET_EXT_ADV_ENABLE,
-	.expect_hci_param = set_ext_adv_disable_param,
-	.expect_hci_len = sizeof(set_ext_adv_disable_param),
+	.expect_hci_param = set_ext_adv_disable_param_1,
+	.expect_hci_len = sizeof(set_ext_adv_disable_param_1),
 };
 
 static const struct generic_data remove_ext_advertising_success_2 = {


### PR DESCRIPTION

This fixes the expected behavior of the following test case:
"Remove Ext Advertising - Success 1", when the fail status
was erroneously overwritten with success:

<log snip>
New Advertising Removed event received
Test condition complete, 2 left
HCI Command 0x2039 length 6
Invalid parameter size for HCI command
Remove Ext Advertising - Success 1 - test failed
HCI Command 0x203c length 1
HCI Command 0x2039 length 2
Test condition complete, 1 left
Remove Advertising (0x003f): Success (0x00)
Test condition complete, 0 left
Remove Ext Advertising - Success 1 - test passed

The expected HCI command to disable extended advertisement for a
non-zero number of sets should contain the specified number the
advertising sets.
In this particular test case, number of sets is set to 1 and,
as a result, the expected HCI command should be:
"00      | 01             | 01 00 00 00"
disable | number of sets | set info

Also, to avoid false positives/negatives, skip exmination of HCI
commands after the test conditions are met.
