### PR TITLE
[PW_SID:494413] [BlueZ] shared/mgmt: Fix not processing request queue


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,26 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  code-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        path: src
+    - name: Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}


### PR DESCRIPTION

From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

If the kernel return an invalid opcode like bellow the request won't be
processed leading making it unusable:

@ MGMT Command: Read Advertising Features (0x003d) plen 0
{0x0001} [hci0] 14:25:11.096370
@ MGMT Event: Command Status (0x0002) plen 3
{0x0001} [hci0] 14:25:11.096373
Set Advertising (0x0029)
Status: Not Supported (0x0c)

In order to fix this attempts to remove the first request pending on the
given index:

= bluetoothd: src/advertising.c:read_adv_features_callback() Failed to
read advertising features: Not Supported (0x0c)
