### PR TITLE
[PW_SID:494447] [V2] shared/mgmt: Fix not processing request queue


### DIFF
--- a/src/shared/mgmt.c
+++ b/src/shared/mgmt.c
@@ -248,6 +248,17 @@ static void request_complete(struct mgmt *mgmt, uint8_t status,
 
 	request = queue_remove_if(mgmt->pending_list,
 					match_request_opcode_index, &match);
+	if (!request) {
+		util_debug(mgmt->debug_callback, mgmt->debug_data,
+				"Unable to find request for opcode 0x%04x",
+				opcode);
+
+		/* Attempt to remove with no opcode */
+		request = queue_remove_if(mgmt->pending_list,
+						match_request_index,
+						UINT_TO_PTR(index));
+	}
+
 	if (request) {
 		if (request->callback)
 			request->callback(status, length, param,


### PR DESCRIPTION

From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

If the kernel returns an invalid opcode like below the request won't
be processed making it unusable:

@ MGMT Command: Read Advertising Features (0x003d) plen 0
{0x0001} [hci0] 14:25:11.096370
@ MGMT Event: Command Status (0x0002) plen 3
{0x0001} [hci0] 14:25:11.096373
Set Advertising (0x0029)
Status: Not Supported (0x0c)

In order to fix this attempts to remove the first request pending on the
given index:

= bluetoothd: src/advertising.c:read_adv_features_callback() Failed to
read advertising features: Not Supported (0x0c)
