### PR TITLE
[PW_SID:502869] Detailed error code


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: CI
+      uses: tedd-an/action-ci@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.ACTION_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -1,0 +1,26 @@
+name: Code Scan
+
+on:
+  schedule:
+  - cron:  "10 7 * * FRI"
+
+jobs:
+  code-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        path: src
+    - name: Code Scan
+      uses: tedd-an/action-code-scan@dev
+      with:
+        src_path: src
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scan_report
+        path: scan_report.tar.gz
+

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,37 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron:  "15,45 * * * *"
+
+jobs:
+
+  manage_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Manage Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluez"
+        src_branch: "master"
+        dest_branch: "master"
+        workflow_branch: "workflow"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    needs: manage_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Patchwork to PR
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        base_branch: "workflow"
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/client/main.c
+++ b/client/main.c
@@ -1966,7 +1966,8 @@ static void connect_reply(DBusMessage *message, void *user_data)
 	dbus_error_init(&error);
 
 	if (dbus_set_error_from_message(&error, message) == TRUE) {
-		bt_shell_printf("Failed to connect: %s\n", error.name);
+		bt_shell_printf("Failed to connect: %s %s\n", error.name,
+				error.message);
 		dbus_error_free(&error);
 		return bt_shell_noninteractive_quit(EXIT_FAILURE);
 	}

--- a/src/error.c
+++ b/src/error.c
@@ -14,6 +14,7 @@
 #include <config.h>
 #endif
 
+#include <stdio.h>
 #include "gdbus/gdbus.h"
 
 #include "error.h"
@@ -26,6 +27,15 @@ DBusMessage *btd_error_invalid_args(DBusMessage *msg)
 
 DBusMessage *btd_error_invalid_args_str(DBusMessage *msg, const char *str)
 {
+	return g_dbus_create_error(msg, ERROR_INTERFACE ".InvalidArguments",
+					"%s", str);
+}
+
+DBusMessage *btd_error_invalid_args_err(DBusMessage *msg, uint16_t err)
+{
+	char str[16];
+
+	sprintf(str, "BtdError:0x%04X", err);
 	return g_dbus_create_error(msg, ERROR_INTERFACE ".InvalidArguments",
 					"%s", str);
 }
@@ -66,10 +76,28 @@ DBusMessage *btd_error_in_progress(DBusMessage *msg)
 					"In Progress");
 }
 
+DBusMessage *btd_error_in_progress_err(DBusMessage *msg, uint16_t err)
+{
+	char str[16];
+
+	sprintf(str, "BtdError:0x%04X", err);
+	return g_dbus_create_error(msg, ERROR_INTERFACE ".InProgress", "%s",
+					str);
+}
+
 DBusMessage *btd_error_not_available(DBusMessage *msg)
 {
 	return g_dbus_create_error(msg, ERROR_INTERFACE ".NotAvailable",
 					"Operation currently not available");
+}
+
+DBusMessage *btd_error_not_available_err(DBusMessage *msg, uint16_t err)
+{
+	char str[16];
+
+	sprintf(str, "BtdError:0x%04X", err);
+	return g_dbus_create_error(msg, ERROR_INTERFACE ".NotAvailable", "%s",
+					str);
 }
 
 DBusMessage *btd_error_does_not_exist(DBusMessage *msg)
@@ -108,8 +136,104 @@ DBusMessage *btd_error_not_ready(DBusMessage *msg)
 					"Resource Not Ready");
 }
 
+DBusMessage *btd_error_not_ready_err(DBusMessage *msg, uint16_t err)
+{
+	char str[16];
+
+	sprintf(str, "BtdError:0x%04X", err);
+	return g_dbus_create_error(msg, ERROR_INTERFACE ".NotReady", "%s", str);
+}
+
 DBusMessage *btd_error_failed(DBusMessage *msg, const char *str)
 {
 	return g_dbus_create_error(msg, ERROR_INTERFACE
 					".Failed", "%s", str);
+}
+
+DBusMessage *btd_error_failed_err(DBusMessage *msg, uint16_t err)
+{
+	char str[16];
+
+	sprintf(str, "BtdError:0x%04X", err);
+	return g_dbus_create_error(msg, ERROR_INTERFACE ".Failed", "%s", str);
+}
+
+uint16_t btd_error_bredr_conn_from_errno(int errno_code)
+{
+	switch (-errno_code) {
+	case EALREADY:
+	case EISCONN: // Fall through
+		return BTD_ERR_BREDR_CONN_ALREADY_CONNECTED;
+	case EHOSTDOWN:
+		return BTD_ERR_BREDR_CONN_PAGE_TIMEOUT;
+	case ENOPROTOOPT:
+		return BTD_ERR_BREDR_CONN_PROFILE_UNAVAILABLE;
+	case EIO:
+		return BTD_ERR_BREDR_CONN_CREATE_SOCKET;
+	case EINVAL:
+		return BTD_ERR_BREDR_CONN_INVALID_ARGUMENTS;
+	case EHOSTUNREACH:
+		return BTD_ERR_BREDR_CONN_ADAPTER_NOT_POWERED;
+	case EOPNOTSUPP:
+	case EPROTONOSUPPORT: // Fall through
+		return BTD_ERR_BREDR_CONN_NOT_SUPPORTED;
+	case EBADFD:
+		return BTD_ERR_BREDR_CONN_BAD_SOCKET;
+	case ENOMEM:
+		return BTD_ERR_BREDR_CONN_MEMORY_ALLOC;
+	case EBUSY:
+		return BTD_ERR_BREDR_CONN_BUSY;
+	case EMLINK:
+		return BTD_ERR_BREDR_CONN_SYNC_CONNECT_LIMIT;
+	case ETIMEDOUT:
+		return BTD_ERR_BREDR_CONN_TIMEOUT;
+	case ECONNREFUSED:
+		return BTD_ERR_BREDR_CONN_REFUSED;
+	case ECONNRESET:
+		return BTD_ERR_BREDR_CONN_TERM_BY_REMOTE;
+	case ECONNABORTED:
+		return BTD_ERR_BREDR_CONN_TERM_BY_LOCAL;
+	case EPROTO:
+		return BTD_ERR_BREDR_CONN_PROTO_ERROR;
+	default:
+		return BTD_ERR_BREDR_CONN_UNKNOWN;
+	}
+}
+
+uint16_t btd_error_le_conn_from_errno(int errno_code)
+{
+	switch (-errno_code) {
+	case EINVAL:
+		return BTD_ERR_LE_CONN_INVALID_ARGUMENTS;
+	case EHOSTUNREACH:
+		return BTD_ERR_LE_CONN_ADAPTER_NOT_POWERED;
+	case EOPNOTSUPP:
+	case EPROTONOSUPPORT: // Fall through
+		return BTD_ERR_LE_CONN_NOT_SUPPORTED;
+	case EALREADY:
+	case EISCONN: // Fall through
+		return BTD_ERR_LE_CONN_ALREADY_CONNECTED;
+	case EBADFD:
+		return BTD_ERR_LE_CONN_BAD_SOCKET;
+	case ENOMEM:
+		return BTD_ERR_LE_CONN_MEMORY_ALLOC;
+	case EBUSY:
+		return BTD_ERR_LE_CONN_BUSY;
+	case ECONNREFUSED:
+		return BTD_ERR_LE_CONN_REFUSED;
+	case EIO:
+		return BTD_ERR_LE_CONN_CREATE_SOCKET;
+	case ETIMEDOUT:
+		return BTD_ERR_LE_CONN_TIMEOUT;
+	case EMLINK:
+		return BTD_ERR_LE_CONN_SYNC_CONNECT_LIMIT;
+	case ECONNRESET:
+		return BTD_ERR_LE_CONN_TERM_BY_REMOTE;
+	case ECONNABORTED:
+		return BTD_ERR_LE_CONN_TERM_BY_LOCAL;
+	case EPROTO:
+		return BTD_ERR_LE_CONN_PROTO_ERROR;
+	default:
+		return BTD_ERR_LE_CONN_UNKNOWN;
+	}
 }

--- a/src/error.h
+++ b/src/error.h
@@ -11,22 +11,193 @@
  */
 
 #include <dbus/dbus.h>
+#include <stdint.h>
 
 #define ERROR_INTERFACE "org.bluez.Error"
 
+/* BR/EDR connection failure reasons
+ * BT_ERR_* should be used as one of the parameters to btd_error_*_err().
+ */
+
+/* Either the profile is already connected or ACL connection is in
+ * place.
+ * errno: EALREADY, EISCONN
+ */
+#define BTD_ERR_BREDR_CONN_ALREADY_CONNECTED	0x0001
+/* Failed due to page timeout.
+ * errno: EHOSTDOWN
+ */
+#define BTD_ERR_BREDR_CONN_PAGE_TIMEOUT		0x0002
+/* Failed to find connectable services or the target service.
+ * errno: ENOPROTOOPT
+ */
+#define BTD_ERR_BREDR_CONN_PROFILE_UNAVAILABLE	0x0003
+/* Failed to complete the SDP search.
+ * errno: none
+ */
+#define BTD_ERR_BREDR_CONN_SDP_SEARCH		0x0004
+/* Failed to create or connect to BT IO socket. This can also indicate
+ * hardware failure in the controller.
+ * errno: EIO
+ */
+#define BTD_ERR_BREDR_CONN_CREATE_SOCKET	0x0005
+/* Failed due to invalid arguments.
+ * errno: EINVAL
+ */
+#define BTD_ERR_BREDR_CONN_INVALID_ARGUMENTS	0x0006
+/* Failed due to adapter not powered.
+ * errno: EHOSTUNREACH
+ */
+#define BTD_ERR_BREDR_CONN_ADAPTER_NOT_POWERED	0x0007
+/* Failed due to unsupported state transition of L2CAP channel or other
+ * features either by the local host or the remote.
+ * errno: EOPNOTSUPP, EPROTONOSUPPORT
+ */
+#define BTD_ERR_BREDR_CONN_NOT_SUPPORTED	0x0008
+/* Failed due to the socket is in bad state.
+ * errno: EBADFD
+ */
+#define BTD_ERR_BREDR_CONN_BAD_SOCKET		0x0009
+/* Failed to allocate memory in either host stack or controller.
+ * errno: ENOMEM
+ */
+#define BTD_ERR_BREDR_CONN_MEMORY_ALLOC		0x000A
+/* Failed due to other ongoing operations, such as pairing, busy L2CAP
+ * channel or the operation disallowed by the controller.
+ * errno: EBUSY
+ */
+#define BTD_ERR_BREDR_CONN_BUSY			0x000B
+/* Failed due to reaching the synchronous connection limit to a device.
+ * errno: EMLINK
+ */
+#define BTD_ERR_BREDR_CONN_SYNC_CONNECT_LIMIT	0x000C
+/* Failed due to connection timeout
+ * errno: ETIMEDOUT
+ */
+#define BTD_ERR_BREDR_CONN_TIMEOUT		0x000D
+/* Refused by the remote device due to limited resource, security reason
+ * or unacceptable address type.
+ * errno: ECONNREFUSED
+ */
+#define BTD_ERR_BREDR_CONN_REFUSED		0x000E
+/* Terminated by the remote device due to limited resource or power
+ * off.
+ * errno: ECONNRESET
+ */
+#define BTD_ERR_BREDR_CONN_TERM_BY_REMOTE	0x000F
+/* Terminated by the local host.
+ * errno: ECONNABORTED
+ */
+#define BTD_ERR_BREDR_CONN_TERM_BY_LOCAL	0x0010
+/* Failed due to LMP protocol error.
+ * errno: EPROTO
+ */
+#define BTD_ERR_BREDR_CONN_PROTO_ERROR		0x0011
+/* Failed due to cancellation caused by adapter drop, unexpected device drop,
+ * or incoming disconnection request before connection request is completed.
+ * errno: none
+ */
+#define BTD_ERR_BREDR_CONN_CANCELED		0x0012
+/* Failed due to unknown reason.
+ * errno: ENOSYS
+ */
+#define BTD_ERR_BREDR_CONN_UNKNOWN		0x0013
+
+/* LE connection failure reasons
+ * BT_ERR_* should be used as one of the parameters to btd_error_*_err().
+ */
+
+/* Failed due to invalid arguments.
+ * errno: EINVAL
+ */
+#define BTD_ERR_LE_CONN_INVALID_ARGUMENTS	0x0101
+/* Failed due to adapter not powered.
+ * errno: EHOSTUNREACH
+ */
+#define BTD_ERR_LE_CONN_ADAPTER_NOT_POWERED	0x0102
+/* Failed due to unsupported state transition of L2CAP channel or other
+ * features (e.g. LE features) either by the local host or the remote.
+ * errno: EOPNOTSUPP, EPROTONOSUPPORT
+ */
+#define BTD_ERR_LE_CONN_NOT_SUPPORTED		0x0103
+/* Either the BT IO is already connected or LE link connection in place.
+ * errno: EALREADY, EISCONN
+ */
+#define BTD_ERR_LE_CONN_ALREADY_CONNECTED	0x0104
+/* Failed due to the socket is in bad state.
+ * errno: EBADFD
+ */
+#define BTD_ERR_LE_CONN_BAD_SOCKET		0x0105
+/* Failed to allocate memory in either host stack or controller.
+ * errno: ENOMEM
+ */
+#define BTD_ERR_LE_CONN_MEMORY_ALLOC		0x0106
+/* Failed due to other ongoing operations, such as pairing, connecting, busy
+ * L2CAP channel or the operation disallowed by the controller.
+ * errno: EBUSY
+ */
+#define BTD_ERR_LE_CONN_BUSY			0x0107
+/* Failed due to that LE is not enabled or the attempt is refused by the remote
+ * device due to limited resource, security reason or unacceptable address type.
+ * errno: ECONNREFUSED
+ */
+#define BTD_ERR_LE_CONN_REFUSED			0x0108
+/* Failed to create or connect to BT IO socket. This can also indicate
+ * hardware failure in the controller.
+ * errno: EIO
+ */
+#define BTD_ERR_LE_CONN_CREATE_SOCKET		0x0109
+/* Failed due to connection timeout
+ * errno: ETIMEDOUT
+ */
+#define BTD_ERR_LE_CONN_TIMEOUT			0x010A
+/* Failed due to reaching the synchronous connection limit to a device.
+ * errno: EMLINK
+ */
+#define BTD_ERR_LE_CONN_SYNC_CONNECT_LIMIT	0x010B
+/* Terminated by the remote device due to limited resource or power
+ * off.
+ * errno: ECONNRESET
+ */
+#define BTD_ERR_LE_CONN_TERM_BY_REMOTE		0x010C
+/* Terminated by the local host.
+ * errno: ECONNABORTED
+ */
+#define BTD_ERR_LE_CONN_TERM_BY_LOCAL		0x010D
+/* Failed due to LL protocol error.
+ * errno: EPROTO
+ */
+#define BTD_ERR_LE_CONN_PROTO_ERROR		0x010E
+/* Failed to complete the GATT browsing.
+ * errno: none
+ */
+#define BTD_ERR_LE_CONN_GATT_BROWSE		0x010F
+/* Failed due to unknown reason.
+ * errno: ENOSYS
+ */
+#define BTD_ERR_LE_CONN_UNKNOWN			0x0110
+
 DBusMessage *btd_error_invalid_args(DBusMessage *msg);
 DBusMessage *btd_error_invalid_args_str(DBusMessage *msg, const char *str);
+DBusMessage *btd_error_invalid_args_err(DBusMessage *msg, uint16_t err);
 DBusMessage *btd_error_busy(DBusMessage *msg);
 DBusMessage *btd_error_already_exists(DBusMessage *msg);
 DBusMessage *btd_error_not_supported(DBusMessage *msg);
 DBusMessage *btd_error_not_connected(DBusMessage *msg);
 DBusMessage *btd_error_already_connected(DBusMessage *msg);
 DBusMessage *btd_error_not_available(DBusMessage *msg);
+DBusMessage *btd_error_not_available_err(DBusMessage *msg, uint16_t err);
 DBusMessage *btd_error_in_progress(DBusMessage *msg);
+DBusMessage *btd_error_in_progress_err(DBusMessage *msg, uint16_t err);
 DBusMessage *btd_error_does_not_exist(DBusMessage *msg);
 DBusMessage *btd_error_not_authorized(DBusMessage *msg);
 DBusMessage *btd_error_not_permitted(DBusMessage *msg, const char *str);
 DBusMessage *btd_error_no_such_adapter(DBusMessage *msg);
 DBusMessage *btd_error_agent_not_available(DBusMessage *msg);
 DBusMessage *btd_error_not_ready(DBusMessage *msg);
+DBusMessage *btd_error_not_ready_err(DBusMessage *msg, uint16_t err);
 DBusMessage *btd_error_failed(DBusMessage *msg, const char *str);
+DBusMessage *btd_error_failed_err(DBusMessage *msg, uint16_t err);
+
+uint16_t btd_error_bredr_conn_from_errno(int errno_code);
+uint16_t btd_error_le_conn_from_errno(int errno_code);


### PR DESCRIPTION

Hi BlueZ maintainers,

Chromium OS has been working closely with Linux Bluetooth community to
improve BlueZ stack, and there are increasing needs from applications
building their features around Bluetooth. One of the major feedback
from these application is the lack of the detailed failure reasons as
return for D-Bus method call, and these failure reasons can be used in
metrics, optimizing retry mechanism, hinting the reproduce scenario to
improve BlueZ stack. The current org.bluez.Error.* are serving the
generic errors well. However,g given org.bluez.Error.* errors are used
across different interface context which does not serve the detailed
failure reasons well. (See https://github.com/bluez/bluez/issues/131)


Miao-chen Chou (3):
BR/EDR and LE connection failure reasons
Include BtdError code in Connect() return
Print error code for connect methods

client/main.c |   3 +-
