### PR TITLE
[PW_SID:507761] [Bluez,v1] src/adv_monitor: Remove checking in device lost timeout


### DIFF
--- a/src/adv_monitor.c
+++ b/src/adv_monitor.c
@@ -1884,30 +1884,15 @@ static bool handle_device_lost_timeout(gpointer user_data)
 {
 	struct adv_monitor_device *dev = user_data;
 	struct adv_monitor *monitor = dev->monitor;
-	time_t curr_time = time(NULL);
 
-	DBG("Device Lost timeout triggered for device %p "
-	    "for the Adv Monitor at path %s", dev->device, monitor->path);
+	DBG("Device Lost timeout triggered for device %p. Calling DeviceLost() "
+	    "on Adv Monitor of owner %s at path %s", dev->device,
+					    monitor->app->owner, monitor->path);
 
+	g_dbus_proxy_method_call(monitor->proxy, "DeviceLost",
+				 report_device_state_setup,
+				 NULL, dev->device, NULL);
 	dev->lost_timer = 0;
-
-	if (dev->found && dev->last_seen) {
-		/* We were tracking for the Low RSSI filter. Check if there is
-		 * any Adv received after the timeout function is invoked.
-		 * If not, report the Device Lost event.
-		 */
-		if (difftime(curr_time, dev->last_seen) >=
-		    monitor->rssi.low_rssi_timeout) {
-			dev->found = false;
-
-			DBG("Calling DeviceLost() on Adv Monitor of owner %s "
-			    "at path %s", monitor->app->owner, monitor->path);
-
-			g_dbus_proxy_method_call(monitor->proxy, "DeviceLost",
-						 report_device_state_setup,
-						 NULL, dev->device, NULL);
-		}
-	}
 
 	return FALSE;
 }


### PR DESCRIPTION

From: Yun-Hao Chung <howardchung@chromium.org>

The time check in device lost timeout could cause DeviceLost never being
reported because of the following reasons:

1. Timer created in timeout_add_seconds, which calls
g_timeout_add_seconds_full internally, can be fired one second
earlier than |timeout| seconds.
2. When handle_device_lost_timeout is invoked early, time diff between
|curr_time| and |last_seen| could be less than |low_rssi_timeout|. In
this case, since handle_device_lost always returns FALSE, the
timer will be removed, but DeviceLost has not been reported yet.
3. If we never receives any advertisement from that peer since then,
DeviceLost will never be reported.

We can remove the checking in handle_device_lost_time because we restart
or remove the timer whenever an advertisement is recevied.

Reviewed-by: apusaka@chromium.org
Reviewed-by: mcchou@chromium.org
Reviewed-by: mmandlik@chromium.org
